### PR TITLE
fix(tmux): don't resolve an empty pane ID to an unrelated mission

### DIFF
--- a/cmd/tmux_resolve_mission.go
+++ b/cmd/tmux_resolve_mission.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/odyssey/agenc/internal/config"
@@ -48,11 +49,17 @@ func runTmuxResolveMission(cmd *cobra.Command, args []string) error {
 		return nil // silently exit — no mission
 	}
 
-	// Try the server first
+	// Try the server first. The pane ID must be URL-escaped, not
+	// concatenated raw: a caller that accidentally passes an unexpanded
+	// tmux format placeholder (e.g. the literal string "#{pane_id}") would
+	// otherwise have everything from "#" onward parsed as a URL fragment
+	// and silently dropped before the request is even sent — the server
+	// would then see an empty tmux_pane, hit the same empty-value fallback
+	// as above, and this command would print an unrelated mission's ID.
 	socketFilepath := config.GetServerSocketFilepath(dirpath)
 	client := server.NewClient(socketFilepath)
 	var responses []server.MissionResponse
-	if err := client.Get("/missions?tmux_pane="+paneID, &responses); err == nil {
+	if err := client.Get("/missions?tmux_pane="+url.QueryEscape(paneID), &responses); err == nil {
 		if len(responses) > 0 {
 			fmt.Print(responses[0].ID)
 		}

--- a/cmd/tmux_resolve_mission.go
+++ b/cmd/tmux_resolve_mission.go
@@ -33,6 +33,15 @@ func runTmuxResolveMission(cmd *cobra.Command, args []string) error {
 	// but tmux format variables like #{pane_id} omit it (42). The database
 	// stores just the number.
 	paneID := strings.TrimPrefix(args[0], "%")
+	if paneID == "" {
+		// An empty pane ID isn't a lookup miss — it's not a lookup at all.
+		// Without this guard it falls through to the /missions?tmux_pane=
+		// server handler's `if tmuxPane != ""` check, which treats an empty
+		// value as "no pane filter" and returns the general mission list
+		// instead of an empty one; this command would then print
+		// responses[0].ID — some unrelated mission — instead of nothing.
+		return nil
+	}
 
 	dirpath, err := config.GetAgencDirpath()
 	if err != nil {


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

## Bug

`agenc tmux resolve-mission` was printing a real (but unrelated) mission UUID for pane IDs that should have resolved to nothing, in two related cases:

1. A genuinely empty pane ID (`resolve-mission ""`).
2. A pane ID containing `#`, such as an accidentally-unexpanded tmux format placeholder passed in literally — e.g. `resolve-mission "#{pane_id}"` (this is what actually surfaced the bug for me, while building a tmux status-bar popup — see #32).

## Root cause

Two distinct issues, same downstream symptom:

**1. Empty pane ID falls through to the general mission list.** `handleListMissions` only takes the pane-specific lookup path when `tmux_pane` is non-empty:

```go
tmuxPane := r.URL.Query().Get("tmux_pane")
if tmuxPane != "" {
    mission, err := s.db.GetMissionByTmuxPane(tmuxPane)
    ...
}
```

An empty value falls through to the general mission-list endpoint instead. `tmux resolve-mission` then does `fmt.Print(responses[0].ID)` — printing whatever mission happens to be first in that unrelated list, rather than treating an empty pane ID as a lookup miss.

**2. The pane ID isn't URL-escaped before being sent.** The request URL is built via raw string concatenation: `"/missions?tmux_pane="+paneID`. A pane ID containing `#` has everything from `#` onward parsed as a URL *fragment* and silently dropped before the request is sent — confirmed directly with a standalone `url.Parse` of the exact string this command builds:

```
RawQuery: tmux_pane=
Fragment: {pane_id}
```

So the server receives an empty `tmux_pane`, hits issue #1's fallthrough, and this command prints an unrelated mission's ID again — the two bugs compound, and #2 is the more likely real-world trigger, since `#` is exactly what any accidentally-unexpanded tmux format placeholder looks like.

## Fix

Two commits:
- Early return in `runTmuxResolveMission` when the pane ID is empty, before any server/database call.
- `url.QueryEscape` the pane ID before building the request URL, so a value containing `#` (or any other URL-special character) can no longer be silently truncated.

## Verification

Built the binary from this branch and tested directly against a real local AgenC server/database:

```
$ agenc tmux resolve-mission ""
$                                      # nothing - fixed
$ agenc tmux resolve-mission "#{pane_id}"
$                                      # nothing - fixed (previously printed a real, unrelated mission UUID)
$ agenc tmux resolve-mission "%129"
61590b9a-bd96-4759-8654-fa3395dfa59a  # real pane still resolves correctly - no regression
```

Also ran `go build ./...` and `go test ./cmd/...` (both pass) from this branch.