### PR TITLE
Add per-mission Claude flags (--model, --effort) to 'agenc mission new'

### DIFF
--- a/cmd/mission_inspect.go
+++ b/cmd/mission_inspect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/odyssey/agenc/internal/claudeconfig"
 	"github.com/odyssey/agenc/internal/config"
 	"github.com/odyssey/agenc/internal/database"
+	"github.com/odyssey/agenc/internal/mission"
 	"github.com/odyssey/agenc/internal/server"
 	"github.com/odyssey/agenc/internal/session"
 )
@@ -111,7 +112,7 @@ func inspectMission(agencDirpath string, missionID string) error {
 	if err != nil {
 		return err
 	}
-	mission, err := client.GetMission(missionID)
+	missionRecord, err := client.GetMission(missionID)
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to get mission")
 	}
@@ -123,39 +124,42 @@ func inspectMission(agencDirpath string, missionID string) error {
 		return nil
 	}
 
-	fmt.Printf("ID:          %s\n", mission.ShortID)
-	fmt.Printf("Full ID:     %s\n", mission.ID)
-	fmt.Printf("Status:      %s\n", getMissionStatus(missionID, mission.Status, mission.ClaudeState))
+	fmt.Printf("ID:          %s\n", missionRecord.ShortID)
+	fmt.Printf("Full ID:     %s\n", missionRecord.ID)
+	fmt.Printf("Status:      %s\n", getMissionStatus(missionID, missionRecord.Status, missionRecord.ClaudeState))
 	cfg, _, _ := config.ReadAgencConfig(agencDirpath)
 	isAdjutant := config.IsMissionAdjutant(agencDirpath, missionID)
 	if isAdjutant {
 		fmt.Printf("Type:        🤖  Adjutant\n")
-	} else if mission.GitRepo != "" {
-		fmt.Printf("Git repo:    %s\n", displayGitRepo(mission.GitRepo))
-		repoDisplay := formatRepoDisplay(mission.GitRepo, false, cfg)
-		if repoDisplay != displayGitRepo(mission.GitRepo) {
+	} else if missionRecord.GitRepo != "" {
+		fmt.Printf("Git repo:    %s\n", displayGitRepo(missionRecord.GitRepo))
+		repoDisplay := formatRepoDisplay(missionRecord.GitRepo, false, cfg)
+		if repoDisplay != displayGitRepo(missionRecord.GitRepo) {
 			fmt.Printf("Title:       %s\n", repoDisplay)
 		}
 	}
-	sessionName := resolveSessionName(mission)
+	sessionName := resolveSessionName(missionRecord)
 	if sessionName == "" {
 		sessionName = "--"
 	}
 	fmt.Printf("Session:     %s\n", sessionName)
-	fmt.Printf("Peer:        %s\n", formatPeerAddress(mission))
-	prompt := mission.Prompt
+	fmt.Printf("Peer:        %s\n", formatPeerAddress(missionRecord))
+	prompt := missionRecord.Prompt
 	if prompt == "" {
 		prompt = "--"
 	}
+	if formattedClaudeArgs := mission.FormatMissionClaudeArgs(missionRecord.ClaudeArgs); formattedClaudeArgs != "" {
+		fmt.Printf("Claude args: %s\n", formattedClaudeArgs)
+	}
 	fmt.Printf("Prompt:      %s\n", prompt)
 	fmt.Printf("Directory:   %s\n", missionDirpath)
-	fmt.Printf("Created:     %s\n", mission.CreatedAt.Format("2006-01-02 15:04:05"))
-	fmt.Printf("Updated:     %s\n", mission.UpdatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Created:     %s\n", missionRecord.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Updated:     %s\n", missionRecord.UpdatedAt.Format("2006-01-02 15:04:05"))
 
 	// List session UUIDs
 	projectDirpath, err := claudeconfig.GetMissionProjectDirpath(agencDirpath, missionID)
 	if err != nil {
-		return stacktrace.Propagate(err, "failed to get project directory for mission %s", missionID)
+		return stacktrace.Propagate(err, "failed to get project directory for missionRecord %s", missionID)
 	}
 	sessionIDs := session.ListSessionIDs(projectDirpath)
 	currentSessionID := claudeconfig.GetLastSessionID(agencDirpath, missionID)

--- a/cmd/mission_new.go
+++ b/cmd/mission_new.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/odyssey/agenc/internal/config"
+	"github.com/odyssey/agenc/internal/mission"
 	"github.com/odyssey/agenc/internal/repo"
 	"github.com/odyssey/agenc/internal/server"
 )
@@ -25,6 +26,12 @@ var headlessFlag bool
 var sourceFlag string
 var sourceIDFlag string
 var sourceMetadataFlag string
+
+// missionClaudeArgFlagValues holds the value of every forwarded Claude flag as
+// the user set it on the command line, keyed by
+// mission.ForwardedClaudeFlag.Key. Registered from the forwarded-flag table so
+// that supporting a new Claude flag stays a single table entry.
+var missionClaudeArgFlagValues = map[string]*string{}
 
 var missionNewCmd = &cobra.Command{
 	Use:   newCmdStr + " [repo]",
@@ -52,10 +59,32 @@ func init() {
 	missionNewCmd.Flags().StringVar(&sourceFlag, "source", "", "mission source type (internal use)")
 	missionNewCmd.Flags().StringVar(&sourceIDFlag, "source-id", "", "mission source identifier (internal use)")
 	missionNewCmd.Flags().StringVar(&sourceMetadataFlag, "source-metadata", "", "mission source metadata JSON (internal use)")
+	for _, forwardedFlag := range mission.ForwardedClaudeFlags {
+		missionClaudeArgFlagValues[forwardedFlag.Key] = missionNewCmd.Flags().String(forwardedFlag.Key, "", forwardedFlag.Usage)
+	}
 	missionNewCmd.Flags().MarkHidden("source")
 	missionNewCmd.Flags().MarkHidden("source-id")
 	missionNewCmd.Flags().MarkHidden("source-metadata")
 	missionCmd.AddCommand(missionNewCmd)
+}
+
+// collectMissionClaudeArgs returns the forwarded Claude flags the user actually
+// set on this command. Unset flags are omitted rather than sent as empty
+// strings, so the mission falls through to the defaultModel/claudeArgs config
+// chain for everything it did not explicitly override. Returns nil when the
+// user set none.
+func collectMissionClaudeArgs() map[string]string {
+	claudeArgs := map[string]string{}
+	for key, value := range missionClaudeArgFlagValues {
+		if value == nil || *value == "" {
+			continue
+		}
+		claudeArgs[key] = *value
+	}
+	if len(claudeArgs) == 0 {
+		return nil
+	}
+	return claudeArgs
 }
 
 // repoLibraryEntry represents a single repo discovered in the
@@ -132,12 +161,20 @@ func runMissionNewWithClone() error {
 		TmuxSession: tmuxSession,
 		Headless:    headlessFlag,
 		NoFocus:     noFocusFlag,
+		ClaudeArgs:  collectMissionClaudeArgs(),
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to create mission")
 	}
 
 	fmt.Printf("Created mission: %s (cloned from %s)\n", missionRecord.ShortID, sourceMission.ShortID)
+	// Report Claude args only when they were inherited rather than typed —
+	// echoing back flags the user just passed is noise, but silently carrying
+	// a stronger (and more expensive) model over from the source mission is a
+	// surprise worth naming.
+	if collectMissionClaudeArgs() == nil && len(missionRecord.ClaudeArgs) > 0 {
+		fmt.Printf("Inherited Claude args: %s\n", mission.FormatMissionClaudeArgs(missionRecord.ClaudeArgs))
+	}
 	if agencDirpath, err := config.GetAgencDirpath(); err == nil {
 		fmt.Printf("Mission directory: %s\n", config.GetMissionDirpath(agencDirpath, missionRecord.ID))
 	}
@@ -239,6 +276,7 @@ func createAndLaunchAdjutantMission(initialPrompt string) error {
 		TmuxSession: tmuxSession,
 		Headless:    headlessFlag,
 		NoFocus:     noFocusFlag,
+		ClaudeArgs:  collectMissionClaudeArgs(),
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to create adjutant mission")
@@ -376,6 +414,7 @@ func createAndLaunchMission(
 		SourceID:       sourceIDFlag,
 		SourceMetadata: sourceMetadataFlag,
 		NoFocus:        noFocusFlag,
+		ClaudeArgs:     collectMissionClaudeArgs(),
 	})
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to create mission")

--- a/cmd/mission_resume.go
+++ b/cmd/mission_resume.go
@@ -117,6 +117,6 @@ func doRunWrapperDirect(missionID string, initialPrompt string) error {
 	// Determine if this is a resume (existing conversation) or a fresh start
 	hasConversation := claudeconfig.GetLastSessionID(agencDirpath, missionID) != ""
 
-	w := wrapper.NewWrapper(agencDirpath, missionID, missionRecord.GitRepo, initialPrompt)
+	w := wrapper.NewWrapper(agencDirpath, missionID, missionRecord.GitRepo, initialPrompt, missionRecord.ClaudeArgs)
 	return w.Run(hasConversation)
 }

--- a/docs/cli/agenc_mission_new.md
+++ b/docs/cli/agenc_mission_new.md
@@ -23,8 +23,10 @@ agenc mission new [repo] [flags]
       --adjutant        create an Adjutant mission
       --blank           create a blank mission with no repo (skip picker)
       --clone string    mission UUID to clone agent directory from
+      --effort string   Claude reasoning effort for this mission (low, medium, high, xhigh, max)
       --headless        run in headless mode (no terminal, outputs to log)
   -h, --help            help for new
+      --model string    Claude model for this mission (e.g. "opus", "sonnet", "claude-opus-4-6"); overrides the defaultModel config
       --no-focus        don't focus the new mission's tmux window after creation
       --prompt string   initial prompt to start Claude with
 ```

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -214,9 +214,9 @@ The wrapper:
 
 1. Writes the wrapper PID to `$AGENC_DIRPATH/missions/<uuid>/pid`
 2. Records the tmux pane ID via the server (cleared on exit) for pane→mission resolution
-3. Resolves the Claude model: checks the repo's `defaultModel` in `config.yml`, falls back to the top-level `defaultModel`, or omits `--model` entirely (letting Claude choose its default)
+3. Resolves the mission's Claude CLI args: merges the mission's own `claude_args` (from `agenc mission new --model`/`--effort`) over the `claudeArgs` config chain and the resolved `defaultModel`, per-mission values winning (see "Claude arg resolution at spawn time" below)
 4. Writes the mission's operational-settings file (`agenc-settings.json`) and its `agenc-hooks/` guard script into the mission dir (via `claudeconfig.WriteMissionOpSettings`). This runs at the top of every Claude spawn — initial start, in-place tmux respawn-pane reload — so each spawn regenerates the operational overlay with the latest config. Under State Y (native passthrough) there is **no** per-mission `claude-config/` snapshot: Claude reads the user's real `~/.claude` directly, and AgenC's operational layer is delivered per-invocation via `claude --settings <op-settings file>` (which unions with `~/.claude/settings.json`).
-5. Spawns Claude as a child process (with 1Password wrapping if `secrets.env` exists), passing `--settings <op-settings file>`, `--model <value>` if a model was resolved, and the initial prompt if any
+5. Spawns Claude as a child process (with 1Password wrapping if `secrets.env` exists), passing `--settings <op-settings file>`, then the merged Claude args, then the call-site args (the conversation shape and the initial prompt if any)
 6. Sets `AGENC_MISSION_UUID` for the child process. Does **not** set `CLAUDE_CONFIG_DIR` (State Y — Claude reads the real `~/.claude`). Injects `CLAUDE_CODE_OAUTH_TOKEN` **only** when a token file is present (the machine-token fallback toggle); absent, Claude uses its native `~/.claude` login.
 7. Starts background goroutines:
    - **Heartbeat writer** — updates `last_heartbeat` via the server on a fixed interval; also piggybacks `last_user_prompt_at` for crash recovery
@@ -253,7 +253,21 @@ The wrapper:
 
 **Conditional auth at spawn time**: missions default to native Claude authentication (set up via `claude auth login`). If an explicit token is stored at `$AGENC_DIRPATH/cache/oauth-token` (written via `agenc token set`), the wrapper reads it and passes it to Claude via `CLAUDE_CODE_OAUTH_TOKEN`. When no token file exists, `CLAUDE_CODE_OAUTH_TOKEN` is omitted and Claude uses its own native credentials. This "conditional passthrough" model avoids forcing token setup while still supporting the State-X fallback for headless/high-concurrency workflows. All missions share the same token file; when the token is updated (`agenc token set <new-token>`), new missions pick it up immediately and running missions pick it up on their next restart.
 
-**Model resolution at spawn time**: the wrapper resolves the Claude model from `config.yml` using a precedence chain: the repo's `repoConfig` `defaultModel` (if set) takes priority over the top-level `defaultModel` (if set). When a model is resolved, the wrapper passes `--model <value>` to the Claude CLI. If neither level specifies a model, `--model` is omitted and Claude uses its own default.
+**Claude arg resolution at spawn time**: the wrapper assembles the Claude CLI args once at construction, from three sources, lowest precedence first:
+
+1. The resolved `defaultModel` — the repo's `repoConfig` `defaultModel` if set, else the top-level `defaultModel`, else nothing.
+2. The `claudeArgs` config chain — global `claudeArgs` then the repo's, appended.
+3. The mission's own `claude_args` — the per-mission overrides set at `agenc mission new` time.
+
+A per-mission override removes every occurrence of the same flag from the two lower-precedence sources, so each forwarded flag reaches Claude exactly once. Claude's parser does resolve duplicate flags last-wins, but AgenC does not lean on that: emitting each flag once makes the precedence AgenC's own, and therefore testable. `mission.MergeClaudeArgs` owns this and is unit-tested.
+
+The resulting argv is `--settings <op-settings file>`, then the merged args, then the call-site args (`-c`, `-r <session>`, `--print`, the initial prompt). If nothing specifies a model, `--model` is omitted and Claude uses its own default.
+
+**Forwarded Claude flags**: `agenc mission new` exposes an allowlist of Claude CLI flags (`internal/mission/claude_args.go`, `ForwardedClaudeFlags` — currently `--model` and `--effort`), registered as real Cobra flags so `--help` lists them and unknown flags are rejected at parse time. It is an allowlist rather than an open passthrough because Claude exposes flags that would break AgenC's invariants: `--settings` carries the operational overlay, `-c`/`-r` are the wrapper's to choose, `--bare` skips the hooks AgenC tracks mission state with. The server re-validates against the same table, since the HTTP API is reachable by clients that never went through Cobra.
+
+Values are persisted per-mission as a JSON object keyed by flag name in `missions.claude_args` (e.g. `{"model":"opus"}`) rather than one column per flag, so supporting a new Claude flag is a single table entry with no migration. Persisting on the mission row — rather than passing the flag along the tmux resume command string — is what makes the override survive stash-restore, reload, and server restart, all of which rebuild that command from scratch.
+
+**Clone inheritance**: `agenc mission new --clone <mission>` carries the source mission's `claude_args` over, so a mission deliberately put on a stronger model does not silently drop back to the config default when cloned. Any forwarded flag given explicitly on the clone command replaces the inherited set wholesale, and the CLI prints what it inherited so the choice is never silent.
 
 
 Directory Structure
@@ -363,7 +377,7 @@ Repo library operations and resolution logic. Used by the server for repo API en
 
 Mission lifecycle: directory creation, repo copying, and Claude process spawning.
 
-- `mission.go` — `CreateMissionDir` (sets up mission directory, copies git repo), `SpawnClaude`/`SpawnClaudeWithPrompt`/`SpawnClaudeResume` (construct and start Claude `exec.Cmd` with 1Password integration, environment variables, and `--model` flag when a `defaultModel` is configured)
+- `mission.go` — `CreateMissionDir` (sets up mission directory, copies git repo), `BuildClaudeCmd`/`SpawnClaudeWithPrompt`/`SpawnClaudeResumeWithSession` (construct and start Claude `exec.Cmd` with 1Password integration and environment variables)
 - `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (rsync-based), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
 
 ### `internal/claudeconfig/`
@@ -412,7 +426,7 @@ HTTP API server that listens on a unix socket. Serves mission lifecycle endpoint
 
 SQLite mission tracking with auto-migration.
 
-- `database.go` — `DB` struct (wraps `sql.DB` with max connections = 1 for SQLite), `Mission` struct, CRUD operations (`CreateMission`, `ListMissions`, `GetMission`, `ResolveMissionID`, `ArchiveMission`, `DeleteMission`), heartbeat updates, session name caching, generic source tracking (`source`, `source_id`, `source_metadata` columns). Idempotent migrations handle schema evolution.
+- `database.go` — `DB` struct (wraps `sql.DB` with max connections = 1 for SQLite), `Mission` struct, CRUD operations (`CreateMission`, `ListMissions`, `GetMission`, `ResolveMissionID`, `ArchiveMission`, `DeleteMission`), heartbeat updates, session name caching, generic source tracking (`source`, `source_id`, `source_metadata` columns), per-mission Claude CLI overrides (`claude_args`, a JSON object keyed by flag name). Idempotent migrations handle schema evolution.
 - `sessions.go` — `Session` struct and CRUD operations: `CreateSession`, `GetSession`, `ListSessions`, `ListSessionsByMission`, `GetActiveSession`, `UpdateSessionAgencCustomTitle`, `UpdateKnownFileSize`, `SessionsWithNullFileSize`, plus the split-loop query and atomic-update helpers — `SessionsNeedingCustomTitleUpdate` / `UpdateCustomTitleAndOffset` / `UpdateCustomTitleScanOffset` for the custom-title loop, and `SessionsNeedingAutoSummary` / `UpdateAutoSummaryAndOffset` / `UpdateAutoSummaryScanOffset` for the auto-summary loop. Each `*AndOffset` helper writes the output column and advances its scan offset in a single UPDATE so failure rolls back both. `GetActiveSession` returns the most recently updated session for a mission, used by tmux title reconciliation to determine the current display title.
 - `notifications.go` — `Notification` struct (with optional `MissionID` attach target) and CRUD operations (`CreateNotification`, `GetNotification`, `ListNotifications`, `MarkNotificationRead`, `CountUnreadNotifications`). Notifications are append-only — `read_at` is the only mutation. The `mission_id` column links a notification to a mission so the Notification Center picker can attach on `ENTER`.
 
@@ -434,7 +448,7 @@ Tmux keybindings generation and version detection, shared by the CLI (`tmux inje
 
 Per-mission Claude child process management.
 
-- `wrapper.go` — `Wrapper` struct (uses `server.Client` for all database operations, `stateMu` protects state for concurrent HTTP reads), `Run` (interactive mode with three-state restart machine), `RunHeadless` (headless mode with timeout and log rotation), background goroutines (heartbeat, remote refs watcher, HTTP server), `handleClaudeUpdate` (processes hook events for idle tracking, needs-attention tracking, and pane coloring), signal handling, OAuth token passthrough via `CLAUDE_CODE_OAUTH_TOKEN` environment variable, model resolution from `defaultModel` config (repo-level then top-level) passed as `--model` to the Claude CLI
+- `wrapper.go` — `Wrapper` struct (uses `server.Client` for all database operations, `stateMu` protects state for concurrent HTTP reads), `Run` (interactive mode with three-state restart machine), `RunHeadless` (headless mode with timeout and log rotation), background goroutines (heartbeat, remote refs watcher, HTTP server), `handleClaudeUpdate` (processes hook events for idle tracking, needs-attention tracking, and pane coloring), signal handling, OAuth token passthrough via `CLAUDE_CODE_OAUTH_TOKEN` environment variable, Claude arg resolution at construction (per-mission `claude_args` merged over the `claudeArgs` and `defaultModel` config chains via `mission.MergeClaudeArgs`)
 - `socket.go` — HTTP server on unix socket (`startHTTPServer`), request/response types (`StatusResponse`, `RestartRequest`, `ClaudeUpdateRequest`, `CommandResponse`), internal `Command`/`commandWithResponse` types for the event loop channel, HTTP handlers for each endpoint
 - `client.go` — `WrapperClient` HTTP client using unix socket transport, typed methods (`GetStatus`, `Restart`, `SendClaudeUpdate`), `ErrWrapperNotRunning` sentinel error
 - `tmux.go` — pane color management (`setWindowBusy`, `setWindowNeedsAttention`, `resetWindowTabStyle`) for visual mission status feedback, pane registration/clearing via server client (triggers initial tmux window title reconciliation on the server side)
@@ -638,6 +652,7 @@ The server's cron syncer (`internal/server/cron_syncer.go`, `internal/launchd/`)
 **Key behaviors:**
 - **Cron missions are normal missions** — no special lifecycle, timeout, or cleanup. Users can attach/detach them like any other mission.
 - **Generic source tracking** — missions have `source`, `source_id`, and `source_metadata` columns instead of cron-specific columns. `source=cron`, `source_id=<UUID>`, `source_metadata={"cron_name":"<name>"}`.
+- **Per-mission Claude args** — missions carry a `claude_args` JSON object (`{"model":"opus"}`) holding the Claude CLI flags set for that mission alone, outranking the `defaultModel`/`claudeArgs` config chains. Keyed JSON rather than a column per flag so a new forwarded flag needs no migration. See "Claude arg resolution at spawn time".
 - **Scheduling reliability** — launchd handles scheduling, survives server restarts
 - **Cron expression support** — basic expressions only (`minute hour day month weekday`), no `*/N` syntax
 - **Plist logs** — single appending log file per cron at `$AGENC_DIRPATH/logs/crons/<cronID>.log` (captures `agenc mission new` stdout/stderr for diagnosing launch failures)
@@ -658,7 +673,7 @@ Data Flow: Mission Lifecycle
 ### Running
 
 1. Wrapper writes PID file, starts socket listener
-2. Wrapper writes the operational-settings file, then spawns Claude (with 1Password wrapping if `secrets.env` exists), passing `--settings <op-settings file>` and `--model` if a `defaultModel` is configured (repo-level overrides top-level). Sets `AGENC_MISSION_UUID`; does **not** set `CLAUDE_CONFIG_DIR` (State Y); injects `CLAUDE_CODE_OAUTH_TOKEN` only when a token file is present
+2. Wrapper writes the operational-settings file, then spawns Claude (with 1Password wrapping if `secrets.env` exists), passing `--settings <op-settings file>` followed by the merged Claude args (per-mission `claude_args` over the `claudeArgs` and `defaultModel` config chains). Sets `AGENC_MISSION_UUID`; does **not** set `CLAUDE_CONFIG_DIR` (State Y); injects `CLAUDE_CODE_OAUTH_TOKEN` only when a token file is present
 3. Background goroutines start: heartbeat writer (sends heartbeats to server), remote refs watcher
 4. Claude hooks send state updates to the wrapper socket (`claude_update` commands); the wrapper uses these for idle detection, conversation tracking, deferred restarts, tmux pane coloring, and recording prompts via the server
 5. Main event loop blocks until Claude exits or a signal arrives

--- a/internal/claudeconfig/adjutant_claude.md
+++ b/internal/claudeconfig/adjutant_claude.md
@@ -26,6 +26,28 @@ agenc mission new <repo> --prompt "Your instructions here"
 agenc mission new --adjutant --prompt "Help with cron setup"
 ```
 
+### Choosing a model or effort level per mission
+
+`agenc mission new` forwards a small allowlist of Claude CLI flags to the mission it launches, scoped to that one mission:
+
+```bash
+# Run this mission on Opus, whatever the configured default is
+agenc mission new <repo> --model opus --prompt "..."
+
+# Cheap model, low effort, for a mechanical task
+agenc mission new <repo> --model haiku --effort low --prompt "..."
+```
+
+`--model` takes a Claude alias (`opus`, `sonnet`, `haiku`) or a full model ID. `--effort` takes `low`, `medium`, `high`, `xhigh`, or `max`.
+
+These override the `defaultModel` and `claudeArgs` config for that mission only — nothing shared changes, so there is no setting to remember to change back. Use them when the user wants a one-off stronger or cheaper mission. Reach for `agenc config set defaultModel <value>` (global) or `agenc config repoConfig set <repo> --default-model <value>` (per-repo) only when they want the change to stick for future missions.
+
+The set of forwardable flags is deliberately small: most Claude flags would break AgenC's own plumbing, so `mission new` refuses anything outside the allowlist. Run `agenc mission new --help` for the current list rather than assuming a flag exists.
+
+`agenc mission inspect <mission>` shows a `Claude args:` line for any mission that has overrides — that is how to answer "why is this mission on Opus?"
+
+Cloning carries the overrides over: `agenc mission new --clone <mission>` inherits the source mission's model and effort (and says so in its output). Pass an explicit flag on the clone command to replace them.
+
 Tmux Configuration Changes
 --------------------------
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -47,6 +47,7 @@ func getMigrationSteps() []migrationStep {
 		{migrateCreateNotificationsTable, "create notifications table"},
 		{migrateCreateWriteableCopyPausesTable, "create writeable_copy_pauses table"},
 		{migrateAddNotificationsMissionID, "add mission_id column to notifications"},
+		{migrateAddClaudeArgs, "add claude_args column"},
 	}
 }
 

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -30,6 +30,7 @@ const (
 	addSourceColumnSQL                 = `ALTER TABLE missions ADD COLUMN source TEXT;`
 	addSourceIDColumnSQL               = `ALTER TABLE missions ADD COLUMN source_id TEXT;`
 	addSourceMetadataColumnSQL         = `ALTER TABLE missions ADD COLUMN source_metadata TEXT;`
+	addClaudeArgsColumnSQL             = `ALTER TABLE missions ADD COLUMN claude_args TEXT;`
 
 	createSessionsTableSQL = `CREATE TABLE IF NOT EXISTS sessions (
 	id TEXT PRIMARY KEY,
@@ -675,4 +676,22 @@ func migrateCreateWriteableCopyPausesTable(conn *sql.DB) error {
 		return stacktrace.Propagate(err, "failed to create writeable_copy_pauses table")
 	}
 	return nil
+}
+
+// migrateAddClaudeArgs idempotently adds the claude_args column, which holds a
+// JSON object of per-mission Claude CLI overrides (e.g. {"model":"opus"}) set
+// at `agenc mission new` time. A JSON object rather than a column per flag so
+// that supporting a new Claude flag stays a code-only change.
+func migrateAddClaudeArgs(conn *sql.DB) error {
+	columns, err := getColumnNames(conn)
+	if err != nil {
+		return err
+	}
+
+	if columns["claude_args"] {
+		return nil
+	}
+
+	_, err = conn.Exec(addClaudeArgsColumnSQL)
+	return err
 }

--- a/internal/database/mission_claude_args_test.go
+++ b/internal/database/mission_claude_args_test.go
@@ -1,0 +1,73 @@
+package database
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCreateMissionPersistsClaudeArgs(t *testing.T) {
+	db := openTestDB(t)
+
+	claudeArgs := map[string]string{"model": "opus", "effort": "high"}
+	created, err := db.CreateMission("github.com/owner/repo", &CreateMissionParams{ClaudeArgs: claudeArgs})
+	if err != nil {
+		t.Fatalf("failed to create mission: %v", err)
+	}
+	if !reflect.DeepEqual(created.ClaudeArgs, claudeArgs) {
+		t.Fatalf("expected the created mission to carry %v, got %v", claudeArgs, created.ClaudeArgs)
+	}
+
+	got, err := db.GetMission(created.ID)
+	if err != nil {
+		t.Fatalf("failed to get mission: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected the mission to be found")
+	}
+	if !reflect.DeepEqual(got.ClaudeArgs, claudeArgs) {
+		t.Fatalf("expected the stored mission to round-trip %v, got %v", claudeArgs, got.ClaudeArgs)
+	}
+}
+
+func TestCreateMissionWithoutClaudeArgsLeavesThemEmpty(t *testing.T) {
+	db := openTestDB(t)
+
+	created, err := db.CreateMission("github.com/owner/repo", nil)
+	if err != nil {
+		t.Fatalf("failed to create mission: %v", err)
+	}
+
+	got, err := db.GetMission(created.ID)
+	if err != nil {
+		t.Fatalf("failed to get mission: %v", err)
+	}
+	if len(got.ClaudeArgs) != 0 {
+		t.Fatalf("expected no Claude args, got %v", got.ClaudeArgs)
+	}
+}
+
+func TestListMissionsCarriesClaudeArgs(t *testing.T) {
+	db := openTestDB(t)
+
+	claudeArgs := map[string]string{"model": "opus"}
+	created, err := db.CreateMission("github.com/owner/repo", &CreateMissionParams{ClaudeArgs: claudeArgs})
+	if err != nil {
+		t.Fatalf("failed to create mission: %v", err)
+	}
+
+	missions, err := db.ListMissions(ListMissionsParams{})
+	if err != nil {
+		t.Fatalf("failed to list missions: %v", err)
+	}
+
+	for _, m := range missions {
+		if m.ID != created.ID {
+			continue
+		}
+		if !reflect.DeepEqual(m.ClaudeArgs, claudeArgs) {
+			t.Fatalf("expected the listed mission to carry %v, got %v", claudeArgs, m.ClaudeArgs)
+		}
+		return
+	}
+	t.Fatal("expected the created mission to appear in the list")
+}

--- a/internal/database/missions.go
+++ b/internal/database/missions.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -27,10 +28,17 @@ type Mission struct {
 	SourceID             *string
 	SourceMetadata       *string
 	ConfigCommit         *string
-	TmuxPane             *string
-	PromptCount          int
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+
+	// ClaudeArgs holds the per-mission Claude CLI overrides set at
+	// `agenc mission new` time, keyed by mission.ForwardedClaudeFlag.Key
+	// (e.g. {"model": "opus"}). Nil when the mission set none, in which
+	// case the mission falls back to the defaultModel/claudeArgs config
+	// chain at spawn time. Stored as a JSON object in the claude_args column.
+	ClaudeArgs  map[string]string
+	TmuxPane    *string
+	PromptCount int
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 
 	// ResolvedSessionTitle is a transient field (not stored in the database).
 	// It is populated by the server from the active session's title chain:
@@ -70,6 +78,7 @@ type CreateMissionParams struct {
 	SourceID       *string
 	SourceMetadata *string
 	ConfigCommit   *string
+	ClaudeArgs     map[string]string
 }
 
 // ListMissionsParams holds optional parameters for filtering missions.
@@ -88,16 +97,23 @@ func (db *DB) CreateMission(gitRepo string, params *CreateMissionParams) (*Missi
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	var configCommit, source, sourceID, sourceMetadata *string
+	var claudeArgs map[string]string
 	if params != nil {
 		configCommit = params.ConfigCommit
 		source = params.Source
 		sourceID = params.SourceID
 		sourceMetadata = params.SourceMetadata
+		claudeArgs = params.ClaudeArgs
 	}
 
-	_, err := db.conn.Exec(
-		"INSERT INTO missions (id, short_id, git_repo, status, config_commit, source, source_id, source_metadata, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)",
-		id, shortID, gitRepo, configCommit, source, sourceID, sourceMetadata, now, now,
+	claudeArgsJSON, err := marshalClaudeArgs(claudeArgs)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to serialize Claude args '%v' for mission '%s'", claudeArgs, id)
+	}
+
+	_, err = db.conn.Exec(
+		"INSERT INTO missions (id, short_id, git_repo, status, config_commit, source, source_id, source_metadata, claude_args, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?)",
+		id, shortID, gitRepo, configCommit, source, sourceID, sourceMetadata, claudeArgsJSON, now, now,
 	)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to insert mission")
@@ -112,6 +128,7 @@ func (db *DB) CreateMission(gitRepo string, params *CreateMissionParams) (*Missi
 		SourceID:       sourceID,
 		SourceMetadata: sourceMetadata,
 		ConfigCommit:   configCommit,
+		ClaudeArgs:     claudeArgs,
 		CreatedAt:      time.Now().UTC(),
 		UpdatedAt:      time.Now().UTC(),
 	}, nil
@@ -137,7 +154,7 @@ func (db *DB) ListMissions(params ListMissionsParams) ([]*Mission, error) {
 // Returns (nil, error) only for actual database failures.
 func (db *DB) GetMission(id string) (*Mission, error) {
 	row := db.conn.QueryRow(
-		"SELECT id, short_id, prompt, status, git_repo, last_heartbeat, last_user_prompt_at, session_name, session_name_updated_at, cron_id, cron_name, config_commit, tmux_pane, prompt_count, created_at, updated_at, source, source_id, source_metadata FROM missions WHERE id = ?",
+		"SELECT "+missionColumnsSQL+" FROM missions WHERE id = ?",
 		id,
 	)
 
@@ -155,7 +172,7 @@ func (db *DB) GetMission(id string) (*Mission, error) {
 // tmux pane ID, or nil if no active mission is running in that pane.
 func (db *DB) GetMissionByTmuxPane(paneID string) (*Mission, error) {
 	row := db.conn.QueryRow(
-		"SELECT id, short_id, prompt, status, git_repo, last_heartbeat, last_user_prompt_at, session_name, session_name_updated_at, cron_id, cron_name, config_commit, tmux_pane, prompt_count, created_at, updated_at, source, source_id, source_metadata FROM missions WHERE tmux_pane = ? AND status = 'active' LIMIT 1",
+		"SELECT "+missionColumnsSQL+" FROM missions WHERE tmux_pane = ? AND status = 'active' LIMIT 1",
 		paneID,
 	)
 
@@ -427,4 +444,32 @@ func (db *DB) ResolveMissionID(userInput string) (string, error) {
 			userInput, len(matches), strings.Join(lines, "\n"),
 		)
 	}
+}
+
+// marshalClaudeArgs renders per-mission Claude args for storage in the
+// claude_args column. An empty map yields nil so the column stays NULL rather
+// than holding a meaningless "{}".
+func marshalClaudeArgs(claudeArgs map[string]string) (*string, error) {
+	if len(claudeArgs) == 0 {
+		return nil, nil
+	}
+	serialized, err := json.Marshal(claudeArgs)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to marshal Claude args '%v'", claudeArgs)
+	}
+	asString := string(serialized)
+	return &asString, nil
+}
+
+// unmarshalClaudeArgs parses a stored claude_args column. A NULL or empty
+// column yields a nil map, meaning the mission set no per-mission overrides.
+func unmarshalClaudeArgs(stored sql.NullString) (map[string]string, error) {
+	if !stored.Valid || stored.String == "" {
+		return nil, nil
+	}
+	var claudeArgs map[string]string
+	if err := json.Unmarshal([]byte(stored.String), &claudeArgs); err != nil {
+		return nil, stacktrace.Propagate(err, "failed to unmarshal stored Claude args '%v'", stored.String)
+	}
+	return claudeArgs, nil
 }

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -5,10 +5,16 @@ import (
 	"time"
 )
 
+// missionColumnsSQL is the missions column list every mission SELECT uses. Its
+// order is load-bearing: scanMission and scanMissions read row values
+// positionally, so a column added here must be added to both scanners in the
+// same position.
+const missionColumnsSQL = "id, short_id, prompt, status, git_repo, last_heartbeat, last_user_prompt_at, session_name, session_name_updated_at, cron_id, cron_name, config_commit, tmux_pane, prompt_count, created_at, updated_at, source, source_id, source_metadata, claude_args"
+
 // buildListMissionsQuery constructs the SQL query and arguments for ListMissions.
 // Returns the query string and a slice of arguments to be used with db.Query.
 func buildListMissionsQuery(params ListMissionsParams) (string, []interface{}) {
-	query := "SELECT id, short_id, prompt, status, git_repo, last_heartbeat, last_user_prompt_at, session_name, session_name_updated_at, cron_id, cron_name, config_commit, tmux_pane, prompt_count, created_at, updated_at, source, source_id, source_metadata FROM missions"
+	query := "SELECT " + missionColumnsSQL + " FROM missions"
 
 	var conditions []string
 	var args []interface{}

--- a/internal/database/scanners.go
+++ b/internal/database/scanners.go
@@ -12,9 +12,9 @@ func scanMissions(rows *sql.Rows) ([]*Mission, error) {
 	var missions []*Mission
 	for rows.Next() {
 		var m Mission
-		var lastHeartbeat, lastUserPromptAt, sessionNameUpdatedAt, cronID, cronName, configCommit, tmuxPane, source, sourceID, sourceMetadata sql.NullString
+		var lastHeartbeat, lastUserPromptAt, sessionNameUpdatedAt, cronID, cronName, configCommit, tmuxPane, source, sourceID, sourceMetadata, claudeArgs sql.NullString
 		var createdAt, updatedAt string
-		if err := rows.Scan(&m.ID, &m.ShortID, &m.Prompt, &m.Status, &m.GitRepo, &lastHeartbeat, &lastUserPromptAt, &m.SessionName, &sessionNameUpdatedAt, &cronID, &cronName, &configCommit, &tmuxPane, &m.PromptCount, &createdAt, &updatedAt, &source, &sourceID, &sourceMetadata); err != nil {
+		if err := rows.Scan(&m.ID, &m.ShortID, &m.Prompt, &m.Status, &m.GitRepo, &lastHeartbeat, &lastUserPromptAt, &m.SessionName, &sessionNameUpdatedAt, &cronID, &cronName, &configCommit, &tmuxPane, &m.PromptCount, &createdAt, &updatedAt, &source, &sourceID, &sourceMetadata, &claudeArgs); err != nil {
 			return nil, stacktrace.Propagate(err, "failed to scan mission row")
 		}
 		if lastHeartbeat.Valid {
@@ -59,7 +59,11 @@ func scanMissions(rows *sql.Rows) ([]*Mission, error) {
 		if sourceMetadata.Valid {
 			m.SourceMetadata = &sourceMetadata.String
 		}
-		var err error
+		parsedClaudeArgs, err := unmarshalClaudeArgs(claudeArgs)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "failed to parse Claude args for mission '%s'", m.ID)
+		}
+		m.ClaudeArgs = parsedClaudeArgs
 		m.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 		if err != nil {
 			return nil, stacktrace.Propagate(err, "failed to parse created_at timestamp")
@@ -150,9 +154,9 @@ func populateNotificationFields(n *Notification, sourceRepo, missionID sql.NullS
 // scanMission scans a single mission row from a query result.
 func scanMission(row *sql.Row) (*Mission, error) {
 	var m Mission
-	var lastHeartbeat, lastUserPromptAt, sessionNameUpdatedAt, cronID, cronName, configCommit, tmuxPane, source, sourceID, sourceMetadata sql.NullString
+	var lastHeartbeat, lastUserPromptAt, sessionNameUpdatedAt, cronID, cronName, configCommit, tmuxPane, source, sourceID, sourceMetadata, claudeArgs sql.NullString
 	var createdAt, updatedAt string
-	if err := row.Scan(&m.ID, &m.ShortID, &m.Prompt, &m.Status, &m.GitRepo, &lastHeartbeat, &lastUserPromptAt, &m.SessionName, &sessionNameUpdatedAt, &cronID, &cronName, &configCommit, &tmuxPane, &m.PromptCount, &createdAt, &updatedAt, &source, &sourceID, &sourceMetadata); err != nil {
+	if err := row.Scan(&m.ID, &m.ShortID, &m.Prompt, &m.Status, &m.GitRepo, &lastHeartbeat, &lastUserPromptAt, &m.SessionName, &sessionNameUpdatedAt, &cronID, &cronName, &configCommit, &tmuxPane, &m.PromptCount, &createdAt, &updatedAt, &source, &sourceID, &sourceMetadata, &claudeArgs); err != nil {
 		return nil, err
 	}
 	if lastHeartbeat.Valid {
@@ -197,7 +201,11 @@ func scanMission(row *sql.Row) (*Mission, error) {
 	if sourceMetadata.Valid {
 		m.SourceMetadata = &sourceMetadata.String
 	}
-	var err error
+	parsedClaudeArgs, err := unmarshalClaudeArgs(claudeArgs)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "failed to parse Claude args for mission '%s'", m.ID)
+	}
+	m.ClaudeArgs = parsedClaudeArgs
 	m.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to parse created_at timestamp")

--- a/internal/mission/claude_args.go
+++ b/internal/mission/claude_args.go
@@ -1,0 +1,198 @@
+package mission
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/mieubrisse/stacktrace"
+)
+
+// Claude CLI flag names AgenC forwards. These are external tokens owned by the
+// Claude CLI, so they are bound to named symbols rather than spelled inline: an
+// upstream rename becomes a one-line change here instead of a silent runtime
+// miss scattered across the spawn path.
+const (
+	modelClaudeFlag  = "--model"
+	effortClaudeFlag = "--effort"
+)
+
+// ForwardedClaudeFlag describes one Claude CLI flag that AgenC forwards from
+// `agenc mission new` through to the Claude process the mission spawns.
+//
+// Key is how the flag is stored in the mission's claude_args JSON object and
+// how it is named as an `agenc mission new` flag; Flag is the Claude CLI
+// spelling emitted at spawn time.
+//
+// Every forwarded flag takes a value. Valueless (boolean) Claude flags are not
+// supported here — stripConflictingArgs assumes a bare forwarded flag's value
+// occupies the following argv slot. Adding one would need that assumption
+// revisited, not just a new table entry.
+type ForwardedClaudeFlag struct {
+	Key   string
+	Flag  string
+	Usage string
+}
+
+// ForwardedClaudeFlags is the allowlist of Claude CLI flags a caller may set
+// per-mission. It is deliberately an allowlist rather than an open passthrough:
+// Claude's CLI exposes flags that would break AgenC's own invariants if a
+// caller set them (--settings carries the operational overlay, -c/-r are the
+// wrapper's to choose, --bare skips the hooks AgenC tracks mission state with).
+//
+// Adding a new forwarded flag is a single entry here. Per-mission values are
+// stored as a JSON object keyed by Key, so no database migration is involved.
+//
+// Order matters: it is the order flags are emitted onto Claude's command line,
+// which keeps spawn commands stable and diffable across runs.
+var ForwardedClaudeFlags = []ForwardedClaudeFlag{
+	{
+		Key:   "model",
+		Flag:  modelClaudeFlag,
+		Usage: `Claude model for this mission (e.g. "opus", "sonnet", "claude-opus-4-6"); overrides the defaultModel config`,
+	},
+	{
+		Key:   "effort",
+		Flag:  effortClaudeFlag,
+		Usage: `Claude reasoning effort for this mission (low, medium, high, xhigh, max)`,
+	},
+}
+
+// lookupForwardedClaudeFlag finds the forwarded flag registered under a key.
+func lookupForwardedClaudeFlag(key string) (ForwardedClaudeFlag, bool) {
+	for _, forwardedFlag := range ForwardedClaudeFlags {
+		if forwardedFlag.Key == key {
+			return forwardedFlag, true
+		}
+	}
+	return ForwardedClaudeFlag{}, false
+}
+
+// forwardedClaudeFlagKeys returns every supported key, for error messages.
+func forwardedClaudeFlagKeys() []string {
+	keys := make([]string, 0, len(ForwardedClaudeFlags))
+	for _, forwardedFlag := range ForwardedClaudeFlags {
+		keys = append(keys, forwardedFlag.Key)
+	}
+	return keys
+}
+
+// ValidateMissionClaudeArgs checks that every per-mission Claude arg names a
+// supported flag and carries a value. The CLI's own flag parsing already
+// rejects unknown flags, so this is the guard for the server's HTTP API, which
+// any client can reach.
+func ValidateMissionClaudeArgs(missionClaudeArgs map[string]string) error {
+	for key, value := range missionClaudeArgs {
+		if _, found := lookupForwardedClaudeFlag(key); !found {
+			return stacktrace.NewError(
+				"unsupported Claude arg '%v'; supported Claude args are: %v",
+				key,
+				strings.Join(forwardedClaudeFlagKeys(), ", "),
+			)
+		}
+		if value == "" {
+			return stacktrace.NewError("Claude arg '%v' needs a value, but was given an empty one", key)
+		}
+	}
+	return nil
+}
+
+// UnknownClaudeArgKeys returns the sorted keys that name no supported flag.
+// Per-mission args are validated on the way in, so a stored mission should
+// never carry one — but a mission created by a newer AgenC and then read by an
+// older one can, and that is worth surfacing rather than silently dropping.
+func UnknownClaudeArgKeys(missionClaudeArgs map[string]string) []string {
+	var unknown []string
+	for key := range missionClaudeArgs {
+		if _, found := lookupForwardedClaudeFlag(key); !found {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// MissionClaudeArgsToArgv renders per-mission Claude args as CLI argv, in
+// ForwardedClaudeFlags order so the result does not depend on Go's randomized
+// map iteration. Unknown keys are dropped rather than emitted — passing an
+// unrecognized flag to Claude would fail the spawn outright, which is a worse
+// outcome than running the mission without it.
+func MissionClaudeArgsToArgv(missionClaudeArgs map[string]string) []string {
+	var argv []string
+	for _, forwardedFlag := range ForwardedClaudeFlags {
+		value, found := missionClaudeArgs[forwardedFlag.Key]
+		if !found || value == "" {
+			continue
+		}
+		argv = append(argv, forwardedFlag.Flag, value)
+	}
+	return argv
+}
+
+// FormatMissionClaudeArgs renders per-mission Claude args for display to the
+// user (mission inspect, mission creation output). Returns an empty string when
+// there are none.
+func FormatMissionClaudeArgs(missionClaudeArgs map[string]string) string {
+	return strings.Join(MissionClaudeArgsToArgv(missionClaudeArgs), " ")
+}
+
+// MergeClaudeArgs assembles the Claude CLI args for a mission spawn from the
+// three sources that can supply them, lowest precedence first:
+//
+//  1. resolvedModel — from the defaultModel config chain (repo, then global)
+//  2. configClaudeArgs — from the claudeArgs config chain (global, then repo)
+//  3. missionClaudeArgs — the per-mission overrides set at `mission new` time
+//
+// A per-mission override removes every occurrence of the same flag from the
+// two lower-precedence sources, so each forwarded flag reaches Claude exactly
+// once. Claude's parser does resolve duplicate flags last-wins, but leaning on
+// that is leaning on undocumented behaviour; emitting each flag once makes the
+// precedence AgenC's own, and therefore testable.
+func MergeClaudeArgs(resolvedModel string, configClaudeArgs []string, missionClaudeArgs map[string]string) []string {
+	overriddenFlags := map[string]bool{}
+	for key := range missionClaudeArgs {
+		forwardedFlag, found := lookupForwardedClaudeFlag(key)
+		if !found {
+			continue
+		}
+		overriddenFlags[forwardedFlag.Flag] = true
+	}
+
+	var merged []string
+	if resolvedModel != "" && !overriddenFlags[modelClaudeFlag] {
+		merged = append(merged, modelClaudeFlag, resolvedModel)
+	}
+	merged = append(merged, stripConflictingArgs(configClaudeArgs, overriddenFlags)...)
+	merged = append(merged, MissionClaudeArgsToArgv(missionClaudeArgs)...)
+	return merged
+}
+
+// stripConflictingArgs removes from args every occurrence of a flag in the
+// overridden set, along with the value token that follows it. Only
+// ForwardedClaudeFlags can ever populate the overridden set, and every one of
+// those takes a value — so a bare "--flag" consumes the next token, while
+// "--flag=value" is self-contained.
+func stripConflictingArgs(args []string, overriddenFlags map[string]bool) []string {
+	var kept []string
+	for i := 0; i < len(args); i++ {
+		flagName, hasInlineValue := splitClaudeArg(args[i])
+		if !overriddenFlags[flagName] {
+			kept = append(kept, args[i])
+			continue
+		}
+		if !hasInlineValue {
+			// Drop the separate value token that follows the bare flag. When
+			// the flag is the final arg there is no value token to drop, and
+			// the loop simply ends.
+			i++
+		}
+	}
+	return kept
+}
+
+// splitClaudeArg splits a CLI arg into its flag name and whether a value was
+// supplied inline: "--model=opus" yields ("--model", true), "--model" yields
+// ("--model", false).
+func splitClaudeArg(arg string) (string, bool) {
+	flagName, _, hasInlineValue := strings.Cut(arg, "=")
+	return flagName, hasInlineValue
+}

--- a/internal/mission/claude_args_test.go
+++ b/internal/mission/claude_args_test.go
@@ -1,0 +1,119 @@
+package mission
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeClaudeArgsWithNoSourcesReturnsNothing(t *testing.T) {
+	merged := MergeClaudeArgs("", nil, nil)
+	if len(merged) != 0 {
+		t.Fatalf("expected no args, got %v", merged)
+	}
+}
+
+func TestMergeClaudeArgsEmitsResolvedModel(t *testing.T) {
+	merged := MergeClaudeArgs("sonnet", nil, nil)
+	expected := []string{"--model", "sonnet"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsMissionModelSuppressesResolvedModel(t *testing.T) {
+	merged := MergeClaudeArgs("sonnet", nil, map[string]string{"model": "opus"})
+	expected := []string{"--model", "opus"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected the resolved model to be replaced, not duplicated; expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsKeepsNonConflictingConfigArgs(t *testing.T) {
+	merged := MergeClaudeArgs("sonnet", []string{"--chrome", "--verbose"}, nil)
+	expected := []string{"--model", "sonnet", "--chrome", "--verbose"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsStripsInlineValueConfigArgConflict(t *testing.T) {
+	merged := MergeClaudeArgs("", []string{"--chrome", "--model=sonnet"}, map[string]string{"model": "opus"})
+	expected := []string{"--chrome", "--model", "opus"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected the config --model=sonnet to be stripped; expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsStripsSeparateValueConfigArgConflict(t *testing.T) {
+	merged := MergeClaudeArgs("", []string{"--model", "sonnet", "--chrome"}, map[string]string{"model": "opus"})
+	expected := []string{"--chrome", "--model", "opus"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected both the config --model and its value token to be stripped; expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsStripsTrailingBareConfigArgConflict(t *testing.T) {
+	merged := MergeClaudeArgs("", []string{"--chrome", "--model"}, map[string]string{"model": "opus"})
+	expected := []string{"--chrome", "--model", "opus"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected a valueless trailing --model to be stripped without panicking; expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsEmitsMissionArgsInTableOrder(t *testing.T) {
+	merged := MergeClaudeArgs("", nil, map[string]string{"effort": "high", "model": "opus"})
+	expected := []string{"--model", "opus", "--effort", "high"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected forwarded flags in table order regardless of map iteration order; expected %v, got %v", expected, merged)
+	}
+}
+
+func TestMergeClaudeArgsIgnoresUnknownMissionKeys(t *testing.T) {
+	merged := MergeClaudeArgs("", nil, map[string]string{"model": "opus", "bogus": "value"})
+	expected := []string{"--model", "opus"}
+	if !reflect.DeepEqual(merged, expected) {
+		t.Fatalf("expected unknown keys to be dropped rather than emitted as flags; expected %v, got %v", expected, merged)
+	}
+}
+
+func TestValidateMissionClaudeArgsAcceptsKnownKeys(t *testing.T) {
+	if err := ValidateMissionClaudeArgs(map[string]string{"model": "opus", "effort": "high"}); err != nil {
+		t.Fatalf("expected known keys to validate, got %v", err)
+	}
+}
+
+func TestValidateMissionClaudeArgsRejectsUnknownKey(t *testing.T) {
+	err := ValidateMissionClaudeArgs(map[string]string{"bogus": "value"})
+	if err == nil {
+		t.Fatal("expected an unknown Claude arg key to be rejected")
+	}
+}
+
+func TestValidateMissionClaudeArgsRejectsEmptyValue(t *testing.T) {
+	err := ValidateMissionClaudeArgs(map[string]string{"model": ""})
+	if err == nil {
+		t.Fatal("expected an empty Claude arg value to be rejected")
+	}
+}
+
+func TestUnknownClaudeArgKeysReportsOnlyUnknownKeys(t *testing.T) {
+	unknown := UnknownClaudeArgKeys(map[string]string{"model": "opus", "zeta": "1", "alpha": "2"})
+	expected := []string{"alpha", "zeta"}
+	if !reflect.DeepEqual(unknown, expected) {
+		t.Fatalf("expected sorted unknown keys %v, got %v", expected, unknown)
+	}
+}
+
+func TestFormatMissionClaudeArgsRendersHumanReadableString(t *testing.T) {
+	formatted := FormatMissionClaudeArgs(map[string]string{"model": "opus", "effort": "high"})
+	expected := "--model opus --effort high"
+	if formatted != expected {
+		t.Fatalf("expected %q, got %q", expected, formatted)
+	}
+}
+
+func TestFormatMissionClaudeArgsRendersEmptyStringForNoArgs(t *testing.T) {
+	if formatted := FormatMissionClaudeArgs(nil); formatted != "" {
+		t.Fatalf("expected an empty string for no args, got %q", formatted)
+	}
+}

--- a/internal/mission/mission.go
+++ b/internal/mission/mission.go
@@ -58,17 +58,19 @@ func CreateMissionDir(agencDirpath string, missionID string, gitRepoName string,
 // (AGENC_MISSION_UUID, conditionally CLAUDE_CODE_OAUTH_TOKEN) set but does NOT
 // set stdin/stdout/stderr — callers should wire those as needed (e.g.
 // interactive mode connects to the terminal, headless mode uses pipes).
-func BuildClaudeCmd(agencDirpath string, missionID string, agentDirpath string, model string, extraClaudeArgs []string, claudeArgs []string) (*exec.Cmd, error) {
-	var fullArgs []string
-	if model != "" {
-		fullArgs = append(fullArgs, "--model", model)
-	}
+//
+// Args reach Claude in three groups, in this order: AgenC's --settings overlay,
+// then extraClaudeArgs (the model/config/per-mission args already merged by
+// MergeClaudeArgs), then claudeArgs (the call-site args that choose the
+// conversation shape — -c, -r <session>, --print, the initial prompt).
+func BuildClaudeCmd(agencDirpath string, missionID string, agentDirpath string, extraClaudeArgs []string, claudeArgs []string) (*exec.Cmd, error) {
 	// Deliver AgenC's operational overlay (hooks, prime, guard, allow/deny,
 	// server socket) via --settings so it applies to every spawn shape
 	// (interactive, resume, headless). --settings unions with the user's own
 	// ~/.claude/settings.json rather than replacing it.
 	opSettingsFilepath := config.GetMissionOpSettingsFilepath(agencDirpath, missionID)
-	fullArgs = append(fullArgs, "--settings", opSettingsFilepath)
+
+	fullArgs := []string{"--settings", opSettingsFilepath}
 	fullArgs = append(fullArgs, extraClaudeArgs...)
 	fullArgs = append(fullArgs, claudeArgs...)
 	claudeArgs = fullArgs
@@ -121,25 +123,19 @@ func BuildClaudeCmd(agencDirpath string, missionID string, agentDirpath string, 
 	return cmd, nil
 }
 
-// SpawnClaude starts claude as a child process in the given agent directory.
-// Returns the running command. The caller is responsible for calling cmd.Wait().
-func SpawnClaude(agencDirpath string, missionID string, agentDirpath string, model string, extraClaudeArgs []string) (*exec.Cmd, error) {
-	return SpawnClaudeWithPrompt(agencDirpath, missionID, agentDirpath, model, extraClaudeArgs, "")
-}
-
 // SpawnClaudeWithPrompt starts claude with an initial prompt as a child process
 // in the given agent directory. Claude always starts in interactive mode; if
 // initialPrompt is non-empty, it is passed as a positional argument to pre-fill
 // the first message. Returns the running command. The caller is responsible for
 // calling cmd.Wait().
-func SpawnClaudeWithPrompt(agencDirpath string, missionID string, agentDirpath string, model string, extraClaudeArgs []string, initialPrompt string) (*exec.Cmd, error) {
+func SpawnClaudeWithPrompt(agencDirpath string, missionID string, agentDirpath string, extraClaudeArgs []string, initialPrompt string) (*exec.Cmd, error) {
 	var args []string
 	if initialPrompt != "" {
 		// Pass prompt as positional argument for interactive mode with pre-filled message
 		args = []string{initialPrompt}
 	}
 
-	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, model, extraClaudeArgs, args)
+	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, extraClaudeArgs, args)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to build claude command")
 	}
@@ -150,26 +146,6 @@ func SpawnClaudeWithPrompt(agencDirpath string, missionID string, agentDirpath s
 
 	if err := cmd.Start(); err != nil {
 		return nil, stacktrace.Propagate(err, "failed to start claude")
-	}
-
-	return cmd, nil
-}
-
-// SpawnClaudeResume starts claude -c as a child process in the given agent
-// directory. Returns the running command. The caller is responsible for
-// calling cmd.Wait().
-func SpawnClaudeResume(agencDirpath string, missionID string, agentDirpath string, model string, extraClaudeArgs []string) (*exec.Cmd, error) {
-	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, model, extraClaudeArgs, []string{"-c"})
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "failed to build claude resume command")
-	}
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Start(); err != nil {
-		return nil, stacktrace.Propagate(err, "failed to start claude -c")
 	}
 
 	return cmd, nil
@@ -196,10 +172,10 @@ func buildResumeArgs(sessionID string, initialPrompt string) []string {
 // argument so claude submits it as the first message after resuming.
 // Returns the running command. The caller is responsible for calling
 // cmd.Wait().
-func SpawnClaudeResumeWithSession(agencDirpath string, missionID string, agentDirpath string, model string, extraClaudeArgs []string, sessionID string, initialPrompt string) (*exec.Cmd, error) {
+func SpawnClaudeResumeWithSession(agencDirpath string, missionID string, agentDirpath string, extraClaudeArgs []string, sessionID string, initialPrompt string) (*exec.Cmd, error) {
 	args := buildResumeArgs(sessionID, initialPrompt)
 
-	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, model, extraClaudeArgs, args)
+	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, extraClaudeArgs, args)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to build claude resume command")
 	}

--- a/internal/mission/mission_test.go
+++ b/internal/mission/mission_test.go
@@ -49,7 +49,7 @@ func TestBuildClaudeCmdStateY(t *testing.T) {
 	agentDirpath := t.TempDir()
 	missionID := "test-mission-uuid"
 
-	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, "", nil, nil)
+	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildClaudeCmd returned error: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestBuildClaudeCmdInjectsTokenWhenPresent(t *testing.T) {
 		t.Fatalf("failed to write token: %v", err)
 	}
 
-	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, "", nil, nil)
+	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, nil, nil)
 	if err != nil {
 		t.Fatalf("BuildClaudeCmd returned error: %v", err)
 	}
@@ -179,5 +179,37 @@ func TestBuildResumeArgs(t *testing.T) {
 				t.Errorf("buildResumeArgs(%q, %q) = %v, want %v", tt.sessionID, tt.initialPrompt, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildClaudeCmdArgOrder pins the argv layout BuildClaudeCmd produces:
+// AgenC's operational overlay first, then the merged model/config/per-mission
+// args, then the call-site args that choose the conversation shape. The order
+// is behaviour, not incidental — a per-mission override that landed before the
+// resolved model would be silently outranked by Claude's last-wins parsing.
+func TestBuildClaudeCmdArgOrder(t *testing.T) {
+	withFakeClaudeOnPath(t)
+
+	agencDirpath := t.TempDir()
+	agentDirpath := t.TempDir()
+	missionID := "test-mission-uuid"
+
+	mergedClaudeArgs := MergeClaudeArgs("sonnet", []string{"--chrome"}, map[string]string{"model": "opus"})
+	cmd, err := BuildClaudeCmd(agencDirpath, missionID, agentDirpath, mergedClaudeArgs, []string{"-c"})
+	if err != nil {
+		t.Fatalf("BuildClaudeCmd returned error: %v", err)
+	}
+
+	// cmd.Args[0] is the claude binary path itself.
+	gotArgs := cmd.Args[1:]
+	opSettingsFilepath := config.GetMissionOpSettingsFilepath(agencDirpath, missionID)
+	expectedArgs := []string{
+		"--settings", opSettingsFilepath,
+		"--chrome",
+		"--model", "opus",
+		"-c",
+	}
+	if !reflect.DeepEqual(gotArgs, expectedArgs) {
+		t.Fatalf("expected args %v, got %v", expectedArgs, gotArgs)
 	}
 }

--- a/internal/server/missions.go
+++ b/internal/server/missions.go
@@ -41,6 +41,11 @@ type MissionResponse struct {
 	CreatedAt            time.Time  `json:"created_at"`
 	UpdatedAt            time.Time  `json:"updated_at"`
 
+	// ClaudeArgs holds the mission's own Claude CLI overrides (e.g.
+	// {"model": "opus"}), set at creation time and outranking the
+	// defaultModel/claudeArgs config chains for this mission only.
+	ClaudeArgs map[string]string `json:"claude_args"`
+
 	// ResolvedSessionTitle is derived from the active session's title chain:
 	// custom_title > agenc_custom_title > auto_summary. Empty if no session exists.
 	ResolvedSessionTitle string `json:"resolved_session_title"`
@@ -87,6 +92,7 @@ func (mr *MissionResponse) ToMission() *database.Mission {
 		PromptCount:          mr.PromptCount,
 		CreatedAt:            mr.CreatedAt,
 		UpdatedAt:            mr.UpdatedAt,
+		ClaudeArgs:           mr.ClaudeArgs,
 		ResolvedSessionTitle: mr.ResolvedSessionTitle,
 		IsAdjutant:           mr.IsAdjutant,
 		ClaudeState:          mr.ClaudeState,
@@ -115,6 +121,7 @@ func toMissionResponse(m *database.Mission) MissionResponse {
 		PromptCount:          m.PromptCount,
 		CreatedAt:            m.CreatedAt,
 		UpdatedAt:            m.UpdatedAt,
+		ClaudeArgs:           m.ClaudeArgs,
 		ResolvedSessionTitle: m.ResolvedSessionTitle,
 		IsAdjutant:           m.IsAdjutant,
 		IsAttached:           m.IsAttached,
@@ -375,6 +382,14 @@ type CreateMissionRequest struct {
 	SourceMetadata string `json:"source_metadata"`
 	CloneFrom      string `json:"clone_from"`
 	NoFocus        bool   `json:"no_focus"`
+
+	// ClaudeArgs holds per-mission Claude CLI overrides keyed by
+	// mission.ForwardedClaudeFlag.Key (e.g. {"model": "opus"}). Validated
+	// against the forwarded-flag allowlist before anything is persisted:
+	// Claude exposes flags that would break AgenC's own invariants, and the
+	// HTTP API is reachable by clients that never went through the CLI's
+	// flag parsing.
+	ClaudeArgs map[string]string `json:"claude_args"`
 }
 
 // resolveTrustedMcpServers reads the MCP trust configuration for a repo from
@@ -424,8 +439,12 @@ func (s *Server) handleCreateMission(w http.ResponseWriter, r *http.Request) err
 		return err
 	}
 
+	if err := mission.ValidateMissionClaudeArgs(req.ClaudeArgs); err != nil {
+		return newHTTPError(http.StatusBadRequest, err.Error())
+	}
+
 	// Build creation params
-	createParams := &database.CreateMissionParams{}
+	createParams := &database.CreateMissionParams{ClaudeArgs: req.ClaudeArgs}
 	if req.Source != "" {
 		createParams.Source = &req.Source
 	}
@@ -611,6 +630,15 @@ func (s *Server) handleCreateClonedMission(w http.ResponseWriter, req CreateMiss
 	sourceMission, err := s.db.GetMission(sourceID)
 	if err != nil || sourceMission == nil {
 		return newHTTPError(http.StatusNotFound, "source mission not found: "+req.CloneFrom)
+	}
+
+	// A clone means "another one of these", so the source mission's Claude args
+	// carry over — otherwise a mission deliberately put on a stronger model
+	// would silently drop back to the config default when cloned. An explicit
+	// --model (or any other forwarded flag) on the clone command still wins,
+	// and the CLI reports what was inherited so it is never a silent choice.
+	if len(createParams.ClaudeArgs) == 0 {
+		createParams.ClaudeArgs = sourceMission.ClaudeArgs
 	}
 
 	missionRecord, err := s.db.CreateMission(sourceMission.GitRepo, createParams)

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -38,14 +38,24 @@ type Wrapper struct {
 	missionID      string
 	gitRepoName    string
 	initialPrompt  string
-	defaultModel   string
-	claudeArgs     []string
 	missionDirpath string
 	agentDirpath   string
 	client         *server.Client
 	claudeCmd      *exec.Cmd
 	logger         *slog.Logger
 	tmuxPaneID     string // numeric pane ID from $TMUX_PANE (%-prefix stripped); empty for headless
+
+	// claudeSpawnArgs is the model/config/per-mission arg list handed to every
+	// Claude spawn, already merged by mission.MergeClaudeArgs at construction
+	// time. Resolved once because the merge reads config, and config must not
+	// shift underneath a mission mid-restart.
+	claudeSpawnArgs []string
+
+	// unknownClaudeArgKeys names per-mission Claude args this build does not
+	// recognize. Only reachable via version skew (a mission created by a newer
+	// AgenC, resumed by an older one). Dropped from the spawn but logged, so a
+	// mission silently missing a flag is diagnosable.
+	unknownClaudeArgKeys []string
 
 	// hasConversation tracks whether a Claude conversation exists that can be
 	// resumed with `claude -c`. Set to true at startup for resumes, and flipped
@@ -83,17 +93,19 @@ type Wrapper struct {
 
 // NewWrapper creates a new Wrapper for the given mission. The initialPrompt
 // parameter is optional; if non-empty, it will be passed to Claude when
-// starting a new conversation (not used for resumes).
-func NewWrapper(agencDirpath string, missionID string, gitRepoName string, initialPrompt string) *Wrapper {
+// starting a new conversation (not used for resumes). missionClaudeArgs holds
+// the mission's own Claude CLI overrides (from `agenc mission new --model` and
+// friends); it outranks the defaultModel and claudeArgs config chains.
+func NewWrapper(agencDirpath string, missionID string, gitRepoName string, initialPrompt string, missionClaudeArgs map[string]string) *Wrapper {
 	// Load window coloring config from config.yml
 	cfg, _, err := config.ReadAgencConfig(agencDirpath)
 	var titleCfg *config.TmuxWindowTitleConfig
 	var defaultModel string
-	var claudeArgs []string
+	var configClaudeArgs []string
 	if err == nil {
 		titleCfg = cfg.GetTmuxWindowTitleConfig()
 		defaultModel = cfg.GetDefaultModel(gitRepoName)
-		claudeArgs = cfg.GetClaudeArgs(gitRepoName)
+		configClaudeArgs = cfg.GetClaudeArgs(gitRepoName)
 	} else {
 		titleCfg = &config.TmuxWindowTitleConfig{}
 	}
@@ -103,8 +115,8 @@ func NewWrapper(agencDirpath string, missionID string, gitRepoName string, initi
 		missionID:                      missionID,
 		gitRepoName:                    gitRepoName,
 		initialPrompt:                  initialPrompt,
-		defaultModel:                   defaultModel,
-		claudeArgs:                     claudeArgs,
+		claudeSpawnArgs:                mission.MergeClaudeArgs(defaultModel, configClaudeArgs, missionClaudeArgs),
+		unknownClaudeArgKeys:           mission.UnknownClaudeArgKeys(missionClaudeArgs),
 		missionDirpath:                 config.GetMissionDirpath(agencDirpath, missionID),
 		agentDirpath:                   config.GetMissionAgentDirpath(agencDirpath, missionID),
 		client:                         server.NewClient(config.GetServerSocketFilepath(agencDirpath)),
@@ -151,6 +163,12 @@ func (w *Wrapper) setupRun(isResume bool) (*runResources, func(), error) {
 		"repo", w.gitRepoName,
 		"is_resume", isResume,
 	)
+	if len(w.unknownClaudeArgKeys) > 0 {
+		w.logger.Warn("Dropping unrecognized per-mission Claude args; this AgenC build does not support them",
+			"mission_id", database.ShortID(w.missionID),
+			"unknown_claude_arg_keys", w.unknownClaudeArgKeys,
+		)
+	}
 
 	// Write wrapper PID
 	pidFilepath := config.GetMissionPIDFilepath(w.agencDirpath, w.missionID)
@@ -262,12 +280,12 @@ func (w *Wrapper) spawnClaudeDirectly(isResume bool) error {
 	if isResume {
 		sessionID := claudeconfig.GetLastSessionID(w.agencDirpath, w.missionID)
 		if sessionID != "" && claudeconfig.ProjectDirectoryExists(w.agentDirpath) {
-			cmd, err = mission.SpawnClaudeResumeWithSession(w.agencDirpath, w.missionID, w.agentDirpath, w.defaultModel, w.claudeArgs, sessionID, w.initialPrompt)
+			cmd, err = mission.SpawnClaudeResumeWithSession(w.agencDirpath, w.missionID, w.agentDirpath, w.claudeSpawnArgs, sessionID, w.initialPrompt)
 		} else {
-			cmd, err = mission.SpawnClaudeWithPrompt(w.agencDirpath, w.missionID, w.agentDirpath, w.defaultModel, w.claudeArgs, w.initialPrompt)
+			cmd, err = mission.SpawnClaudeWithPrompt(w.agencDirpath, w.missionID, w.agentDirpath, w.claudeSpawnArgs, w.initialPrompt)
 		}
 	} else {
-		cmd, err = mission.SpawnClaudeWithPrompt(w.agencDirpath, w.missionID, w.agentDirpath, w.defaultModel, w.claudeArgs, w.initialPrompt)
+		cmd, err = mission.SpawnClaudeWithPrompt(w.agencDirpath, w.missionID, w.agentDirpath, w.claudeSpawnArgs, w.initialPrompt)
 	}
 
 	if err != nil {
@@ -704,7 +722,7 @@ func (w *Wrapper) buildHeadlessClaudeCmd(isResume bool) (*exec.Cmd, error) {
 		args = []string{"--print", "-p", w.initialPrompt}
 	}
 
-	return mission.BuildClaudeCmd(w.agencDirpath, w.missionID, w.agentDirpath, w.defaultModel, w.claudeArgs, args)
+	return mission.BuildClaudeCmd(w.agencDirpath, w.missionID, w.agentDirpath, w.claudeSpawnArgs, args)
 }
 
 // gracefulShutdownClaude attempts to gracefully shut down a Claude process.

--- a/internal/wrapper/wrapper_integration_test.go
+++ b/internal/wrapper/wrapper_integration_test.go
@@ -164,7 +164,7 @@ func getStatusRaw(socketFilepath string, timeout time.Duration) (*StatusResponse
 
 // createTestWrapper creates a wrapper with a logger initialized for testing.
 func createTestWrapper(agencDirpath, missionID, gitRepoName string) *Wrapper {
-	w := NewWrapper(agencDirpath, missionID, gitRepoName, "")
+	w := NewWrapper(agencDirpath, missionID, gitRepoName, "", nil)
 	w.logger = slog.Default()
 	return w
 }
@@ -580,7 +580,7 @@ func TestSpawnClaude_WritesOpSettings(t *testing.T) {
 		t.Fatalf("failed to create mission agent dir: %v", err)
 	}
 
-	w := NewWrapper(setup.agencDirpath, setup.missionID, "github.com/test/repo", "")
+	w := NewWrapper(setup.agencDirpath, setup.missionID, "github.com/test/repo", "", nil)
 	w.logger = slog.Default()
 
 	if err := w.spawnClaude(false); err != nil {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -14,6 +14,7 @@ agenc_test="${repo_dirpath}/_build/agenc-test"
 
 passed=0
 failed=0
+skipped=0
 total=0
 
 run_test() {
@@ -1455,12 +1456,135 @@ else
     tmux kill-session -t "=${detach_caller_session}" >/dev/null 2>&1 || true
 fi
 
+echo ""
+echo "--- Per-mission Claude args (--model / --effort) ---"
+
+# `agenc mission new` forwards an allowlisted set of Claude CLI flags to the
+# Claude process a mission spawns, stored per-mission as a JSON object in the
+# missions.claude_args column so they survive wrapper restarts, stash-restore
+# and reload without travelling through the tmux resume command string.
+#
+# Every mission below is identified by the short ID its own create output
+# printed. Selecting "the newest row" instead would be unreliable: created_at
+# has second granularity, so missions created in the same second tie.
+
+claude_args_db_filepath="${repo_dirpath}/_test-env/database.sqlite"
+
+# Runs `mission new` with the given args and echoes the short ID it created.
+create_mission_and_echo_short_id() {
+    "${agenc_test}" mission new "$@" 2>&1 | awk '/^Created mission:/{print $3; exit}'
+}
+
+model_short_id=$(create_mission_and_echo_short_id --blank --headless --no-focus --model=haiku)
+
+total=$((total + 1))
+printf "  %-50s " "mission new --model created a mission..."
+if [ -n "${model_short_id}" ]; then
+    echo "PASS"
+    passed=$((passed + 1))
+else
+    echo "FAIL (no mission short ID in create output)"
+    failed=$((failed + 1))
+fi
+
+# The stored shape is a JSON object keyed by flag name, not a positional argv
+# array — that is what keeps adding a new forwarded flag migration-free.
+run_test_output_contains \
+    "mission new --model persists claude_args as keyed JSON" \
+    '"model":"haiku"' \
+    sqlite3 "${claude_args_db_filepath}" "SELECT claude_args FROM missions WHERE short_id='${model_short_id}';"
+
+run_test_output_contains \
+    "mission inspect surfaces the per-mission Claude args" \
+    "Claude args: --model haiku" \
+    "${agenc_test}" mission inspect "${model_short_id}"
+
+# Multiple forwarded flags are emitted in the order ForwardedClaudeFlags
+# declares them, so spawn commands stay stable across runs.
+multi_flag_short_id=$(create_mission_and_echo_short_id --blank --headless --no-focus --model=haiku --effort=low)
+run_test_output_contains \
+    "multiple forwarded flags render in table order" \
+    "Claude args: --model haiku --effort low" \
+    "${agenc_test}" mission inspect "${multi_flag_short_id}"
+
+# A mission with no overrides stores NULL and falls through to the
+# defaultModel / claudeArgs config chain.
+no_args_short_id=$(create_mission_and_echo_short_id --blank --headless --no-focus)
+run_test_output_contains \
+    "mission without Claude args stores no claude_args" \
+    "^$" \
+    sqlite3 "${claude_args_db_filepath}" "SELECT COALESCE(claude_args, '') FROM missions WHERE short_id='${no_args_short_id}';"
+
+# Only allowlisted Claude flags are reachable. Claude's CLI exposes flags that
+# would break AgenC's invariants (--settings carries the operational overlay,
+# -c/-r are the wrapper's to choose, --bare skips the hooks AgenC tracks state
+# with), so anything off the table must be refused rather than forwarded.
+run_test "mission new rejects a Claude flag that is not forwarded" \
+    1 \
+    "${agenc_test}" mission new --blank --headless --no-focus --bare
+
+run_test "mission new rejects an unknown flag" \
+    1 \
+    "${agenc_test}" mission new --blank --headless --no-focus --bogus=value
+
+# A clone means "another one of these", so the source mission's Claude args
+# carry over — and the CLI says so, since silently inheriting a more expensive
+# model would be a surprise.
+run_test_output_contains \
+    "mission new --clone reports inherited Claude args" \
+    "Inherited Claude args: --model haiku" \
+    "${agenc_test}" mission new --clone "${model_short_id}" --headless --no-focus
+
+cloned_short_id=$(create_mission_and_echo_short_id --clone "${model_short_id}" --headless --no-focus)
+run_test_output_contains \
+    "cloned mission carries the inherited Claude args" \
+    "Claude args: --model haiku" \
+    "${agenc_test}" mission inspect "${cloned_short_id}"
+
+# An explicit flag on the clone command outranks what the source carried.
+clone_override_short_id=$(create_mission_and_echo_short_id --clone "${model_short_id}" --headless --no-focus --effort=high)
+run_test_output_contains \
+    "explicit Claude args on a clone replace the source's" \
+    "Claude args: --effort high" \
+    "${agenc_test}" mission inspect "${clone_override_short_id}"
+
+# The assertion the rest of this section cannot make: that the flag reaches the
+# real Claude command line. Poll for the mission's own Claude child, matched on
+# its --settings path, which embeds the mission UUID.
+model_mission_uuid=$(sqlite3 "${claude_args_db_filepath}" "SELECT id FROM missions WHERE short_id='${model_short_id}';")
+total=$((total + 1))
+printf "  %-50s " "spawned Claude process carries --model..."
+claude_argv=""
+for _ in $(seq 1 20); do
+    claude_argv=$(ps -eo args 2>/dev/null | grep -- "${model_mission_uuid}" | grep "bin/claude" | grep -v grep || true)
+    if [ -n "${claude_argv}" ]; then
+        break
+    fi
+    sleep 1
+done
+if [ -z "${claude_argv}" ]; then
+    # Not a pass and not a failure: this environment never brought a Claude
+    # process up (no credentials, no binary). Say so rather than counting it.
+    echo "SKIP (no Claude process observed for the mission)"
+    skipped=$((skipped + 1))
+elif echo "${claude_argv}" | grep -q -- "--model haiku"; then
+    echo "PASS"
+    passed=$((passed + 1))
+else
+    echo "FAIL (Claude argv lacked '--model haiku': ${claude_argv})"
+    failed=$((failed + 1))
+fi
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
 echo "=========================================="
-echo "  E2E Results: ${passed}/${total} passed, ${failed} failed"
+if [ "${skipped}" -gt 0 ]; then
+    echo "  E2E Results: ${passed}/${total} passed, ${failed} failed, ${skipped} skipped"
+else
+    echo "  E2E Results: ${passed}/${total} passed, ${failed} failed"
+fi
 echo "=========================================="
 
 if [ "${failed}" -gt 0 ]; then


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Closes #24.

## What this adds

`agenc mission new` now forwards an allowlisted set of Claude CLI flags to the mission it launches, scoped to that mission alone:

```bash
agenc mission new <repo> --model opus --prompt "..."
agenc mission new <repo> --model haiku --effort low
```

These override the `defaultModel` and `claudeArgs` config chains for that one mission, so spinning up one mission on Opus and another on Sonnet no longer means mutating shared config between spawns and remembering to change it back.

## Design

**Allowlist, not open passthrough.** The forwarded flags live in one table (`internal/mission/claude_args.go`, `ForwardedClaudeFlags` — currently `--model` and `--effort`) and are registered as real Cobra flags, so they appear in `--help` and typos are rejected at parse time. Claude's CLI exposes flags that would break AgenC's own invariants — `--settings` carries the operational overlay, `-c`/`-r` are the wrapper's to choose, `--bare` skips the hooks AgenC tracks mission state with — so anything off the table is refused rather than forwarded. The server re-validates against the same table, since the HTTP API is reachable by clients that never went through Cobra.

Adding another forwarded flag is a single table entry.

**Stored as keyed JSON on the mission row.** Values persist in a new `missions.claude_args` column as a JSON object keyed by flag name (`{"model":"opus"}`) rather than a column per flag, so a new forwarded flag needs no migration. Persisting on the row — rather than threading the flag through the tmux resume command string — is what makes the override survive stash-restore, reload, and server restart, all of which rebuild that command from scratch. Those paths needed no changes.

**Precedence is AgenC's, not the parser's.** `MergeClaudeArgs` merges the resolved `defaultModel`, the `claudeArgs` config chain, and the per-mission overrides, with a per-mission value removing same-flag occurrences from the lower-precedence sources — so each flag reaches Claude exactly once. Claude does resolve duplicate flags last-wins, but relying on undocumented parser behaviour isn't testable; this is.

**Clones inherit, and say so.** `--clone` carries the source mission's args over, so a mission deliberately put on a stronger model doesn't silently drop to the config default. An explicit flag on the clone command replaces them, and the CLI prints what it inherited.

`agenc mission inspect` shows a `Claude args:` line for any mission with overrides — that's how you answer "why is this mission on Opus?"

## Testing

- 15 unit tests on merge/validation/rendering, 3 on the DB round-trip, 1 pinning the spawn argv order
- 11 new E2E tests, including one that reads the spawned Claude process's actual command line and asserts `--model haiku` is on it — so the flag is verified all the way to the real process, not just to the database
- `make check` and `make e2e` pass

## Also in this diff

Two changes beyond the feature, both forced by it:

- Deleted `SpawnClaude` and `SpawnClaudeResume` — zero callers, and their signatures were changing anyway
- Renamed the local `mission` to `missionRecord` in `inspectMission`, since it shadowed the `internal/mission` package