### PR TITLE
Stop emitting ANSI colour codes in agenc command output

### DIFF
--- a/cmd/ansi_colors.go
+++ b/cmd/ansi_colors.go
@@ -4,7 +4,6 @@ package cmd
 const (
 	ansiReset     = "\033[0m"
 	ansiBold      = "\033[1m"
-	ansiRed       = "\033[31m"
 	ansiGreen     = "\033[32m"
 	ansiYellow    = "\033[33m"
 	ansiDarkGray  = "\033[90m"

--- a/cmd/cron_history.go
+++ b/cmd/cron_history.go
@@ -71,7 +71,6 @@ func runCronHistory(cmd *cobra.Command, args []string) error {
 
 	for _, m := range displayMissions {
 		status := getMissionStatus(m.ID, m.Status, m.ClaudeState)
-		coloredStatus := colorizeStatus(status)
 
 		started := m.CreatedAt.Local().Format("2006-01-02 15:04:05")
 
@@ -84,7 +83,7 @@ func runCronHistory(cmd *cobra.Command, args []string) error {
 			duration = "--"
 		}
 
-		tbl.AddRow(started, m.ShortID, coloredStatus, duration)
+		tbl.AddRow(started, m.ShortID, string(status), duration)
 	}
 
 	tbl.Print()

--- a/cmd/cron_ls.go
+++ b/cmd/cron_ls.go
@@ -42,7 +42,7 @@ func runCronLs(cmd *cobra.Command, args []string) error {
 	for _, c := range crons {
 		enabled := "yes"
 		if !c.Enabled {
-			enabled = ansiYellow + "no" + ansiReset
+			enabled = "no"
 		}
 
 		lastRun, status := getCronLastRunStatus(client, c)
@@ -74,7 +74,6 @@ func getCronLastRunStatus(client *server.Client, cronInfo server.CronInfo) (stri
 	lastRun := mission.CreatedAt.Local().Format("2006-01-02 15:04")
 
 	status := getMissionStatus(mission.ID, mission.Status, mission.ClaudeState)
-	coloredStatus := colorizeStatus(status)
 
-	return lastRun, coloredStatus
+	return lastRun, string(status)
 }

--- a/cmd/mission_helpers.go
+++ b/cmd/mission_helpers.go
@@ -63,7 +63,7 @@ func buildMissionPickerEntries(missions []*database.Mission, sessionMaxLen int) 
 	for _, m := range missions {
 		sessionName := resolveSessionName(m)
 		status := getMissionStatus(m.ID, m.Status, m.ClaudeState)
-		repo := formatRepoDisplay(m.GitRepo, m.IsAdjutant, cfg)
+		repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 		entries = append(entries, missionPickerEntry{
 			MissionID:  m.ID,
 			LastPrompt: formatLastPrompt(m.LastUserPromptAt, m.CreatedAt),

--- a/cmd/mission_ls.go
+++ b/cmd/mission_ls.go
@@ -98,7 +98,7 @@ func runMissionLs(cmd *cobra.Command, args []string) error {
 			tbl.AddRow(
 				m.ShortID,
 				formatLastPrompt(m.LastUserPromptAt, m.CreatedAt),
-				colorizeStatus(status),
+				string(status),
 				pane,
 				truncatePrompt(sessionName, defaultPromptMaxLen),
 				repo,
@@ -107,7 +107,7 @@ func runMissionLs(cmd *cobra.Command, args []string) error {
 			tbl.AddRow(
 				m.ShortID,
 				formatLastPrompt(m.LastUserPromptAt, m.CreatedAt),
-				colorizeStatus(status),
+				string(status),
 				truncatePrompt(sessionName, defaultPromptMaxLen),
 				repo,
 			)
@@ -127,15 +127,28 @@ func runMissionLs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// displayGitRepo formats a canonical repo name for user-facing display.
-// GitHub repos have their "github.com/" prefix stripped; non-GitHub repos are
-// shown in full. The repo name (final path segment) is colored light blue.
-// Returns "--" for an empty repo name.
+// displayGitRepo formats a canonical repo name for command output. GitHub
+// repos have their "github.com/" prefix stripped; non-GitHub repos are shown
+// in full. Returns "--" for an empty repo name.
+//
+// Deliberately uncolored: command output is parsed by agents, and ANSI codes
+// would land in the middle of the values they parse. The colored counterpart
+// is displayGitRepoForPicker.
 func displayGitRepo(gitRepo string) string {
 	if gitRepo == "" {
 		return "--"
 	}
-	display := strings.TrimPrefix(gitRepo, "github.com/")
+	return strings.TrimPrefix(gitRepo, "github.com/")
+}
+
+// displayGitRepoForPicker is displayGitRepo with the repo name (final path
+// segment) colored light blue. Only for fzf pickers and other interactive TUI
+// surfaces a human reads — never for command output.
+func displayGitRepoForPicker(gitRepo string) string {
+	if gitRepo == "" {
+		return "--"
+	}
+	display := displayGitRepo(gitRepo)
 	if idx := strings.LastIndex(display, "/"); idx != -1 {
 		return display[:idx+1] + ansiLightBlue + display[idx+1:] + ansiReset
 	}
@@ -152,16 +165,38 @@ func plainGitRepoName(gitRepo string) string {
 	return strings.TrimPrefix(gitRepo, "github.com/")
 }
 
-// formatRepoDisplay returns a user-facing display string for a repo, combining
-// emoji prefix (if configured), title (if configured), or colored canonical name.
-// For adjutant missions, returns "🤖  Adjutant" regardless of other parameters.
+// formatRepoDisplay returns a display string for a repo, combining emoji
+// prefix (if configured), title (if configured), or canonical name. For
+// adjutant missions, returns "🤖  Adjutant" regardless of other parameters.
 // Safe to call with nil cfg (falls back to displayGitRepo with no emoji).
+//
+// Uncolored, for command output. The colored counterpart is
+// formatRepoDisplayForPicker.
 func formatRepoDisplay(repoName string, isAdjutant bool, cfg *config.AgencConfig) string {
+	return buildRepoDisplay(repoName, isAdjutant, cfg, displayGitRepo)
+}
+
+// formatRepoDisplayForPicker is formatRepoDisplay with the canonical repo name
+// colored. Only for fzf pickers and other interactive TUI surfaces a human
+// reads — never for command output.
+func formatRepoDisplayForPicker(repoName string, isAdjutant bool, cfg *config.AgencConfig) string {
+	return buildRepoDisplay(repoName, isAdjutant, cfg, displayGitRepoForPicker)
+}
+
+// buildRepoDisplay is the shared body of formatRepoDisplay and
+// formatRepoDisplayForPicker; formatCanonicalName decides whether the
+// canonical repo name is colored.
+func buildRepoDisplay(
+	repoName string,
+	isAdjutant bool,
+	cfg *config.AgencConfig,
+	formatCanonicalName func(string) string,
+) string {
 	if isAdjutant {
 		return "🤖  Adjutant"
 	}
 
-	displayName := displayGitRepo(repoName)
+	displayName := formatCanonicalName(repoName)
 	emoji := ""
 	if cfg != nil {
 		if t := cfg.GetRepoTitle(repoName); t != "" {
@@ -188,7 +223,9 @@ func formatLastPrompt(lastUserPromptAt *time.Time, _ time.Time) string {
 	return lastUserPromptAt.Local().Format("2006-01-02 15:04")
 }
 
-// colorizeStatus wraps a status string with ANSI color codes.
+// colorizeStatus wraps a status string with ANSI color codes. Only for fzf
+// pickers and other interactive TUI surfaces a human reads — command output
+// prints the bare status so agents can compare against it.
 func colorizeStatus(status MissionDisplayStatus) string {
 	s := string(status)
 	switch status {

--- a/cmd/mission_new.go
+++ b/cmd/mission_new.go
@@ -337,7 +337,7 @@ func selectFromRepoLibrary(agencDirpath string, entries []repoLibraryEntry, init
 	rows = append(rows, []string{"🐙  Github Repo"})
 	cfg, _, _ := config.ReadAgencConfig(agencDirpath)
 	for _, entry := range entries {
-		display := formatRepoDisplay(entry.RepoName, false, cfg)
+		display := formatRepoDisplayForPicker(entry.RepoName, false, cfg)
 		// Add default 📦 icon for repos without a configured emoji to keep
 		// the picker visually uniform (every row has an icon).
 		if cfg == nil || cfg.GetRepoEmoji(entry.RepoName) == "" {

--- a/cmd/mission_search.go
+++ b/cmd/mission_search.go
@@ -79,7 +79,7 @@ func runMissionSearch(cmd *cobra.Command, args []string) error {
 
 		fmt.Printf("%s  %s  %s\n", shortID, session, repo)
 		if r.Snippet != "" {
-			fmt.Printf("  %s\n\n", database.ColorizeSnippet(r.Snippet))
+			fmt.Printf("  %s\n\n", database.StripSnippetMarkers(r.Snippet))
 		}
 	}
 

--- a/cmd/mission_search_fzf.go
+++ b/cmd/mission_search_fzf.go
@@ -64,7 +64,7 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 	if looksLikeMissionID(query) {
 		if m, resolveErr := client.GetMission(query); resolveErr == nil {
 			session := resolveSessionName(m)
-			repo := formatRepoDisplay(m.GitRepo, m.IsAdjutant, cfg)
+			repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 			lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 			rows = append(rows, searchFzfRow{
 				shortID: m.ShortID,
@@ -98,7 +98,7 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 			session = truncatePrompt(session, 30)
 		}
 
-		repo := formatRepoDisplay(r.GitRepo, false, cfg)
+		repo := formatRepoDisplayForPicker(r.GitRepo, false, cfg)
 
 		snippet := strings.ReplaceAll(r.Snippet, "\n", " ")
 		snippet = database.ColorizeSnippet(snippet)
@@ -177,7 +177,7 @@ func appendSubstringMatches(
 		appended++
 
 		session := truncatePrompt(resolveSessionName(m), 30)
-		repo := formatRepoDisplay(m.GitRepo, m.IsAdjutant, cfg)
+		repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 		lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 		rows = append(rows, searchFzfRow{
 			shortID: m.ShortID,

--- a/cmd/repo_display_test.go
+++ b/cmd/repo_display_test.go
@@ -69,3 +69,53 @@ func TestFormatRepoDisplay_EmojiAndTitle(t *testing.T) {
 		t.Errorf("expected title in result, got %q", result)
 	}
 }
+
+// The tests below hold the line agenc-hxr4 draws: command output is parsed by
+// agents and carries no ANSI escapes, while the fzf pickers and the tmux
+// command palette are read by a human and keep their color. The two halves
+// share formatting code, so a change to one can silently take the other with
+// it — these assert both directions.
+
+const ansiEscape = "\033"
+
+func TestFormatRepoDisplay_HasNoAnsi(t *testing.T) {
+	result := formatRepoDisplay("github.com/owner/repo", false, nil)
+	if strings.Contains(result, ansiEscape) {
+		t.Errorf("command output must carry no ANSI escapes, got %q", result)
+	}
+}
+
+func TestDisplayGitRepo_HasNoAnsi(t *testing.T) {
+	for _, gitRepo := range []string{"", "github.com/owner/repo", "gitlab.com/owner/repo"} {
+		result := displayGitRepo(gitRepo)
+		if strings.Contains(result, ansiEscape) {
+			t.Errorf("displayGitRepo(%q) must carry no ANSI escapes, got %q", gitRepo, result)
+		}
+	}
+}
+
+func TestColorizeStatus_KeepsAnsiForPicker(t *testing.T) {
+	// mission ls / cron ls / cron history print the bare status; the picker is
+	// the only caller of colorizeStatus, and it keeps the color.
+	result := colorizeStatus(StatusIdle)
+	if !strings.Contains(result, ansiEscape) {
+		t.Errorf("picker status must keep its ANSI color, got %q", result)
+	}
+	if string(StatusIdle) == result {
+		t.Errorf("expected colorizeStatus to wrap the status, got the bare value %q", result)
+	}
+}
+
+func TestFormatRepoDisplayForPicker_KeepsAnsi(t *testing.T) {
+	result := formatRepoDisplayForPicker("github.com/owner/repo", false, nil)
+	if !strings.Contains(result, ansiEscape) {
+		t.Errorf("picker repo display must keep its ANSI color, got %q", result)
+	}
+}
+
+func TestFormatRepoDisplayForPicker_EmptyRepoIsPlain(t *testing.T) {
+	result := formatRepoDisplayForPicker("", false, nil)
+	if result != "--" {
+		t.Errorf("got %q, want %q", result, "--")
+	}
+}

--- a/cmd/repo_helpers.go
+++ b/cmd/repo_helpers.go
@@ -15,7 +15,7 @@ func selectReposWithFzfAndQuery(repoNames []string, prompt string, initialQuery 
 	// Build rows for the picker (single column: repo display name)
 	var rows [][]string
 	for _, name := range repoNames {
-		rows = append(rows, []string{displayGitRepo(name)})
+		rows = append(rows, []string{displayGitRepoForPicker(name)})
 	}
 
 	indices, err := runFzfPicker(FzfPickerConfig{

--- a/cmd/repo_rm.go
+++ b/cmd/repo_rm.go
@@ -77,7 +77,7 @@ func runRepoRm(cmd *cobra.Command, args []string) error {
 		},
 		GetItems: func() ([]string, error) { return repoNames, nil },
 		FormatRow: func(repoName string) []string {
-			return []string{formatRepoDisplay(repoName, false, cfg)}
+			return []string{formatRepoDisplayForPicker(repoName, false, cfg)}
 		},
 		FzfPrompt:         "Select repos to remove (TAB to multi-select): ",
 		FzfHeaders:        []string{"REPO"},

--- a/cmd/server_status.go
+++ b/cmd/server_status.go
@@ -60,13 +60,10 @@ func runServerStatus(cmd *cobra.Command, args []string) error {
 
 		for _, name := range names {
 			status := health.Loops[name]
-			marker := ansiGreen + "●" + ansiReset
-			if status == "crashed" {
-				marker = ansiRed + "●" + ansiReset
-			} else if status == "stopped" {
-				marker = ansiYellow + "●" + ansiReset
-			}
-			fmt.Printf("  %s %-25s %s\n", marker, name, status)
+			// Deliberately uncolored: this is command output that agents
+			// parse. The status text alongside carries the same information
+			// the marker color used to.
+			fmt.Printf("  ● %-25s %s\n", name, status)
 		}
 	}
 

--- a/cmd/tmux_palette_ansi_test.go
+++ b/cmd/tmux_palette_ansi_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/odyssey/agenc/internal/config"
+)
+
+// The tmux command palette is an interactive human surface, so it keeps its
+// color even though agenc's command output no longer has any (agenc-hxr4).
+func TestFormatPaletteEntryLine_KeepsAnsi(t *testing.T) {
+	line := formatPaletteEntryLine(config.ResolvedPaletteCommand{
+		Name:        "open-repo-example",
+		Title:       "Example",
+		Description: "Open the example repo",
+	})
+	if !strings.Contains(line, "\033") {
+		t.Errorf("palette entry must keep its ANSI color, got %q", line)
+	}
+}

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -101,6 +101,35 @@ run_test_no_crash() {
     fi
 }
 
+# Runs a command, captures stdout+stderr to a file, and fails if the raw bytes
+# contain an ANSI escape (0x1b). Command output is consumed by agents, so an
+# escape lands inside the value they compare against and the comparison just
+# silently never matches. A terminal renders escapes invisibly, so byte
+# inspection is the only check that catches this.
+run_test_output_has_no_ansi() {
+    local test_name="${1}"
+    shift
+
+    total=$((total + 1))
+    printf "  %-50s " "${test_name}..."
+
+    local capture_filepath
+    capture_filepath="$(mktemp)"
+    "$@" >"${capture_filepath}" 2>&1 || true
+
+    if LC_ALL=C grep -q $'\033' "${capture_filepath}"; then
+        echo "FAIL (ANSI escape in output)"
+        od -c "${capture_filepath}" | head -10 | sed 's/^/    /'
+        rm -f "${capture_filepath}"
+        failed=$((failed + 1))
+        return
+    fi
+
+    rm -f "${capture_filepath}"
+    echo "PASS"
+    passed=$((passed + 1))
+}
+
 # ---------------------------------------------------------------------------
 # Preflight checks
 # ---------------------------------------------------------------------------
@@ -1573,6 +1602,56 @@ elif echo "${claude_argv}" | grep -q -- "--model haiku"; then
 else
     echo "FAIL (Claude argv lacked '--model haiku': ${claude_argv})"
     failed=$((failed + 1))
+fi
+
+echo ""
+echo "--- No ANSI escapes in command output (agenc-hxr4) ---"
+
+# AgenC command output is consumed overwhelmingly by agents, not read by a
+# human at a terminal. A color code in a status field breaks a comparison
+# against IDLE or STOPPED with no error to notice, so command output carries no
+# escapes at all. Interactive TUI surfaces (the tmux command palette and the
+# fzf pickers it opens) are a separate destination and keep their color, which
+# TestFormatRepoDisplayForPicker_KeepsAnsi and its siblings hold in place.
+#
+# Missions from earlier sections are still present, so the status and repo
+# columns these commands print are actually exercised.
+
+run_test_output_has_no_ansi "mission ls emits no ANSI" \
+    "${agenc_test}" mission ls
+
+run_test_output_has_no_ansi "mission ls --all emits no ANSI" \
+    "${agenc_test}" mission ls --all
+
+run_test_output_has_no_ansi "mission peers emits no ANSI" \
+    "${agenc_test}" mission peers
+
+run_test_output_has_no_ansi "repo ls emits no ANSI" \
+    "${agenc_test}" repo ls
+
+run_test_output_has_no_ansi "cron ls emits no ANSI" \
+    "${agenc_test}" cron ls
+
+run_test_output_has_no_ansi "server status emits no ANSI" \
+    "${agenc_test}" server status
+
+run_test_output_has_no_ansi "notification ls emits no ANSI" \
+    "${agenc_test}" notification ls
+
+run_test_output_has_no_ansi "mission search emits no ANSI" \
+    "${agenc_test}" mission search mission
+
+run_test_output_has_no_ansi "config repoConfig ls emits no ANSI" \
+    "${agenc_test}" config repoConfig ls
+
+if [ -n "${model_short_id}" ]; then
+    run_test_output_has_no_ansi "mission inspect emits no ANSI" \
+        "${agenc_test}" mission inspect "${model_short_id}"
+else
+    total=$((total + 1))
+    printf "  %-50s " "mission inspect emits no ANSI..."
+    echo "SKIP (no mission short ID available)"
+    skipped=$((skipped + 1))
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Closes the silent-parse-failure class described in `agenc-hxr4`: an agent reading `agenc mission ls` got `\033[94mIDLE\033[0m` in the status field, so a comparison against `IDLE` or `STOPPED` was always false with nothing to notice.

## The line this draws

Destination, not file. **Output a command writes to stdout carries no escapes.** **Strings handed to fzf as TUI chrome keep their colour** — the tmux command palette and the pickers it opens are read by a human, and Kevin confirmed the palette keeps its colour.

That line cuts through shared code rather than along file boundaries: `formatRepoDisplay`, `displayGitRepo`, and `colorizeStatus` were each used by both a stdout table and an fzf picker. Rather than making them conditional at runtime, the plain form is now the default and the colouring variants (`formatRepoDisplayForPicker`, `displayGitRepoForPicker`) are named for their destination, so a stdout caller cannot pick up colour by accident.

## Changed

- `mission ls`, `cron ls`, `cron history` print the bare status instead of a colourised one
- `mission ls`, `repo ls`, `mission inspect`, `config repoConfig ls` print plain repo names
- `mission search` strips snippet match markers instead of colourising them
- `server status` drops its per-loop colour marker; the status text beside it already carried the same information
- `ansiRed` deleted — nothing outside command output used it

Unchanged and deliberate: `formatPaletteEntryLine`, the palette's unread-notification header (the inline `\x1b[33m` at `tmux_palette.go:333` that `agenc-hxr4` flagged), `attachedDot`, `colorizeStatus` on the picker path, and the cyan mission column in the notification centre. All are fzf-only.

## Verification

Byte-level, not by eye — a terminal renders escapes invisibly, which is how the original bug hid.

- New E2E section captures each command's output to a file and fails on any `0x1b` byte: `mission ls`, `mission ls --all`, `mission peers`, `repo ls`, `cron ls`, `server status`, `notification ls`, `mission search`, `config repoConfig ls`, `mission inspect`. All pass.
- Go unit tests assert both halves — the plain formatters carry no escape, the picker and palette formatters still do. These run under `make check`, so the pre-commit hook catches a regression in either direction.
- Manual `od -c` check against the real instance (real missions, real repos — the test env's blank missions do not exercise the status and repo columns): zero escape bytes across all ten commands, while `mission search-fzf`, the palette's feeder sharing the same helpers, still emits them.

`make build`, `make check`, and `make e2e` all pass.

Follow-up filed as `agenc-afp8`: the convention is enforced by tests but not yet written down where an agent adding new output would read it.