### PR TITLE
Document the no-ANSI-in-command-output convention and start CLAUDE.design.md

### DIFF
--- a/CLAUDE.design.md
+++ b/CLAUDE.design.md
@@ -1,0 +1,43 @@
+AgenC CLAUDE.md — Design Notes
+==============================
+
+This document records why `CLAUDE.md` at the repo root says what it says, so a future agent can verify, extend, or argue with a convention instead of inheriting it as an unexplained rule.
+
+Where This Document Starts
+--------------------------
+
+It starts on 2026-09-01, with the "Command Output Carries No ANSI Escapes" section, and records only decisions made from that point forward.
+
+The sections that predate it were **not** reconstructed. Their reasoning lives in the conversations, pull requests, and beads that produced them, and writing a plausible-sounding rationale here from the outside would be worse than leaving the gap: a reader trusts a design document precisely where they have no other source, so an invented "why" teaches the wrong generalisation exactly where it does the most damage.
+
+If you genuinely know the reasoning behind an earlier section — you made the call, or you can source it from a bead, a PR, or a session transcript — add it, and say where it came from. If you are inferring, say that instead.
+
+Provenance
+----------
+
+### Created
+
+2026-09-01, during AgenC mission `2c644c10-f76c-441c-8e1f-092a90b0566b`, under bead `agenc-afp8`.
+
+The document exists because of the gap that bead names. While shipping `agenc-hxr4` (PR [#37](https://github.com/mieubrisse/agenc/pull/37)), the ANSI convention needed a home in `CLAUDE.md`, and Kevin's configuration requires a sibling design document when editing a `CLAUDE.md` that lacks one. Bootstrapping one meant either reconstructing rationale for the whole existing file — inventing it, in practice — or leaving the convention undocumented. Kevin resolved it directly: start the document, record only what is actually known, and say on the page where it begins.
+
+### Edits
+
+- **2026-09-01** — Created, alongside the "Command Output Carries No ANSI Escapes" section. Mission `2c644c10-f76c-441c-8e1f-092a90b0566b`; beads `agenc-hxr4` (the change) and `agenc-afp8` (this document). Field evidence originates from mission `591187e7-dab6-4b2d-a063-ff12220d4c3a`.
+
+Design Decisions
+----------------
+
+### Command output carries no ANSI escapes (2026-09-01)
+
+**The failure being prevented.** A parent mission armed three background watchers, each branching on `if [ "$ST" = "STOPPED" ]`. The branch never fired in any of them, because `agenc mission ls` returned the status wrapped in colour codes. Nothing errored. Two of the three watchers appeared to work, because their success path was driven by a GitHub API call and only their stall path depended on parsing — so the broken half stayed masked. A dead child mission and a healthy one produced identical output: silence. Recorded in bead `agenc-5jxx`.
+
+**Removal, not conditional colour.** The conventional fix is to emit colour only when stdout is a terminal, and it was cheap here — `github.com/mattn/go-isatty` is already a dependency, already used for stdin checks across the CLI (`cmd/first_run.go`, `cmd/fzf_picker.go`, `cmd/cron_new.go`, and six others). Kevin considered that alternative and chose removal, on the grounds that the human-reader case for command output barely exists any more, so conditional-colour machinery would be complexity serving almost nobody. Recorded in bead `agenc-hxr4`.
+
+**The palette is carved out, deliberately.** Mid-implementation Kevin narrowed the scope: it is `agenc <command>` output that is agent-consumed. He uses the tmux command palette heavily, and it is a genuinely interactive human surface, so it keeps its colour. This is why the inline escape at `cmd/tmux_palette.go:333` — the one `agenc-hxr4` flagged as the sequence a constants-only change would miss — is kept on purpose rather than overlooked.
+
+**The line is drawn by destination, not by file.** The shared formatters (`formatRepoDisplay`, `displayGitRepo`, `colorizeStatus`) each served both a stdout table and an fzf picker, so a file-scoped rule would have been wrong in both directions at once: strip globally and the palette silently loses its colour, keep per-file and escapes stay in parsed output.
+
+**Named variants, not a `colored bool` parameter.** A boolean parameter puts the decision at every call site and depends on each caller passing the right value — the same "expected not to" that produced the original bug. Two functions named for where their output goes (`formatRepoDisplay` vs. `formatRepoDisplayForPicker`) mean the plain form is what a caller reaches for by default, and colour has to be asked for explicitly. This mattered in practice: while auditing call sites during the change, one fzf picker (the repo multi-select in `cmd/repo_helpers.go`) was initially misfiled as stdout, and re-checking each site by reading where its output actually goes is what caught it.
+
+**Verification is byte-level in both directions.** A terminal draws escape sequences invisibly, which is exactly how the original bug hid, so "it looks clean" is not evidence. Go unit tests assert that the plain formatters carry no escape and that the picker and palette formatters still do; they run under `make check`, so the pre-commit hook catches a regression either way. An E2E section captures each agent-facing command's output to a file and fails on any `0x1b` byte.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,17 @@ Concrete examples:
 - The CLI does NOT call `tmux display-message` to resolve the session name itself — that requires the tmux socket, which may be blocked by a sandbox.
 - New server endpoints are preferred over new CLI logic.
 
+Command Output Carries No ANSI Escapes
+--------------------------------------
+
+AgenC's command output is consumed overwhelmingly by agents, not read by a human at a terminal. A colour code inside a status field breaks an agent's comparison against `IDLE` or `STOPPED`, and breaks it silently — nothing errors, the match simply never happens, and a terminal renders the escape invisibly so the output looks fine.
+
+The rule is by destination, not by file: **anything a command writes to stdout carries no ANSI escapes.** Strings handed to `fzf` as TUI chrome — the tmux command palette and the pickers it opens — are read by a human and keep their colour.
+
+Formatters shared between the two audiences are named for their destination (`formatRepoDisplay` vs. `formatRepoDisplayForPicker`), so a stdout caller cannot pick up colour by accident. When adding a command or a column, print the plain form; reach for a `...ForPicker` variant only when the string's sole destination is fzf.
+
+Both directions are asserted — Go unit tests pin the formatters under `make check`, and an E2E section captures each agent-facing command's output to a file and fails on any escape byte. Verify by inspecting bytes (`od -c`, or grep for `\033`), never by looking at a terminal.
+
 Building and Checking
 ---------------------
 


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Closes `agenc-afp8`, the follow-up split out of `agenc-hxr4` (#37). That PR removed ANSI colour from command output and enforced it with tests, but left the convention undiscoverable: someone adding a new command or column had no reason to know the rule exists, and would find out only if they ran `make e2e` — which the pre-commit hook does not.

## Two files

**`CLAUDE.md`** gains a short section stating the rule by destination rather than by file: command output carries no escapes, `fzf` TUI chrome (the palette and its pickers) keeps its colour, shared formatters are named for where their output goes, and verification is byte-level because a terminal renders escapes invisibly.

**`CLAUDE.design.md`** is new, and starts here rather than covering the whole file. It records the reasoning behind that one section — the silent watcher failure it prevents, why removal was chosen over conditional `isatty` colour, why the palette is carved out, why named variants beat a `colored bool`, and why `cmd/tmux_palette.go:333` is kept on purpose.

## On the scope of the design document

The document says on its own first page that it starts on 2026-09-01 and that pre-existing sections were **not** reconstructed. That is deliberate, and it is the reason I stopped short of this in #37: a reader trusts a design document precisely where they have no other source, so an invented rationale for an older section would teach the wrong generalisation exactly where it does the most damage. Everything recorded is either something I witnessed making the change, or sourced from a bead (`agenc-hxr4`, `agenc-5jxx`) or the code itself — the `go-isatty` usage claim was re-checked against the tree rather than copied from the bead, and corrected where the bead's list was partial. The page invites the next person to fill in what they genuinely know.

No code changes; `make check` passes via the pre-commit hook.