### PR TITLE
Copy mission repos with APFS clones: 5.8s -> 0.1s per mission creation

### DIFF
--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -378,7 +378,7 @@ Repo library operations and resolution logic. Used by the server for repo API en
 Mission lifecycle: directory creation, repo copying, and Claude process spawning.
 
 - `mission.go` — `CreateMissionDir` (sets up mission directory, copies git repo), `BuildClaudeCmd`/`SpawnClaudeWithPrompt`/`SpawnClaudeResumeWithSession` (construct and start Claude `exec.Cmd` with 1Password integration and environment variables)
-- `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (rsync-based), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
+- `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (APFS copy-on-write clones via `cp -c` on macOS, falling back to `rsync -a`), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
 
 ### `internal/claudeconfig/`
 
@@ -666,7 +666,7 @@ Data Flow: Mission Lifecycle
 1. CLI ensures the server is running and a config source repo is registered
 2. Resolves the git repo reference (URL, shorthand, or fzf picker) and ensures it is cloned into the repo library
 3. Creates a database record — generates UUID + 8-char short ID, records the git repo name and optional cron association
-4. Creates the mission directory structure: copies the repo from the library via rsync
+4. Creates the mission directory structure: copies the repo from the library, as APFS copy-on-write clones on macOS and via rsync elsewhere
 5. Server-side, seeds the mission's agent-dir trust entry (`projects["<agentDir>"].hasTrustDialogAccepted=true`, plus the repo's `trustedMcpServers`) into the real `~/.claude.json` (or `$CLAUDE_CONFIG_DIR/.claude.json` when set) under a mutex, via atomic temp-file+rename with verify-retry — so the first Claude in the mission does not hit a blocking trust dialog (State Y; see "Trust seeding" under Key Architectural Patterns)
 6. Creates a `Wrapper` and calls `Run` or `RunHeadless` depending on flags
 

--- a/internal/mission/repo.go
+++ b/internal/mission/repo.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -122,44 +123,75 @@ func ValidateGitRepo(repoDirpath string) error {
 	return nil
 }
 
-// CopyRepo copies an entire git repository from srcRepoDirpath to
-// dstRepoDirpath using rsync. The destination receives a full independent
-// copy including the .git/ directory.
-func CopyRepo(srcRepoDirpath string, dstRepoDirpath string) error {
-	srcPath := srcRepoDirpath + "/"
-	dstPath := dstRepoDirpath + "/"
+// copyDirContents copies everything inside srcDirpath into dstDirpath, which
+// must already exist. The destination receives a full, independent copy —
+// including dotfiles, symlinks (copied as symlinks, never followed), modes and
+// mtimes.
+//
+// On macOS this runs `cp -c`, which uses clonefile(2) to make each file a
+// copy-on-write clone of its source. A clone is a complete, independent file:
+// writing to either side breaks sharing for the affected blocks only, so the
+// two copies can never alias each other. What it buys is that the copy is
+// near-instant and initially costs no additional disk. `cp -c` degrades on its
+// own — per cp(1), "if the source and target are on different filesystems, or
+// the target filesystem does not support cloning, cp will fallback to using
+// copyfile(2) instead to ensure the copy still succeeds" — so a non-APFS or
+// cross-volume $AGENC_DIRPATH still gets a correct copy.
+//
+// Everywhere else, and on any `cp` failure at all, this falls back to the
+// `rsync -a` that AgenC has always used, so mission creation is never blocked
+// by cloning being unavailable. A failed `cp` can only have written a subset of
+// the source, and rsync preserves size and mtime the same way cp does, so the
+// fallback rsync repairs a partial tree rather than being confused by it.
+func copyDirContents(srcDirpath string, dstDirpath string) error {
+	// Trailing slashes make both tools copy the CONTENTS of src into dst,
+	// rather than nesting src as a subdirectory of dst.
+	srcPath := srcDirpath + "/"
+	dstPath := dstDirpath + "/"
 
+	if runtime.GOOS == "darwin" {
+		cloneCmd := exec.Command("cp", "-c", "-R", srcPath, dstPath)
+		if _, err := cloneCmd.CombinedOutput(); err == nil {
+			return nil
+		}
+	}
+
+	rsyncCmd := exec.Command("rsync", "-a", srcPath, dstPath)
+	output, err := rsyncCmd.CombinedOutput()
+	if err != nil {
+		return stacktrace.Propagate(err, "rsync failed: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// CopyRepo copies an entire git repository from srcRepoDirpath to
+// dstRepoDirpath. The destination receives a full independent copy including
+// the .git/ directory.
+func CopyRepo(srcRepoDirpath string, dstRepoDirpath string) error {
 	if err := os.MkdirAll(dstRepoDirpath, 0755); err != nil {
 		return stacktrace.Propagate(err, "failed to create directory '%s'", dstRepoDirpath)
 	}
 
-	cmd := exec.Command("rsync", "-a", srcPath, dstPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to copy repo: %s", strings.TrimSpace(string(output)))
+	if err := copyDirContents(srcRepoDirpath, dstRepoDirpath); err != nil {
+		return stacktrace.Propagate(err, "failed to copy repo")
 	}
 	return nil
 }
 
 // CopyAgentDir copies an entire agent directory from srcAgentDirpath to
-// dstAgentDirpath using rsync. If the source directory does not exist,
-// this is a no-op (empty agent directory = nothing to copy).
+// dstAgentDirpath. If the source directory does not exist, this is a no-op
+// (empty agent directory = nothing to copy).
 func CopyAgentDir(srcAgentDirpath string, dstAgentDirpath string) error {
 	if _, err := os.Stat(srcAgentDirpath); os.IsNotExist(err) {
 		return nil
 	}
 
-	srcPath := srcAgentDirpath + "/"
-	dstPath := dstAgentDirpath + "/"
-
 	if err := os.MkdirAll(dstAgentDirpath, 0755); err != nil {
 		return stacktrace.Propagate(err, "failed to create directory '%s'", dstAgentDirpath)
 	}
 
-	cmd := exec.Command("rsync", "-a", srcPath, dstPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to copy agent directory: %s", strings.TrimSpace(string(output)))
+	if err := copyDirContents(srcAgentDirpath, dstAgentDirpath); err != nil {
+		return stacktrace.Propagate(err, "failed to copy agent directory")
 	}
 	return nil
 }

--- a/internal/mission/repo_test.go
+++ b/internal/mission/repo_test.go
@@ -308,3 +308,237 @@ func TestParseRepoReferenceWithDefaultOwner(t *testing.T) {
 		})
 	}
 }
+
+// writeCopySourceTree builds a source tree exercising the properties a repo
+// copy has to preserve: dotfiles and dot-directories (.git), nesting, a
+// symlink (which must be copied as a symlink, not followed), a dangling
+// symlink, a non-default file mode, and a non-current mtime.
+func writeCopySourceTree(t *testing.T, srcDirpath string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(srcDirpath, ".git", "objects"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcDirpath, "sub"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, ".git", "config"), []byte("[core]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, ".git", "objects", "obj"), []byte("object-bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, "sub", "nested.txt"), []byte("nested"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, "script.sh"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("script.sh", filepath.Join(srcDirpath, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("does-not-exist", filepath.Join(srcDirpath, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+
+	// A mtime well in the past, so "preserved" is distinguishable from
+	// "happened to be written at the same second as the copy".
+	past := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(filepath.Join(srcDirpath, "script.sh"), past, past); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// assertEntryMatches requires one source entry's destination counterpart to
+// have the same mode, and — by type — the same symlink target, or the same
+// content and mtime.
+func assertEntryMatches(t *testing.T, relPath string, srcPath string, dstPath string, srcInfo os.FileInfo) {
+	t.Helper()
+
+	dstInfo, err := os.Lstat(dstPath)
+	if err != nil {
+		t.Errorf("%s: missing from destination: %v", relPath, err)
+		return
+	}
+
+	if srcInfo.Mode() != dstInfo.Mode() {
+		t.Errorf("%s: mode = %v, want %v", relPath, dstInfo.Mode(), srcInfo.Mode())
+	}
+
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		srcTarget, srcErr := os.Readlink(srcPath)
+		dstTarget, dstErr := os.Readlink(dstPath)
+		if srcErr != nil || dstErr != nil {
+			t.Errorf("%s: readlink failed: source %v, destination %v", relPath, srcErr, dstErr)
+			return
+		}
+		if srcTarget != dstTarget {
+			t.Errorf("%s: symlink target = %q, want %q", relPath, dstTarget, srcTarget)
+		}
+		return
+	}
+
+	// Directory mtimes shift as children are written into them, so content and
+	// mtime are asserted for regular files only.
+	if srcInfo.IsDir() {
+		return
+	}
+
+	srcContent, srcErr := os.ReadFile(srcPath)
+	dstContent, dstErr := os.ReadFile(dstPath)
+	if srcErr != nil || dstErr != nil {
+		t.Errorf("%s: read failed: source %v, destination %v", relPath, srcErr, dstErr)
+		return
+	}
+	if string(srcContent) != string(dstContent) {
+		t.Errorf("%s: content = %q, want %q", relPath, dstContent, srcContent)
+	}
+	if !srcInfo.ModTime().Equal(dstInfo.ModTime()) {
+		t.Errorf("%s: mtime = %v, want %v", relPath, dstInfo.ModTime(), srcInfo.ModTime())
+	}
+}
+
+// assertTreesMatch walks srcDirpath and requires dstDirpath to hold the same
+// relative paths with the same types, contents, modes, mtimes and symlink
+// targets — then requires dstDirpath to hold nothing extra.
+func assertTreesMatch(t *testing.T, srcDirpath string, dstDirpath string) {
+	t.Helper()
+
+	seen := map[string]bool{}
+	walkErr := filepath.Walk(srcDirpath, func(srcPath string, srcInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(srcDirpath, srcPath)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+		seen[relPath] = true
+		assertEntryMatches(t, relPath, srcPath, filepath.Join(dstDirpath, relPath), srcInfo)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking source tree failed: %v", walkErr)
+	}
+
+	// Positive control on the walk itself: a comparison that visited nothing
+	// would pass every assertion above.
+	if len(seen) == 0 {
+		t.Fatal("source tree was empty, so this comparison proved nothing")
+	}
+
+	extraErr := filepath.Walk(dstDirpath, func(dstPath string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(dstDirpath, dstPath)
+		if err != nil {
+			return err
+		}
+		if relPath != "." && !seen[relPath] {
+			t.Errorf("%s: present in destination but not in source", relPath)
+		}
+		return nil
+	})
+	if extraErr != nil {
+		t.Fatalf("walking destination tree failed: %v", extraErr)
+	}
+}
+
+func TestCopyRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+	writeCopySourceTree(t, srcDirpath)
+
+	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyRepo failed: %v", err)
+	}
+
+	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+func TestCopyRepo_CreatesMissingDestination(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "not", "yet", "there")
+	writeCopySourceTree(t, srcDirpath)
+
+	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyRepo failed: %v", err)
+	}
+
+	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+func TestCopyRepo_IndependentOfSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+	if err := os.MkdirAll(srcDirpath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	srcFilepath := filepath.Join(srcDirpath, "file.txt")
+	if err := os.WriteFile(srcFilepath, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyRepo failed: %v", err)
+	}
+
+	// Cloned files are copy-on-write, not shared: a write to either side must
+	// not be visible on the other.
+	dstFilepath := filepath.Join(dstDirpath, "file.txt")
+	if err := os.WriteFile(dstFilepath, []byte("changed in destination"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	srcContent, err := os.ReadFile(srcFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(srcContent) != "original" {
+		t.Errorf("writing the destination changed the source: got %q, want %q", srcContent, "original")
+	}
+
+	if err := os.WriteFile(srcFilepath, []byte("changed in source"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dstContent, err := os.ReadFile(dstFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dstContent) != "changed in destination" {
+		t.Errorf("writing the source changed the destination: got %q, want %q", dstContent, "changed in destination")
+	}
+}
+
+func TestCopyAgentDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+	writeCopySourceTree(t, srcDirpath)
+
+	if err := CopyAgentDir(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyAgentDir failed: %v", err)
+	}
+
+	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+func TestCopyAgentDir_MissingSourceIsNoOp(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "does-not-exist")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+
+	if err := CopyAgentDir(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyAgentDir failed: %v", err)
+	}
+
+	if _, err := os.Stat(dstDirpath); !os.IsNotExist(err) {
+		t.Errorf("expected destination not to be created, got err = %v", err)
+	}
+}


### PR DESCRIPTION
Closes the storage half of #15, but the reason I went and did it is the other half: **mission creation latency**.

## The measurement

`CopyRepo` copies the repo-library clone into the mission's `agent/` directory with `rsync -a`. On a 1.6 GB repo, through the real function, on APFS:

| | wall time | disk consumed |
|---|---|---|
| `rsync -a` (today) | 5.833 s | 1611 MB |
| `cp -c` (this PR) | 0.099 s | 0 MB |

That 5.8 seconds is time the user sits and watches before Claude starts, on every mission. Pruning old missions does not touch it: a cleanup tool fixes the disk that already accumulated, but every new mission still pays the copy. That is why I think this is worth doing even though you were right that the storage side is not hair-on-fire.

## On the hardlink concern

Your comment on #15 was wary of "tricky hardlinking stuff", and that wariness is correct for options 2 and 3 in that issue. `clonefile` is not that.

A clone is not a shared inode. It is a separate file that happens to start out pointing at the same physical blocks, and APFS breaks the sharing per-block on the first write to either side. Two missions cloned from the same library repo cannot see each other's writes, cannot corrupt each other, and `rm -rf` on one does nothing to the other. There is a unit test in here that asserts exactly that (`TestCopyRepo_IndependentOfSource`): it writes to each side and checks the other did not move.

So the aliasing risk you were avoiding does not exist on this path. The only thing shared is disk blocks that nobody has written to yet.

## The change

`CopyRepo` and `CopyAgentDir` now share one `copyDirContents` helper. On darwin it runs `cp -c -R`; everywhere else, and on any `cp` failure at all, it runs the same `rsync -a` as before. The fallback is automatic and silent, so mission creation can never fail because cloning was unavailable.

Two layers of degradation, not one:

1. `cp -c` handles the common cases itself. Per `cp(1)`: "if the source and target are on different filesystems, or the target filesystem does not support cloning, cp will fallback to using copyfile(2) instead to ensure the copy still succeeds." I verified this against a mounted HFS+ image: `cp -c -R` onto it exits 0 with a correct tree. So a non-APFS or cross-volume `$AGENC_DIRPATH` needs no special handling.
2. If `cp` errors anyway, `rsync -a` runs. A failed `cp` can only have written a subset of the source, and both tools preserve size and mtime, so rsync repairs a partial tree rather than being confused by it.

## Verification

Everything below is from an actual run, not from reasoning about the code.

**Behaviour parity.** `cp -c -R src/ dst/` and `rsync -a src/ dst/` produce identical trees on the same input: same paths, same modes, same mtimes, symlinks preserved as symlinks (including dangling ones), dotfiles and `.git/` included, FIFOs preserved. New unit tests assert all of it, plus destination creation and the missing-source no-op.

**That the clone path is real, and that each fallback works.** Unit tests pass whichever path runs, so they cannot tell you the clone actually happened. I forced each path to be the only one available, calling the real `CopyRepo` on the 1.6 GB repo:

- `rsync` stubbed to fail: **0.180 s, 0 MB**, tree identical. The clone path carried the whole copy alone.
- `cp` stubbed to fail: **5.304 s, 1604 MB**, tree identical. Clean fallback to today's behaviour.
- both stubbed to fail: errors out loudly with the rsync output attached, rather than silently reporting success.

**Checks.** `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `deadcode ./...` (no new entries), `gofmt -l .` (clean), and `go test -race -cover ./...` all pass. `internal/mission` coverage is 47.5%.

I also mutation-tested the new assertions: making `copyDirContents` a no-op turns three of the new tests red, so they are load-bearing rather than decorative.

## Two things I did not do

- **No E2E test.** `scripts/e2e-test.sh` only creates `--blank` missions, which take the `gitRepoSource == ""` branch and never reach `CopyRepo`, so there was nothing existing to extend. I could add a `mission new --repo ...` case, but I would rather not hand you a test I have not watched go green in your harness. Say the word and I will add it.
- **The `cp` failure is swallowed silently.** Neither function has a logger, and threading one in would change both signatures and both call sites. It means a systematic `cp` failure would quietly cost the rsync price forever with no signal. Happy to add a log line if you would rather have one.

I updated `docs/system-architecture.md` in the same commit, per CLAUDE.md.
