### PR TITLE
Sort mission search results by recency, not FTS rank

### DIFF
--- a/cmd/mission_search_fzf.go
+++ b/cmd/mission_search_fzf.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +40,10 @@ const substringMergeCap = 30
 type searchFzfRow struct {
 	shortID string
 	cols    []string
+	// sortTime is COALESCE(last_user_prompt_at, created_at) — the same
+	// recency key the empty-query picker sorts on, so search results stay
+	// in the date order the user sees before typing.
+	sortTime time.Time
 }
 
 func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
@@ -67,8 +72,9 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 			repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 			lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 			rows = append(rows, searchFzfRow{
-				shortID: m.ShortID,
-				cols:    []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+				shortID:  m.ShortID,
+				cols:     []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+				sortTime: missionRecency(m.LastUserPromptAt, m.CreatedAt),
 			})
 			seenMissionIDs[m.ID] = true
 		}
@@ -106,8 +112,9 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 		lastPrompt := formatLastPromptFromStrings(r.LastUserPromptAt, r.CreatedAt)
 
 		rows = append(rows, searchFzfRow{
-			shortID: shortID,
-			cols:    []string{shortID, attachedDotForPicker(r.IsAttached), lastPrompt, session, repo, snippet},
+			shortID:  shortID,
+			cols:     []string{shortID, attachedDotForPicker(r.IsAttached), lastPrompt, session, repo, snippet},
+			sortTime: recencyFromStrings(r.LastUserPromptAt, r.CreatedAt),
 		})
 	}
 
@@ -119,6 +126,8 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 	if len(rows) == 0 {
 		return nil
 	}
+
+	sortSearchRowsByRecency(rows)
 
 	// Render through tableprinter for alignment
 	var buf strings.Builder
@@ -180,8 +189,9 @@ func appendSubstringMatches(
 		repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 		lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 		rows = append(rows, searchFzfRow{
-			shortID: m.ShortID,
-			cols:    []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+			shortID:  m.ShortID,
+			cols:     []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+			sortTime: missionRecency(m.LastUserPromptAt, m.CreatedAt),
 		})
 	}
 	return rows
@@ -202,6 +212,38 @@ func matchMissionSubstring(m *database.Mission, lowerQuery string) bool {
 		return true
 	}
 	return false
+}
+
+// sortSearchRowsByRecency sorts search rows in-place, newest first, by
+// COALESCE(last_user_prompt_at, created_at) — matching the empty-query
+// picker's ordering so typing a query does not reshuffle the list into
+// FTS-rank order. The sort is stable, so rows sharing a timestamp keep the
+// order they were merged in (direct ID hit, then FTS rank, then substring).
+func sortSearchRowsByRecency(rows []searchFzfRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].sortTime.After(rows[j].sortTime)
+	})
+}
+
+// missionRecency returns COALESCE(lastUserPromptAt, createdAt).
+func missionRecency(lastUserPromptAt *time.Time, createdAt time.Time) time.Time {
+	if lastUserPromptAt != nil {
+		return *lastUserPromptAt
+	}
+	return createdAt
+}
+
+// recencyFromStrings is missionRecency over the RFC3339 timestamps that
+// SearchMissionsResponse carries across JSON. Unparseable values fall back to
+// the zero time, which sorts such rows to the bottom.
+func recencyFromStrings(lastUserPromptAt *string, createdAtRFC3339 string) time.Time {
+	if lastUserPromptAt != nil {
+		if t, err := time.Parse(time.RFC3339, *lastUserPromptAt); err == nil {
+			return t
+		}
+	}
+	createdAt, _ := time.Parse(time.RFC3339, createdAtRFC3339)
+	return createdAt
 }
 
 // formatLastPromptFromStrings parses the RFC3339 timestamps that

--- a/cmd/mission_search_fzf_test.go
+++ b/cmd/mission_search_fzf_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/odyssey/agenc/internal/database"
 )
@@ -42,5 +43,77 @@ func TestMatchMissionSubstring_EmptyFieldsDoNotFalseMatch(t *testing.T) {
 	m := &database.Mission{Prompt: "", GitRepo: ""}
 	if matchMissionSubstring(m, "anything") {
 		t.Fatal("empty fields should not match a non-empty query")
+	}
+}
+
+func TestSortSearchRowsByRecency_NewestFirst(t *testing.T) {
+	mk := func(id string, ts string) searchFzfRow {
+		t.Helper()
+		parsed, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			t.Fatalf("bad test timestamp %q: %v", ts, err)
+		}
+		return searchFzfRow{shortID: id, sortTime: parsed}
+	}
+	rows := []searchFzfRow{
+		mk("old", "2026-06-17T13:04:00Z"),
+		mk("new", "2026-09-05T23:13:00Z"),
+		mk("mid", "2026-08-04T21:20:00Z"),
+	}
+
+	sortSearchRowsByRecency(rows)
+
+	got := []string{rows[0].shortID, rows[1].shortID, rows[2].shortID}
+	want := []string{"new", "mid", "old"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestSortSearchRowsByRecency_StableOnTies(t *testing.T) {
+	ts := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	rows := []searchFzfRow{
+		{shortID: "first", sortTime: ts},
+		{shortID: "second", sortTime: ts},
+	}
+
+	sortSearchRowsByRecency(rows)
+
+	if rows[0].shortID != "first" || rows[1].shortID != "second" {
+		t.Fatalf("expected merge order preserved on ties, got %s,%s", rows[0].shortID, rows[1].shortID)
+	}
+}
+
+func TestMissionRecency_PrefersLastUserPrompt(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prompted := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
+
+	if got := missionRecency(&prompted, created); !got.Equal(prompted) {
+		t.Fatalf("expected last-prompt time, got %v", got)
+	}
+	if got := missionRecency(nil, created); !got.Equal(created) {
+		t.Fatalf("expected created-at fallback, got %v", got)
+	}
+}
+
+func TestRecencyFromStrings(t *testing.T) {
+	prompted := "2026-05-05T00:00:00Z"
+	created := "2026-01-01T00:00:00Z"
+
+	got := recencyFromStrings(&prompted, created)
+	if got.Format(time.RFC3339) != prompted {
+		t.Fatalf("expected %s, got %s", prompted, got.Format(time.RFC3339))
+	}
+
+	got = recencyFromStrings(nil, created)
+	if got.Format(time.RFC3339) != created {
+		t.Fatalf("expected %s, got %s", created, got.Format(time.RFC3339))
+	}
+
+	bad := "not-a-timestamp"
+	if got := recencyFromStrings(&bad, "also-bad"); !got.IsZero() {
+		t.Fatalf("expected zero time for unparseable input, got %v", got)
 	}
 }


### PR DESCRIPTION
## Problem

The mission picker (`mission attach`, and the palette entry bound to it) sorts its empty-query list by `COALESCE(last_user_prompt_at, created_at) DESC` via `sortMissionsForPicker`. The moment a query is typed, `mission search-fzf` takes over and emits rows in *merge* order instead — direct mission-ID hit first, then FTS results by rank, then the substring-match merge — with no re-sort.

The visible effect: the list is in date order, you type one character, and it reshuffles into an order with no meaning to the user. Screenshot of the old behaviour searching `ynab`, dates jumping 08-30 → 08-04 → 08-10 → 07-06 → 09-05 → 06-24 → 06-17.

## Fix

Carry the same recency key (`COALESCE(last_user_prompt_at, created_at)`) on each `searchFzfRow`, and sort the merged set before rendering. Two small helpers cover the two shapes the timestamp arrives in: `*time.Time` from `ListMissions`/`GetMission`, and RFC3339 strings from `SearchMissionsResponse` across JSON.

The sort is `SliceStable`, so rows sharing a timestamp keep their merge order (direct ID hit, then FTS rank, then substring). Unparseable timestamps fall back to the zero time and sort to the bottom rather than to the top.

Same query after the change, as `mission search-fzf` emits it:

```
c0e5b0f5  2026-09-05 23:26  YNAB and ING
348568e1  2026-08-30 13:09  Friction Reduction Ideas
75a00d6f  2026-08-10 13:27  July Spending Analysis
113d4217  2026-08-04 21:20  Business EUR Banking
94b42c6d  2026-07-06 17:35  June Revenue Retro
ccb53eff  2026-06-24 21:20  YNAB Review Automation
01f53e78  2026-06-17 13:04  April May Revenue
```

Note the picker renders that bottom-up: `runFzfSearchPicker` passes no `--layout`, so fzf's default puts the prompt at the bottom and grows the list upward, which lands the newest mission on the cursor and the oldest at the top of the screen. That is the same way the empty-query list has always rendered through the same code path, so the two are now consistent on screen as well as in the emitted order.

This deliberately leaves the empty-query ordering alone, including the `needs_attention` tier in `sortMissionsForPicker` — the change is only about the typed-query path matching the untyped one on the date tier.

## Testing

`make check` passes. Four unit tests in `cmd/mission_search_fzf_test.go` pin newest-first ordering, tie stability, the `COALESCE` preference, and the string-parsing path including the unparseable fallback.

No E2E test: the test environment cannot populate search rows, which is why `scripts/e2e-test.sh` already lists `mission search` as an explicit skip. Verified manually against a real database, which is where the before/after output above comes from.
