### PR TITLE
Sort mission search results by recency, with the direct ID match pinned on top

### DIFF
--- a/cmd/mission_search_fzf.go
+++ b/cmd/mission_search_fzf.go
@@ -44,6 +44,10 @@ type searchFzfRow struct {
 	// recency key the empty-query picker sorts on, so search results stay
 	// in the date order the user sees before typing.
 	sortTime time.Time
+	// isDirectIDMatch marks the row produced by resolving the query as a
+	// mission ID. It outranks recency: typing a mission's ID has to land the
+	// cursor on that mission, not on a newer one that merely mentions the ID.
+	isDirectIDMatch bool
 }
 
 func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
@@ -72,9 +76,10 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 			repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 			lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 			rows = append(rows, searchFzfRow{
-				shortID:  m.ShortID,
-				cols:     []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
-				sortTime: missionRecency(m.LastUserPromptAt, m.CreatedAt),
+				shortID:         m.ShortID,
+				cols:            []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+				sortTime:        missionRecency(m.LastUserPromptAt, m.CreatedAt),
+				isDirectIDMatch: true,
 			})
 			seenMissionIDs[m.ID] = true
 		}
@@ -127,7 +132,7 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	sortSearchRowsByRecency(rows)
+	sortSearchRows(rows)
 
 	// Render through tableprinter for alignment
 	var buf strings.Builder
@@ -214,13 +219,27 @@ func matchMissionSubstring(m *database.Mission, lowerQuery string) bool {
 	return false
 }
 
-// sortSearchRowsByRecency sorts search rows in-place, newest first, by
-// COALESCE(last_user_prompt_at, created_at) — matching the empty-query
-// picker's ordering so typing a query does not reshuffle the list into
-// FTS-rank order. The sort is stable, so rows sharing a timestamp keep the
-// order they were merged in (direct ID hit, then FTS rank, then substring).
-func sortSearchRowsByRecency(rows []searchFzfRow) {
+// sortSearchRows sorts search rows in-place using two tiers:
+//  1. The direct mission-ID match first, so typing a mission's ID lands the
+//     cursor on that mission rather than on a newer row that merely mentions
+//     the ID in its prompt, title, or indexed session content
+//  2. COALESCE(last_user_prompt_at, created_at) DESC — the same recency key
+//     the empty-query picker sorts on, so typing a query does not reshuffle
+//     the list into FTS-rank order
+//
+// The empty-query picker floats needs_attention missions above its date tier;
+// search rows cannot match that, because SearchMissionsResponse carries no
+// claude_state to tier on.
+//
+// The sort is stable, so rows sharing a tier and a timestamp keep the order
+// they were merged in (FTS rank, then substring).
+func sortSearchRows(rows []searchFzfRow) {
 	sort.SliceStable(rows, func(i, j int) bool {
+		// Tier 1: the direct mission-ID match
+		if rows[i].isDirectIDMatch != rows[j].isDirectIDMatch {
+			return rows[i].isDirectIDMatch
+		}
+		// Tier 2: COALESCE(last_user_prompt_at, created_at) DESC
 		return rows[i].sortTime.After(rows[j].sortTime)
 	})
 }

--- a/cmd/mission_search_fzf.go
+++ b/cmd/mission_search_fzf.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +40,10 @@ const substringMergeCap = 30
 type searchFzfRow struct {
 	shortID string
 	cols    []string
+	// sortTime is COALESCE(last_user_prompt_at, created_at) — the same
+	// recency key the empty-query picker sorts on, so search results stay
+	// in the date order the user sees before typing.
+	sortTime time.Time
 }
 
 func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
@@ -67,8 +72,9 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 			repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 			lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 			rows = append(rows, searchFzfRow{
-				shortID: m.ShortID,
-				cols:    []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+				shortID:  m.ShortID,
+				cols:     []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+				sortTime: missionRecency(m.LastUserPromptAt, m.CreatedAt),
 			})
 			seenMissionIDs[m.ID] = true
 		}
@@ -106,8 +112,9 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 		lastPrompt := formatLastPromptFromStrings(r.LastUserPromptAt, r.CreatedAt)
 
 		rows = append(rows, searchFzfRow{
-			shortID: shortID,
-			cols:    []string{shortID, attachedDotForPicker(r.IsAttached), lastPrompt, session, repo, snippet},
+			shortID:  shortID,
+			cols:     []string{shortID, attachedDotForPicker(r.IsAttached), lastPrompt, session, repo, snippet},
+			sortTime: recencyFromStrings(r.LastUserPromptAt, r.CreatedAt),
 		})
 	}
 
@@ -119,6 +126,8 @@ func runMissionSearchFzf(cmd *cobra.Command, args []string) error {
 	if len(rows) == 0 {
 		return nil
 	}
+
+	sortSearchRowsByRecency(rows)
 
 	// Render through tableprinter for alignment
 	var buf strings.Builder
@@ -180,8 +189,9 @@ func appendSubstringMatches(
 		repo := formatRepoDisplayForPicker(m.GitRepo, m.IsAdjutant, cfg)
 		lastPrompt := formatLastPrompt(m.LastUserPromptAt, m.CreatedAt)
 		rows = append(rows, searchFzfRow{
-			shortID: m.ShortID,
-			cols:    []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+			shortID:  m.ShortID,
+			cols:     []string{m.ShortID, attachedDotForPicker(m.IsAttached), lastPrompt, session, repo, ""},
+			sortTime: missionRecency(m.LastUserPromptAt, m.CreatedAt),
 		})
 	}
 	return rows
@@ -202,6 +212,38 @@ func matchMissionSubstring(m *database.Mission, lowerQuery string) bool {
 		return true
 	}
 	return false
+}
+
+// sortSearchRowsByRecency sorts search rows in-place, newest first, by
+// COALESCE(last_user_prompt_at, created_at) — matching the empty-query
+// picker's ordering so typing a query does not reshuffle the list into
+// FTS-rank order. The sort is stable, so rows sharing a timestamp keep the
+// order they were merged in (direct ID hit, then FTS rank, then substring).
+func sortSearchRowsByRecency(rows []searchFzfRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].sortTime.After(rows[j].sortTime)
+	})
+}
+
+// missionRecency returns COALESCE(lastUserPromptAt, createdAt).
+func missionRecency(lastUserPromptAt *time.Time, createdAt time.Time) time.Time {
+	if lastUserPromptAt != nil {
+		return *lastUserPromptAt
+	}
+	return createdAt
+}
+
+// recencyFromStrings is missionRecency over the RFC3339 timestamps that
+// SearchMissionsResponse carries across JSON. Unparseable values fall back to
+// the zero time, which sorts such rows to the bottom.
+func recencyFromStrings(lastUserPromptAt *string, createdAtRFC3339 string) time.Time {
+	if lastUserPromptAt != nil {
+		if t, err := time.Parse(time.RFC3339, *lastUserPromptAt); err == nil {
+			return t
+		}
+	}
+	createdAt, _ := time.Parse(time.RFC3339, createdAtRFC3339)
+	return createdAt
 }
 
 // formatLastPromptFromStrings parses the RFC3339 timestamps that

--- a/cmd/mission_search_fzf_test.go
+++ b/cmd/mission_search_fzf_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/odyssey/agenc/internal/database"
 )
@@ -42,5 +43,77 @@ func TestMatchMissionSubstring_EmptyFieldsDoNotFalseMatch(t *testing.T) {
 	m := &database.Mission{Prompt: "", GitRepo: ""}
 	if matchMissionSubstring(m, "anything") {
 		t.Fatal("empty fields should not match a non-empty query")
+	}
+}
+
+func TestSortSearchRowsByRecency_NewestFirst(t *testing.T) {
+	mk := func(id string, ts string) searchFzfRow {
+		t.Helper()
+		parsed, err := time.Parse(time.RFC3339, ts)
+		if err != nil {
+			t.Fatalf("bad test timestamp %q: %v", ts, err)
+		}
+		return searchFzfRow{shortID: id, sortTime: parsed}
+	}
+	rows := []searchFzfRow{
+		mk("old", "2026-06-17T13:04:00Z"),
+		mk("new", "2026-09-05T23:13:00Z"),
+		mk("mid", "2026-08-04T21:20:00Z"),
+	}
+
+	sortSearchRowsByRecency(rows)
+
+	got := []string{rows[0].shortID, rows[1].shortID, rows[2].shortID}
+	want := []string{"new", "mid", "old"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestSortSearchRowsByRecency_StableOnTies(t *testing.T) {
+	ts := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	rows := []searchFzfRow{
+		{shortID: "first", sortTime: ts},
+		{shortID: "second", sortTime: ts},
+	}
+
+	sortSearchRowsByRecency(rows)
+
+	if rows[0].shortID != "first" || rows[1].shortID != "second" {
+		t.Fatalf("expected merge order preserved on ties, got %s,%s", rows[0].shortID, rows[1].shortID)
+	}
+}
+
+func TestMissionRecency_PrefersLastUserPrompt(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prompted := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
+
+	if got := missionRecency(&prompted, created); !got.Equal(prompted) {
+		t.Fatalf("expected last-prompt time, got %v", got)
+	}
+	if got := missionRecency(nil, created); !got.Equal(created) {
+		t.Fatalf("expected created-at fallback, got %v", got)
+	}
+}
+
+func TestRecencyFromStrings(t *testing.T) {
+	prompted := "2026-05-05T00:00:00Z"
+	created := "2026-01-01T00:00:00Z"
+
+	got := recencyFromStrings(&prompted, created)
+	if got.Format(time.RFC3339) != prompted {
+		t.Fatalf("expected %s, got %s", prompted, got.Format(time.RFC3339))
+	}
+
+	got = recencyFromStrings(nil, created)
+	if got.Format(time.RFC3339) != created {
+		t.Fatalf("expected %s, got %s", created, got.Format(time.RFC3339))
+	}
+
+	bad := "not-a-timestamp"
+	if got := recencyFromStrings(&bad, "also-bad"); !got.IsZero() {
+		t.Fatalf("expected zero time for unparseable input, got %v", got)
 	}
 }

--- a/cmd/mission_search_fzf_test.go
+++ b/cmd/mission_search_fzf_test.go
@@ -46,7 +46,7 @@ func TestMatchMissionSubstring_EmptyFieldsDoNotFalseMatch(t *testing.T) {
 	}
 }
 
-func TestSortSearchRowsByRecency_NewestFirst(t *testing.T) {
+func TestSortSearchRows_NewestFirst(t *testing.T) {
 	mk := func(id string, ts string) searchFzfRow {
 		t.Helper()
 		parsed, err := time.Parse(time.RFC3339, ts)
@@ -61,7 +61,7 @@ func TestSortSearchRowsByRecency_NewestFirst(t *testing.T) {
 		mk("mid", "2026-08-04T21:20:00Z"),
 	}
 
-	sortSearchRowsByRecency(rows)
+	sortSearchRows(rows)
 
 	got := []string{rows[0].shortID, rows[1].shortID, rows[2].shortID}
 	want := []string{"new", "mid", "old"}
@@ -72,14 +72,14 @@ func TestSortSearchRowsByRecency_NewestFirst(t *testing.T) {
 	}
 }
 
-func TestSortSearchRowsByRecency_StableOnTies(t *testing.T) {
+func TestSortSearchRows_StableOnTies(t *testing.T) {
 	ts := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
 	rows := []searchFzfRow{
 		{shortID: "first", sortTime: ts},
 		{shortID: "second", sortTime: ts},
 	}
 
-	sortSearchRowsByRecency(rows)
+	sortSearchRows(rows)
 
 	if rows[0].shortID != "first" || rows[1].shortID != "second" {
 		t.Fatalf("expected merge order preserved on ties, got %s,%s", rows[0].shortID, rows[1].shortID)
@@ -115,5 +115,29 @@ func TestRecencyFromStrings(t *testing.T) {
 	bad := "not-a-timestamp"
 	if got := recencyFromStrings(&bad, "also-bad"); !got.IsZero() {
 		t.Fatalf("expected zero time for unparseable input, got %v", got)
+	}
+}
+
+// A search for an exact mission ID resolves that mission directly, but a newer
+// mission that merely mentions the ID in its prompt, title, or session content
+// matches the same query. Recency alone would hand fzf's cursor to the newer
+// row, so Enter would attach the wrong mission. The direct match is appended
+// first in production, so it is placed second here to prove the tier — not
+// merely the stability of the sort — is what puts it back on top.
+func TestSortSearchRows_DirectIDMatchOutranksNewerRow(t *testing.T) {
+	older := time.Date(2026, 6, 17, 13, 4, 0, 0, time.UTC)
+	newer := time.Date(2026, 9, 5, 23, 13, 0, 0, time.UTC)
+	rows := []searchFzfRow{
+		{shortID: "mentions-the-id", sortTime: newer},
+		{shortID: "exact-id-match", sortTime: older, isDirectIDMatch: true},
+	}
+
+	sortSearchRows(rows)
+
+	if rows[0].shortID != "exact-id-match" {
+		t.Fatalf("expected the direct ID match first, got %s", rows[0].shortID)
+	}
+	if rows[1].shortID != "mentions-the-id" {
+		t.Fatalf("expected the newer row second, got %s", rows[1].shortID)
 	}
 }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -574,6 +574,19 @@ fi
 run_test_no_crash "mission search-fzf empty query renders" \
     "${agenc_test}" mission search-fzf
 
+# Search-result ordering — newest first, with the direct mission-ID match
+# pinned above it — is pinned by unit tests only. Neither ordering path can be
+# made to differ here. The substring-merge path reads ListMissions, which
+# already returns newest-first, so a test over it passes whether or not the
+# sort runs. The FTS path needs indexed session content, and putting a second
+# row in front of a mission-ID query needs a session title, and both of those
+# need a live Claude session. Listed as a skip rather than a pass so the gap
+# stays visible — see agenc-t3fb.
+total=$((total + 1))
+printf "  %-50s " "search-fzf orders results newest-first..."
+echo "SKIP (cannot populate discriminating rows in the test environment)"
+skipped=$((skipped + 1))
+
 echo ""
 echo "--- LAST PROMPT column (requires server) ---"
 


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

This is @ro0mquy's #41 with a follow-up fix on top. The first commit is Yannik's, unchanged and under his authorship — finding and fixing the original problem is entirely his work. Opening this rather than asking him for another round, since we both just want the fix in.

## The original problem (#41)

The mission picker sorts its empty-query list by `COALESCE(last_user_prompt_at, created_at) DESC`. The moment a query was typed, `mission search-fzf` emitted rows in merge order instead — direct mission-ID hit, then FTS results by rank, then substring matches — so the list visibly reshuffled out of date order under the user's cursor. Yannik's commit carries the same recency key on every search row and sorts the merged set before rendering.

## What the follow-up fixes

Sorting every row by recency alone also demoted the row that comes from resolving the query *as* a mission ID. A newer mission that merely mentions that ID in its prompt or title — and AgenC missions reference each other by ID constantly — took fzf's cursor instead. Indexed session content is likely a third route to the same collision, though I only verified the first two. Enter then attached the wrong mission, with nothing signalling it.

Observed on identical data, searching the exact short ID `7d9e7838`:

```
#41 as-is:      0f80b9fb  follow-up to mission 7d9e7838   <- cursor lands here
                7d9e7838                                  (the mission actually searched for)

with this fix:  7d9e7838                                  <- cursor lands here
                0f80b9fb  follow-up to mission 7d9e7838
```

The fix makes the direct mission-ID match tier 1 and recency tier 2, mirroring the two-tier shape `sortMissionsForPicker` already uses for the empty-query list.

One gap carried over from #41 deliberately: the empty-query picker floats `needs_attention` missions above its date tier, and search rows still cannot. `SearchMissionsResponse` carries no `claude_state`, so closing that needs a new server-side field — out of scope here.

## Testing

`make check` and `make e2e` both pass (E2E: 175/179, 0 failed, 3 skipped).

Unit tests in `cmd/mission_search_fzf_test.go` pin newest-first ordering, tie stability, the `COALESCE` preference, the string-parsing path including the unparseable fallback, and the direct-ID tier outranking a newer row.

There is still no discriminating E2E test for the ordering, and #41 was right to leave it out — though for a narrower reason than "the test environment cannot populate search rows." The substring-merge path *can* be populated there, but it reads `ListMissions`, which already returns newest-first, so a test over it would pass whether or not the sort ran at all. The two paths that actually reorder need a live Claude session: FTS rows need indexed session content, and getting a second row in front of a mission-ID query needs a session title. That gap is now a visible SKIP in `scripts/e2e-test.sh` and a tracked issue (agenc-t3fb) rather than silence.

The before/after above comes from running both builds against the same database in a test environment.
