### PR TITLE
Run make check in CI and make the pre-commit hook self-activating

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,7 @@
             "Bash(rm -rf:*)",
             "Bash(sudo:*)",
             "Bash(git commit --no-verify:*)",
+            "Bash(git commit -n:*)",
             "Skill(agenc-engineer:*)"
         ]
     },
@@ -60,7 +61,9 @@
         },
         "network": {
             "allowLocalBinding": true,
-            "allowedDomains": ["vuln.go.dev"],
+            "allowedDomains": [
+                "vuln.go.dev"
+            ],
             "allowUnixSockets": [
                 "//tmp/claude",
                 "//private/tmp/claude",
@@ -94,4 +97,3 @@
         ]
     }
 }
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ concurrency:
 jobs:
   check:
     name: make check
-    runs-on: ubuntu-latest
+    # macOS, not Linux: this must be the same gate the pre-commit hook runs, and
+    # that hook runs on macOS. internal/launchd's tests also shell out to plutil,
+    # which only exists on macOS — AgenC's cron is launchd-based, so macOS is the
+    # real target rather than a convenience.
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# Runs the same quality gate as the pre-commit hook (`make check`), so a commit
+# that reached the repo with hooks bypassed or inactive is still caught here.
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+# Supersede in-flight runs for the same ref. Many agents push to the same branch
+# in quick succession; only the newest commit's result is interesting.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: make check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # `make check` invokes these by bare name, so they must be on PATH.
+      # Versions are pinned to match the ones documented in README.md.
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+
+      - name: Install deadcode
+        run: go install golang.org/x/tools/cmd/deadcode@v0.43.0
+
+      # The per-package coverage gate in `make check` shells out to bc.
+      - name: Verify bc is available
+        run: bc --version
+
+      - name: Run quality checks
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ endif
 
 LDFLAGS := -X $(VERSION_PKG).Version=$(VERSION)
 
+# The check target uses `set -o pipefail`, which dash does not support. Linux
+# defaults /bin/sh to dash, so pin recipes to bash for macOS/Linux parity.
+SHELL := /bin/bash
+
 TEST_ENV_DIR := _test-env
 BUILD_DIR    := _build
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ setup:
 		fi; \
 	fi
 
-check: genprime
+check: setup genprime
 	@echo "Checking module tidiness..."
 	@go mod tidy
 	@dirty=$$(git diff -- go.mod go.sum); \

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Local Development
 ### Install development tools
 
 ```bash
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.11.4
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 go install golang.org/x/tools/cmd/deadcode@v0.43.0
 ```
@@ -577,6 +577,20 @@ make check
 ```
 
 The pre-commit hook runs `make check` automatically on every commit, so you generally don't need to run this manually.
+
+The hook is activated by `make setup`, which `make check` and `make build` both
+depend on — so the first `make` you run in a fresh clone wires it up. If you have
+never run `make` in a clone, the hook is not yet active; run `make setup`.
+
+### Continuous integration
+
+`.github/workflows/ci.yml` runs `make check` on every push and pull request. It is
+the same gate as the pre-commit hook, so a commit that reached the repo with hooks
+bypassed or inactive still fails here.
+
+Local hooks stop honest mistakes; CI detects bypasses. Neither *prevents* a red
+commit from landing on `main` on its own — that requires a branch protection rule
+requiring the `make check` status check to pass before merge.
 
 ### E2E tests
 

--- a/README.md
+++ b/README.md
@@ -550,17 +550,21 @@ Local Development
 ### Prerequisites
 
 - **Go** (version specified in `go.mod`)
-- **golangci-lint**, **govulncheck**, and **deadcode** (see below)
+- **golangci-lint** and **deadcode** (see below)
 
 ### Install development tools
 
 ```bash
 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
-go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 go install golang.org/x/tools/cmd/deadcode@v0.43.0
 ```
 
-These are the same versions pinned in CI. `govulncheck` and `deadcode` are official Go team tools from the `golang.org/x/` extended repositories.
+These are the same versions pinned in CI. `deadcode` is an official Go team tool
+from the `golang.org/x/` extended repositories.
+
+`govulncheck` is not in that list because nothing in the build currently invokes
+it — it was dropped from `make check` in April 2026 and the docs did not follow.
+Wiring the vulnerability scan back up is tracked in `agenc-2x6f`.
 
 ### Build
 
@@ -568,7 +572,7 @@ These are the same versions pinned in CI. `govulncheck` and `deadcode` are offic
 make build
 ```
 
-This runs code generation, quality checks (formatting, vet, lint, vulnerability scan, dead code analysis, tests with race detection and coverage), and compiles the binary to `_build/agenc`.
+This runs code generation, quality checks (formatting, vet, lint, dead code analysis, tests with race detection and coverage), and compiles the binary to `_build/agenc`.
 
 ### Quality checks only
 


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Kevin asked for these branches to be verified to a standard where they can be merged without him reading the diff. This body is written for that reader: what changed, what was checked, how, and what was not.

## What this branch does

Makes it harder for an agent to commit against a red test suite, in four small pieces.

1. **`make check` now depends on `setup`.** `setup` sets `core.hooksPath` to `.githooks`, which is what activates the pre-commit hook. Previously only `make build` did this, so a fresh clone where someone only ever ran `make check` had no active hook.
2. **A CI workflow** (`.github/workflows/ci.yml`) running `make check` on macOS for every push and pull request — the same gate as the pre-commit hook, so a commit that reached the repo with hooks bypassed or inactive still fails somewhere.
3. **`Bash(git commit -n:*)` added to the deny list** in `.claude/settings.json`, the short form of the already-denied `--no-verify`.
4. **`SHELL := /bin/bash` in the Makefile**, and a README fix to the `golangci-lint` install path.

## Verification

Everything below was run against the branch. Guards were proven by defeating them, not by reading them.

**The red-suite block is real, in both directions.** A genuinely failing test was planted in an existing package. First the threat was established: with `core.hooksPath` unset, the red commit landed cleanly. Then with the hook active, the same commit was refused — and refused by the test failure itself, not by some other gate:

```
--- FAIL: TestReviewerPlantedRedTest
    redsuite_test.go:8: REVIEWER_PLANTED_FAILURE: this test fails on purpose
make: *** [check] Error 1
COMMIT_EXIT=1        HEAD before: 8cb5de3        HEAD after: 8cb5de3
```

Flipping the same test green let the commit through. All attempts ran with the sandbox disabled, so a sandbox denial could not have masqueraded as the guard firing.

**The hook self-activation is real and genuinely new.** In a clone with `core.hooksPath` unset, running `make check` set it to `.githooks`. `make -n check` on `main` contains no `git config` line at all; on this branch it contains two. Stronger: because `setup` is a prerequisite, even a *failing* `make check` repairs the hook first. This was also observed live while committing the README fix in this PR — `hooksPath before: []`, then `Git hooks configured (.githooks/)`, then `hooksPath after: [.githooks]`.

**`SHELL := /bin/bash` regresses nothing.** `make check`, `make build`, and `make e2e` all pass. The `$(shell ...)` version assignments at the top of the file are evaluated before the `SHELL` line and run under `/bin/sh`, but their commands are plain POSIX and the result is correct — `./_build/agenc version` prints the right short hash, not `unknown` or `-dirty`. Worth recording that on macOS `/bin/sh` *is* bash 3.2 and already supports `pipefail`, so this line is defensive for Linux only. Since CI now runs on macOS it is currently vestigial, but harmless.

**The README install path correction was needed.** Installed into a throwaway `GOBIN` so nothing on the machine's PATH was touched. The old path fails outright (`unknown revision cmd/golangci-lint/v2.11.4`); the new one installs `golangci-lint 2.11.4`.

**CI does real work, and has been observed failing for real reasons.** The green run on the branch HEAD shows every step succeeding with nothing skipped, all seven `make check` gate markers present, and 17 real coverage lines. Better, the two earlier runs on this branch failed for genuine and distinct reasons — a `dash`/`pipefail` failure on Ubuntu, then a real `internal/launchd` test failure on Ubuntu — each fixed by the next commit. The three commits are an evidence-driven convergence rather than a guess. The workflow installs everything `make check` needs, and *verifies* `bc` rather than assuming it, so a runner-image change would fail loudly.

**The prior decision to delete CI is not being blindly reversed.** A `ci.yml` existed before and was deleted in `3f90e26` to stop "No jobs were run" notification spam. The cause was traced: the preceding commit had commented out the entire file including the `on:` block, so GitHub registered zero-second failed runs on every push. The history confirms it — three `main` runs on 2026-05-03, each `failure` at `0s`. The new workflow has a live `on:` block and a real job, and all three of its runs did real work. It cannot reproduce the problem that got the old one deleted.

**Merge behaviour.** Merges cleanly onto `main`, and cleanly when stacked with the two other open branches. `make check` and `make e2e` are green on that combined three-way merge — 184 passed, 0 failed, 3 skipped — not only on this branch alone.

## Two things found while verifying

**The vulnerability scan silently fell out of `make check` five months ago.** `govulncheck` was removed from the Makefile on 2026-04-01 in commit `a5ff0f1` — three lines deleted inside a commit about refactoring the cron CLI, with no mention in the message. It reads as accidental, and nothing noticed, because a check that stops running emits no signal.

This surfaced *because* of this branch: it made the README's "these are the same versions pinned in CI" claim checkable for the first time, and the claim turned out to be false for `govulncheck`.

Measured today, `govulncheck ./...` **exits 3**: the code is affected by 5 standard-library vulnerabilities (fixed in go1.26.6, the toolchain is on go1.26.5) and 2 in imported packages (`golang.org/x/net@v0.53.0`, fixed in `v0.55.0`). Those accumulated behind the missing gate. So restoring the check here was deliberately **not** done — `make check` runs in the pre-commit hook, and a red `govulncheck` would immediately block every commit across every running mission. That is a call with a real cost and it is not one to make inside a verification pass. Filed as **`agenc-2x6f`** (P1) with the full evidence. This PR only corrects the README so it stops describing a scan that does not run.

**"Structurally impossible to commit against a red suite" does not hold.** Bypasses confirmed by hand: `git commit --no-verif` (git accepts the abbreviation; only the full `--no-verify` is denied), `git commit -m "msg" -n` (the denylist is prefix-based, so flag reordering evades it), `git -c core.hooksPath=/dev/null commit`, editing `.git/config` directly, and any clone where nobody has ever run `make`. The branch's own README says this squarely — *"Local hooks stop honest mistakes; CI detects bypasses. Neither prevents a red commit from landing on main on its own — that requires a branch protection rule."* That honesty is a point in its favour. **No branch protection rule was added** — that would break the standing workflow of agents pushing straight to `main`, and is Kevin's call, not a verifier's.

## Nits accepted rather than fixed

- **A push to a branch with an open PR produces two CI runs.** `push` and `pull_request` both fire, and their refs land in different concurrency groups so they do not dedupe each other. The repo is public, so macOS runner minutes are free and this is cost-free noise.
- **`make check` now silently overrides a non-default `core.hooksPath`.** A developer with a global hooks directory would have it overridden for this repo without being asked. Arguably correct for this repo.

## What was not verified

- **Whether `main` has a branch protection rule.** `gh api .../branches/main/protection` was denied by this session's permission layer. This matters, because the README's own caveat says branch protection is the thing that would actually *prevent* a red commit on `main`. The indirect evidence is that PR #43 reports `mergeStateStatus: CLEAN` with no required status checks, which is consistent with no rule — but that is inference, not the API answer.
- **Claude Code's permission matcher itself.** Which flag forms *git* accepts was probed empirically; that the matcher treats `Bash(git commit -n:*)` as a literal prefix is reasoned from documented semantics, not exercised.
- **The two-runs-per-push claim is analytic**, derived from the concurrency expression and the differing refs. Confirming it would require pushing to observe.
- **One `make e2e` run** was done with the pre-commit hook's beads section stubbed to a no-op, to avoid a hook writing to the live shared Dolt database during a scratch commit. The beads block is pre-existing and untouched here. Other `make e2e` runs used the real hook.
