### PR TITLE
Copy mission repos with APFS clones, with the copy path hardened (adopts #40)

### DIFF
--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -378,7 +378,7 @@ Repo library operations and resolution logic. Used by the server for repo API en
 Mission lifecycle: directory creation, repo copying, and Claude process spawning.
 
 - `mission.go` — `CreateMissionDir` (sets up mission directory, copies git repo), `BuildClaudeCmd`/`SpawnClaudeWithPrompt`/`SpawnClaudeResumeWithSession` (construct and start Claude `exec.Cmd` with 1Password integration and environment variables)
-- `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (rsync-based), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
+- `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (APFS copy-on-write clones via `cp -c` on macOS, falling back to `rsync -a`), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
 
 ### `internal/claudeconfig/`
 
@@ -666,7 +666,7 @@ Data Flow: Mission Lifecycle
 1. CLI ensures the server is running and a config source repo is registered
 2. Resolves the git repo reference (URL, shorthand, or fzf picker) and ensures it is cloned into the repo library
 3. Creates a database record — generates UUID + 8-char short ID, records the git repo name and optional cron association
-4. Creates the mission directory structure: copies the repo from the library via rsync
+4. Creates the mission directory structure: copies the repo from the library, as APFS copy-on-write clones on macOS and via rsync elsewhere
 5. Server-side, seeds the mission's agent-dir trust entry (`projects["<agentDir>"].hasTrustDialogAccepted=true`, plus the repo's `trustedMcpServers`) into the real `~/.claude.json` (or `$CLAUDE_CONFIG_DIR/.claude.json` when set) under a mutex, via atomic temp-file+rename with verify-retry — so the first Claude in the mission does not hit a blocking trust dialog (State Y; see "Trust seeding" under Key Architectural Patterns)
 6. Creates a `Wrapper` and calls `Run` or `RunHeadless` depending on flags
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -378,7 +378,7 @@ Repo library operations and resolution logic. Used by the server for repo API en
 Mission lifecycle: directory creation, repo copying, and Claude process spawning.
 
 - `mission.go` — `CreateMissionDir` (sets up mission directory, copies git repo), `BuildClaudeCmd`/`SpawnClaudeWithPrompt`/`SpawnClaudeResumeWithSession` (construct and start Claude `exec.Cmd` with 1Password integration and environment variables)
-- `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (APFS copy-on-write clones via `cp -c` on macOS, falling back to `rsync -a`), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
+- `repo.go` — git repository operations: `CopyRepo`/`CopyAgentDir` (APFS copy-on-write clones via `/bin/cp -c -p` on macOS, degrading per-file to plain copies on non-cloneable filesystems, with `rsync -a` running only when cp errors), `ForceUpdateRepo` (fetch + reset to remote default branch), `ParseRepoReference`/`ParseGitHubRemoteURL` (handle shorthand, canonical, SSH, and HTTPS URL formats), `EnsureRepoClone`, `DetectPreferredProtocol` (infers SSH vs HTTPS from existing repos)
 
 ### `internal/claudeconfig/`
 
@@ -666,7 +666,7 @@ Data Flow: Mission Lifecycle
 1. CLI ensures the server is running and a config source repo is registered
 2. Resolves the git repo reference (URL, shorthand, or fzf picker) and ensures it is cloned into the repo library
 3. Creates a database record — generates UUID + 8-char short ID, records the git repo name and optional cron association
-4. Creates the mission directory structure: copies the repo from the library, as APFS copy-on-write clones on macOS and via rsync elsewhere
+4. Creates the mission directory structure: copies the repo from the library — APFS copy-on-write clones on macOS (plain per-file copies on non-cloneable filesystems), with rsync used on other platforms or when cp errors
 5. Server-side, seeds the mission's agent-dir trust entry (`projects["<agentDir>"].hasTrustDialogAccepted=true`, plus the repo's `trustedMcpServers`) into the real `~/.claude.json` (or `$CLAUDE_CONFIG_DIR/.claude.json` when set) under a mutex, via atomic temp-file+rename with verify-retry — so the first Claude in the mission does not hit a blocking trust dialog (State Y; see "Trust seeding" under Key Architectural Patterns)
 6. Creates a `Wrapper` and calls `Run` or `RunHeadless` depending on flags
 

--- a/internal/mission/mission.go
+++ b/internal/mission/mission.go
@@ -1,6 +1,7 @@
 package mission
 
 import (
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,8 +19,10 @@ import (
 // The per-mission claude config directory is built by the wrapper on every
 // Claude spawn, so this function does not pre-build it.
 //
+// The logger receives copy-degradation warnings from CopyRepo.
+//
 // Returns the mission root directory path (not the agent/ subdirectory).
-func CreateMissionDir(agencDirpath string, missionID string, gitRepoName string, gitRepoSource string) (string, error) {
+func CreateMissionDir(logger *log.Logger, agencDirpath string, missionID string, gitRepoName string, gitRepoSource string) (string, error) {
 	missionDirpath := config.GetMissionDirpath(agencDirpath, missionID)
 	agentDirpath := config.GetMissionAgentDirpath(agencDirpath, missionID)
 
@@ -29,7 +32,7 @@ func CreateMissionDir(agencDirpath string, missionID string, gitRepoName string,
 
 	if gitRepoSource != "" {
 		// Copy the repo directly as agent/ (CopyRepo creates the destination)
-		if err := CopyRepo(gitRepoSource, agentDirpath); err != nil {
+		if err := CopyRepo(logger, gitRepoSource, agentDirpath); err != nil {
 			return "", stacktrace.Propagate(err, "failed to copy git repo into agent directory")
 		}
 	} else {

--- a/internal/mission/repo.go
+++ b/internal/mission/repo.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -122,44 +123,75 @@ func ValidateGitRepo(repoDirpath string) error {
 	return nil
 }
 
-// CopyRepo copies an entire git repository from srcRepoDirpath to
-// dstRepoDirpath using rsync. The destination receives a full independent
-// copy including the .git/ directory.
-func CopyRepo(srcRepoDirpath string, dstRepoDirpath string) error {
-	srcPath := srcRepoDirpath + "/"
-	dstPath := dstRepoDirpath + "/"
+// copyDirContents copies everything inside srcDirpath into dstDirpath, which
+// must already exist. The destination receives a full, independent copy —
+// including dotfiles, symlinks (copied as symlinks, never followed), modes and
+// mtimes.
+//
+// On macOS this runs `cp -c`, which uses clonefile(2) to make each file a
+// copy-on-write clone of its source. A clone is a complete, independent file:
+// writing to either side breaks sharing for the affected blocks only, so the
+// two copies can never alias each other. What it buys is that the copy is
+// near-instant and initially costs no additional disk. `cp -c` degrades on its
+// own — per cp(1), "if the source and target are on different filesystems, or
+// the target filesystem does not support cloning, cp will fallback to using
+// copyfile(2) instead to ensure the copy still succeeds" — so a non-APFS or
+// cross-volume $AGENC_DIRPATH still gets a correct copy.
+//
+// Everywhere else, and on any `cp` failure at all, this falls back to the
+// `rsync -a` that AgenC has always used, so mission creation is never blocked
+// by cloning being unavailable. A failed `cp` can only have written a subset of
+// the source, and rsync preserves size and mtime the same way cp does, so the
+// fallback rsync repairs a partial tree rather than being confused by it.
+func copyDirContents(srcDirpath string, dstDirpath string) error {
+	// Trailing slashes make both tools copy the CONTENTS of src into dst,
+	// rather than nesting src as a subdirectory of dst.
+	srcPath := srcDirpath + "/"
+	dstPath := dstDirpath + "/"
 
+	if runtime.GOOS == "darwin" {
+		cloneCmd := exec.Command("cp", "-c", "-R", srcPath, dstPath)
+		if _, err := cloneCmd.CombinedOutput(); err == nil {
+			return nil
+		}
+	}
+
+	rsyncCmd := exec.Command("rsync", "-a", srcPath, dstPath)
+	output, err := rsyncCmd.CombinedOutput()
+	if err != nil {
+		return stacktrace.Propagate(err, "rsync failed: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// CopyRepo copies an entire git repository from srcRepoDirpath to
+// dstRepoDirpath. The destination receives a full independent copy including
+// the .git/ directory.
+func CopyRepo(srcRepoDirpath string, dstRepoDirpath string) error {
 	if err := os.MkdirAll(dstRepoDirpath, 0755); err != nil {
 		return stacktrace.Propagate(err, "failed to create directory '%s'", dstRepoDirpath)
 	}
 
-	cmd := exec.Command("rsync", "-a", srcPath, dstPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to copy repo: %s", strings.TrimSpace(string(output)))
+	if err := copyDirContents(srcRepoDirpath, dstRepoDirpath); err != nil {
+		return stacktrace.Propagate(err, "failed to copy repo")
 	}
 	return nil
 }
 
 // CopyAgentDir copies an entire agent directory from srcAgentDirpath to
-// dstAgentDirpath using rsync. If the source directory does not exist,
-// this is a no-op (empty agent directory = nothing to copy).
+// dstAgentDirpath. If the source directory does not exist, this is a no-op
+// (empty agent directory = nothing to copy).
 func CopyAgentDir(srcAgentDirpath string, dstAgentDirpath string) error {
 	if _, err := os.Stat(srcAgentDirpath); os.IsNotExist(err) {
 		return nil
 	}
 
-	srcPath := srcAgentDirpath + "/"
-	dstPath := dstAgentDirpath + "/"
-
 	if err := os.MkdirAll(dstAgentDirpath, 0755); err != nil {
 		return stacktrace.Propagate(err, "failed to create directory '%s'", dstAgentDirpath)
 	}
 
-	cmd := exec.Command("rsync", "-a", srcPath, dstPath)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return stacktrace.Propagate(err, "failed to copy agent directory: %s", strings.TrimSpace(string(output)))
+	if err := copyDirContents(srcAgentDirpath, dstAgentDirpath); err != nil {
+		return stacktrace.Propagate(err, "failed to copy agent directory")
 	}
 	return nil
 }

--- a/internal/mission/repo.go
+++ b/internal/mission/repo.go
@@ -3,6 +3,7 @@ package mission
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,13 @@ const (
 	// gitOperationTimeout defines the maximum duration for any single git operation.
 	// This prevents indefinite hangs on network failures.
 	gitOperationTimeout = 30 * time.Second
+
+	// copyOperationTimeout caps each copy-tool invocation when copying a repo
+	// or agent directory into a mission. Sized for a multi-gigabyte rsync
+	// fallback copy — far above the git timeout, mirroring the server's
+	// clone-scale git timeout — while still preventing an indefinite hang on
+	// a stalled volume.
+	copyOperationTimeout = 10 * time.Minute
 )
 
 // IsRepoStale reports whether the repo's last fetch is older than maxAge.
@@ -124,39 +132,60 @@ func ValidateGitRepo(repoDirpath string) error {
 }
 
 // copyDirContents copies everything inside srcDirpath into dstDirpath, which
-// must already exist. The destination receives a full, independent copy —
-// including dotfiles, symlinks (copied as symlinks, never followed), modes and
-// mtimes.
+// must already exist and must not be nested inside srcDirpath. The destination
+// receives a full, independent copy — including dotfiles, symlinks (copied as
+// symlinks, never followed), modes and mtimes.
 //
-// On macOS this runs `cp -c`, which uses clonefile(2) to make each file a
-// copy-on-write clone of its source. A clone is a complete, independent file:
-// writing to either side breaks sharing for the affected blocks only, so the
-// two copies can never alias each other. What it buys is that the copy is
-// near-instant and initially costs no additional disk. `cp -c` degrades on its
-// own — per cp(1), "if the source and target are on different filesystems, or
-// the target filesystem does not support cloning, cp will fallback to using
-// copyfile(2) instead to ensure the copy still succeeds" — so a non-APFS or
-// cross-volume $AGENC_DIRPATH still gets a correct copy.
+// On macOS this runs /bin/cp -c -p -R, which uses clonefile(2) to make each
+// file a copy-on-write clone of its source. A clone is a complete, independent
+// file: writing to either side breaks sharing for the affected blocks only, so
+// the two copies can never alias each other. What it buys is that the copy is
+// near-instant and initially costs no additional disk. Two details of that
+// invocation are load-bearing:
 //
-// Everywhere else, and on any `cp` failure at all, this falls back to the
-// `rsync -a` that AgenC has always used, so mission creation is never blocked
-// by cloning being unavailable. A failed `cp` can only have written a subset of
-// the source, and rsync preserves size and mtime the same way cp does, so the
-// fallback rsync repairs a partial tree rather than being confused by it.
-func copyDirContents(srcDirpath string, dstDirpath string) error {
+//   - /bin/cp, not a PATH lookup: GNU coreutils cp (commonly ahead on PATH via
+//     Homebrew's gnubin) rejects -c, which would silently disable cloning on
+//     every copy forever.
+//   - -p: when the destination cannot clone (non-APFS filesystem, cross-volume
+//     target), cp degrades per-file to a plain copyfile(2) copy and still
+//     exits 0 — the rsync fallback below never sees this case. Without -p that
+//     degraded copy would arrive with fresh mtimes and default modes. -p also
+//     applies the source root's own mode to the destination root, matching
+//     what rsync -a does.
+//
+// On any cp error, this falls back to the `rsync -a` that AgenC has always
+// used — logging the cp failure first — so mission creation is never blocked by
+// cloning being unavailable. A partial cp tree is safe to repair with rsync:
+// its size+mtime quick-check either skips a file cp completed or re-copies it,
+// and re-copying is wasted work, not corruption.
+//
+// Known cp/rsync divergences accepted here (no occurrences in any AgenC copy
+// source today, and none producible by a git checkout): cp skips Unix sockets
+// while still exiting 0 where rsync recreates them; cp preserves xattrs and
+// BSD file flags where rsync strips them; and cp refuses to carry
+// setuid/setgid on regular files (a clonefile security property) where rsync
+// preserves them.
+func copyDirContents(logger *log.Logger, srcDirpath string, dstDirpath string) error {
 	// Trailing slashes make both tools copy the CONTENTS of src into dst,
 	// rather than nesting src as a subdirectory of dst.
 	srcPath := srcDirpath + "/"
 	dstPath := dstDirpath + "/"
 
 	if runtime.GOOS == "darwin" {
-		cloneCmd := exec.Command("cp", "-c", "-R", srcPath, dstPath)
-		if _, err := cloneCmd.CombinedOutput(); err == nil {
+		cloneCtx, cloneCancel := context.WithTimeout(context.Background(), copyOperationTimeout)
+		defer cloneCancel()
+		cloneCmd := exec.CommandContext(cloneCtx, "/bin/cp", "-c", "-p", "-R", srcPath, dstPath)
+		cloneOutput, cloneErr := cloneCmd.CombinedOutput()
+		if cloneErr == nil {
 			return nil
 		}
+		logger.Printf("Warning: clone-based copy of '%s' failed, falling back to rsync: %v: %s",
+			srcDirpath, cloneErr, strings.TrimSpace(string(cloneOutput)))
 	}
 
-	rsyncCmd := exec.Command("rsync", "-a", srcPath, dstPath)
+	rsyncCtx, rsyncCancel := context.WithTimeout(context.Background(), copyOperationTimeout)
+	defer rsyncCancel()
+	rsyncCmd := exec.CommandContext(rsyncCtx, "rsync", "-a", srcPath, dstPath)
 	output, err := rsyncCmd.CombinedOutput()
 	if err != nil {
 		return stacktrace.Propagate(err, "rsync failed: %s", strings.TrimSpace(string(output)))
@@ -167,12 +196,12 @@ func copyDirContents(srcDirpath string, dstDirpath string) error {
 // CopyRepo copies an entire git repository from srcRepoDirpath to
 // dstRepoDirpath. The destination receives a full independent copy including
 // the .git/ directory.
-func CopyRepo(srcRepoDirpath string, dstRepoDirpath string) error {
+func CopyRepo(logger *log.Logger, srcRepoDirpath string, dstRepoDirpath string) error {
 	if err := os.MkdirAll(dstRepoDirpath, 0755); err != nil {
 		return stacktrace.Propagate(err, "failed to create directory '%s'", dstRepoDirpath)
 	}
 
-	if err := copyDirContents(srcRepoDirpath, dstRepoDirpath); err != nil {
+	if err := copyDirContents(logger, srcRepoDirpath, dstRepoDirpath); err != nil {
 		return stacktrace.Propagate(err, "failed to copy repo")
 	}
 	return nil
@@ -181,7 +210,7 @@ func CopyRepo(srcRepoDirpath string, dstRepoDirpath string) error {
 // CopyAgentDir copies an entire agent directory from srcAgentDirpath to
 // dstAgentDirpath. If the source directory does not exist, this is a no-op
 // (empty agent directory = nothing to copy).
-func CopyAgentDir(srcAgentDirpath string, dstAgentDirpath string) error {
+func CopyAgentDir(logger *log.Logger, srcAgentDirpath string, dstAgentDirpath string) error {
 	if _, err := os.Stat(srcAgentDirpath); os.IsNotExist(err) {
 		return nil
 	}
@@ -190,7 +219,7 @@ func CopyAgentDir(srcAgentDirpath string, dstAgentDirpath string) error {
 		return stacktrace.Propagate(err, "failed to create directory '%s'", dstAgentDirpath)
 	}
 
-	if err := copyDirContents(srcAgentDirpath, dstAgentDirpath); err != nil {
+	if err := copyDirContents(logger, srcAgentDirpath, dstAgentDirpath); err != nil {
 		return stacktrace.Propagate(err, "failed to copy agent directory")
 	}
 	return nil

--- a/internal/mission/repo_test.go
+++ b/internal/mission/repo_test.go
@@ -308,3 +308,237 @@ func TestParseRepoReferenceWithDefaultOwner(t *testing.T) {
 		})
 	}
 }
+
+// writeCopySourceTree builds a source tree exercising the properties a repo
+// copy has to preserve: dotfiles and dot-directories (.git), nesting, a
+// symlink (which must be copied as a symlink, not followed), a dangling
+// symlink, a non-default file mode, and a non-current mtime.
+func writeCopySourceTree(t *testing.T, srcDirpath string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(srcDirpath, ".git", "objects"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcDirpath, "sub"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, ".git", "config"), []byte("[core]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, ".git", "objects", "obj"), []byte("object-bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, "sub", "nested.txt"), []byte("nested"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDirpath, "script.sh"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("script.sh", filepath.Join(srcDirpath, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("does-not-exist", filepath.Join(srcDirpath, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+
+	// A mtime well in the past, so "preserved" is distinguishable from
+	// "happened to be written at the same second as the copy".
+	past := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(filepath.Join(srcDirpath, "script.sh"), past, past); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// assertEntryMatches requires one source entry's destination counterpart to
+// have the same mode, and — by type — the same symlink target, or the same
+// content and mtime.
+func assertEntryMatches(t *testing.T, relPath string, srcPath string, dstPath string, srcInfo os.FileInfo) {
+	t.Helper()
+
+	dstInfo, err := os.Lstat(dstPath)
+	if err != nil {
+		t.Errorf("%s: missing from destination: %v", relPath, err)
+		return
+	}
+
+	if srcInfo.Mode() != dstInfo.Mode() {
+		t.Errorf("%s: mode = %v, want %v", relPath, dstInfo.Mode(), srcInfo.Mode())
+	}
+
+	if srcInfo.Mode()&os.ModeSymlink != 0 {
+		srcTarget, srcErr := os.Readlink(srcPath)
+		dstTarget, dstErr := os.Readlink(dstPath)
+		if srcErr != nil || dstErr != nil {
+			t.Errorf("%s: readlink failed: source %v, destination %v", relPath, srcErr, dstErr)
+			return
+		}
+		if srcTarget != dstTarget {
+			t.Errorf("%s: symlink target = %q, want %q", relPath, dstTarget, srcTarget)
+		}
+		return
+	}
+
+	// Directory mtimes shift as children are written into them, so content and
+	// mtime are asserted for regular files only.
+	if srcInfo.IsDir() {
+		return
+	}
+
+	srcContent, srcErr := os.ReadFile(srcPath)
+	dstContent, dstErr := os.ReadFile(dstPath)
+	if srcErr != nil || dstErr != nil {
+		t.Errorf("%s: read failed: source %v, destination %v", relPath, srcErr, dstErr)
+		return
+	}
+	if string(srcContent) != string(dstContent) {
+		t.Errorf("%s: content = %q, want %q", relPath, dstContent, srcContent)
+	}
+	if !srcInfo.ModTime().Equal(dstInfo.ModTime()) {
+		t.Errorf("%s: mtime = %v, want %v", relPath, dstInfo.ModTime(), srcInfo.ModTime())
+	}
+}
+
+// assertTreesMatch walks srcDirpath and requires dstDirpath to hold the same
+// relative paths with the same types, contents, modes, mtimes and symlink
+// targets — then requires dstDirpath to hold nothing extra.
+func assertTreesMatch(t *testing.T, srcDirpath string, dstDirpath string) {
+	t.Helper()
+
+	seen := map[string]bool{}
+	walkErr := filepath.Walk(srcDirpath, func(srcPath string, srcInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(srcDirpath, srcPath)
+		if err != nil {
+			return err
+		}
+		if relPath == "." {
+			return nil
+		}
+		seen[relPath] = true
+		assertEntryMatches(t, relPath, srcPath, filepath.Join(dstDirpath, relPath), srcInfo)
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking source tree failed: %v", walkErr)
+	}
+
+	// Positive control on the walk itself: a comparison that visited nothing
+	// would pass every assertion above.
+	if len(seen) == 0 {
+		t.Fatal("source tree was empty, so this comparison proved nothing")
+	}
+
+	extraErr := filepath.Walk(dstDirpath, func(dstPath string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(dstDirpath, dstPath)
+		if err != nil {
+			return err
+		}
+		if relPath != "." && !seen[relPath] {
+			t.Errorf("%s: present in destination but not in source", relPath)
+		}
+		return nil
+	})
+	if extraErr != nil {
+		t.Fatalf("walking destination tree failed: %v", extraErr)
+	}
+}
+
+func TestCopyRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+	writeCopySourceTree(t, srcDirpath)
+
+	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyRepo failed: %v", err)
+	}
+
+	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+func TestCopyRepo_CreatesMissingDestination(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "not", "yet", "there")
+	writeCopySourceTree(t, srcDirpath)
+
+	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyRepo failed: %v", err)
+	}
+
+	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+func TestCopyRepo_IndependentOfSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+	if err := os.MkdirAll(srcDirpath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	srcFilepath := filepath.Join(srcDirpath, "file.txt")
+	if err := os.WriteFile(srcFilepath, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyRepo failed: %v", err)
+	}
+
+	// Cloned files are copy-on-write, not shared: a write to either side must
+	// not be visible on the other.
+	dstFilepath := filepath.Join(dstDirpath, "file.txt")
+	if err := os.WriteFile(dstFilepath, []byte("changed in destination"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	srcContent, err := os.ReadFile(srcFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(srcContent) != "original" {
+		t.Errorf("writing the destination changed the source: got %q, want %q", srcContent, "original")
+	}
+
+	if err := os.WriteFile(srcFilepath, []byte("changed in source"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dstContent, err := os.ReadFile(dstFilepath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dstContent) != "changed in destination" {
+		t.Errorf("writing the source changed the destination: got %q, want %q", dstContent, "changed in destination")
+	}
+}
+
+func TestCopyAgentDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "src")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+	writeCopySourceTree(t, srcDirpath)
+
+	if err := CopyAgentDir(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyAgentDir failed: %v", err)
+	}
+
+	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+func TestCopyAgentDir_MissingSourceIsNoOp(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "does-not-exist")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+
+	if err := CopyAgentDir(srcDirpath, dstDirpath); err != nil {
+		t.Fatalf("CopyAgentDir failed: %v", err)
+	}
+
+	if _, err := os.Stat(dstDirpath); !os.IsNotExist(err) {
+		t.Errorf("expected destination not to be created, got err = %v", err)
+	}
+}

--- a/internal/mission/repo_test.go
+++ b/internal/mission/repo_test.go
@@ -1,12 +1,21 @@
 package mission
 
 import (
+	"bytes"
+	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
+
+// discardLogger satisfies the copy functions' logger parameter in tests, where
+// the fallback warning has no useful destination.
+var discardLogger = log.New(io.Discard, "", 0)
 
 func TestGetHEAD(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -341,11 +350,28 @@ func writeCopySourceTree(t *testing.T, srcDirpath string) {
 		t.Fatal(err)
 	}
 
-	// A mtime well in the past, so "preserved" is distinguishable from
-	// "happened to be written at the same second as the copy".
-	past := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
-	if err := os.Chtimes(filepath.Join(srcDirpath, "script.sh"), past, past); err != nil {
+	// A non-default mode on the source root itself, so the root-mode assertion
+	// in assertTreesMatch can tell "copied" apart from "MkdirAll's default".
+	if err := os.Chmod(srcDirpath, 0750); err != nil {
 		t.Fatal(err)
+	}
+
+	// Mtimes well in the past, so "preserved" is distinguishable from
+	// "happened to be written at the same second as the copy". Every regular
+	// file gets a whole-second timestamp: rsync -a truncates mtimes to whole
+	// seconds where cp preserves nanoseconds, so a sub-second fixture mtime
+	// would make the mtime assertions fail on whichever platforms take the
+	// rsync path.
+	past := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	for _, relFilepath := range []string{
+		filepath.Join(".git", "config"),
+		filepath.Join(".git", "objects", "obj"),
+		filepath.Join("sub", "nested.txt"),
+		"script.sh",
+	} {
+		if err := os.Chtimes(filepath.Join(srcDirpath, relFilepath), past, past); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -381,6 +407,12 @@ func assertEntryMatches(t *testing.T, relPath string, srcPath string, dstPath st
 	// Directory mtimes shift as children are written into them, so content and
 	// mtime are asserted for regular files only.
 	if srcInfo.IsDir() {
+		return
+	}
+
+	// Reading a special file would block (a FIFO's open(2) waits for a writer),
+	// so anything that is not a regular file stops at the mode comparison.
+	if !srcInfo.Mode().IsRegular() {
 		return
 	}
 
@@ -430,6 +462,21 @@ func assertTreesMatch(t *testing.T, srcDirpath string, dstDirpath string) {
 		t.Fatal("source tree was empty, so this comparison proved nothing")
 	}
 
+	// The walk above skips the roots themselves, but the destination root's
+	// mode must match the source root's whichever backend ran (rsync -a and
+	// cp -p both apply it to the destination root).
+	srcRootInfo, err := os.Lstat(srcDirpath)
+	if err != nil {
+		t.Fatalf("stat of source root failed: %v", err)
+	}
+	dstRootInfo, err := os.Lstat(dstDirpath)
+	if err != nil {
+		t.Fatalf("stat of destination root failed: %v", err)
+	}
+	if srcRootInfo.Mode().Perm() != dstRootInfo.Mode().Perm() {
+		t.Errorf("destination root mode = %v, want %v", dstRootInfo.Mode().Perm(), srcRootInfo.Mode().Perm())
+	}
+
 	extraErr := filepath.Walk(dstDirpath, func(dstPath string, _ os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -454,7 +501,7 @@ func TestCopyRepo(t *testing.T) {
 	dstDirpath := filepath.Join(tmpDir, "dst")
 	writeCopySourceTree(t, srcDirpath)
 
-	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+	if err := CopyRepo(discardLogger, srcDirpath, dstDirpath); err != nil {
 		t.Fatalf("CopyRepo failed: %v", err)
 	}
 
@@ -467,7 +514,7 @@ func TestCopyRepo_CreatesMissingDestination(t *testing.T) {
 	dstDirpath := filepath.Join(tmpDir, "not", "yet", "there")
 	writeCopySourceTree(t, srcDirpath)
 
-	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+	if err := CopyRepo(discardLogger, srcDirpath, dstDirpath); err != nil {
 		t.Fatalf("CopyRepo failed: %v", err)
 	}
 
@@ -486,7 +533,7 @@ func TestCopyRepo_IndependentOfSource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := CopyRepo(srcDirpath, dstDirpath); err != nil {
+	if err := CopyRepo(discardLogger, srcDirpath, dstDirpath); err != nil {
 		t.Fatalf("CopyRepo failed: %v", err)
 	}
 
@@ -522,11 +569,36 @@ func TestCopyAgentDir(t *testing.T) {
 	dstDirpath := filepath.Join(tmpDir, "dst")
 	writeCopySourceTree(t, srcDirpath)
 
-	if err := CopyAgentDir(srcDirpath, dstDirpath); err != nil {
+	if err := CopyAgentDir(discardLogger, srcDirpath, dstDirpath); err != nil {
 		t.Fatalf("CopyAgentDir failed: %v", err)
 	}
 
 	assertTreesMatch(t, srcDirpath, dstDirpath)
+}
+
+// TestCopyRepo_MissingSourceFailsLoudly pins the failure path: when the copy
+// cannot succeed at all, the returned error carries the rsync failure, and (on
+// macOS) the cp failure that preceded it is logged rather than swallowed.
+func TestCopyRepo_MissingSourceFailsLoudly(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDirpath := filepath.Join(tmpDir, "does-not-exist")
+	dstDirpath := filepath.Join(tmpDir, "dst")
+
+	var logBuffer bytes.Buffer
+	logger := log.New(&logBuffer, "", 0)
+
+	err := CopyRepo(logger, srcDirpath, dstDirpath)
+	if err == nil {
+		t.Fatal("expected CopyRepo of a nonexistent source to fail")
+	}
+	if !strings.Contains(err.Error(), "rsync") {
+		t.Errorf("error should carry the rsync failure, got: %v", err)
+	}
+	if runtime.GOOS == "darwin" {
+		if !strings.Contains(logBuffer.String(), "falling back to rsync") {
+			t.Errorf("cp failure should be logged before the rsync fallback, got log: %q", logBuffer.String())
+		}
+	}
 }
 
 func TestCopyAgentDir_MissingSourceIsNoOp(t *testing.T) {
@@ -534,7 +606,7 @@ func TestCopyAgentDir_MissingSourceIsNoOp(t *testing.T) {
 	srcDirpath := filepath.Join(tmpDir, "does-not-exist")
 	dstDirpath := filepath.Join(tmpDir, "dst")
 
-	if err := CopyAgentDir(srcDirpath, dstDirpath); err != nil {
+	if err := CopyAgentDir(discardLogger, srcDirpath, dstDirpath); err != nil {
 		t.Fatalf("CopyAgentDir failed: %v", err)
 	}
 

--- a/internal/server/missions.go
+++ b/internal/server/missions.go
@@ -497,7 +497,7 @@ func (s *Server) handleCreateMission(w http.ResponseWriter, r *http.Request) err
 	}
 
 	// Create mission directory structure
-	if _, err := mission.CreateMissionDir(s.agencDirpath, missionRecord.ID, gitRepoName, gitCloneDirpath); err != nil {
+	if _, err := mission.CreateMissionDir(s.logger, s.agencDirpath, missionRecord.ID, gitRepoName, gitCloneDirpath); err != nil {
 		return newHTTPErrorf(http.StatusInternalServerError, "failed to create mission directory: %s", err.Error())
 	}
 
@@ -647,13 +647,13 @@ func (s *Server) handleCreateClonedMission(w http.ResponseWriter, req CreateMiss
 	}
 
 	// Create empty mission dir structure, then copy agent dir from source
-	if _, err := mission.CreateMissionDir(s.agencDirpath, missionRecord.ID, "", ""); err != nil {
+	if _, err := mission.CreateMissionDir(s.logger, s.agencDirpath, missionRecord.ID, "", ""); err != nil {
 		return newHTTPErrorf(http.StatusInternalServerError, "failed to create mission directory: %s", err.Error())
 	}
 
 	srcAgentDirpath := config.GetMissionAgentDirpath(s.agencDirpath, sourceMission.ID)
 	dstAgentDirpath := config.GetMissionAgentDirpath(s.agencDirpath, missionRecord.ID)
-	if err := mission.CopyAgentDir(srcAgentDirpath, dstAgentDirpath); err != nil {
+	if err := mission.CopyAgentDir(s.logger, srcAgentDirpath, dstAgentDirpath); err != nil {
 		return newHTTPErrorf(http.StatusInternalServerError, "failed to copy agent directory: %s", err.Error())
 	}
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -472,6 +472,45 @@ run_test "repo rm cleans up description-test repo" \
     "${agenc_test}" repo rm github.com/mieubrisse/stacktrace
 
 echo ""
+echo "--- Repo-backed mission creation (requires server + network) ---"
+# Every other mission test uses --blank, which skips CopyRepo entirely — this
+# section is the only end-to-end coverage of the library-repo -> agent/ copy
+# path (APFS clones on macOS, rsync fallback).
+run_test "repo add for CopyRepo test" \
+    0 \
+    "${agenc_test}" repo add mieubrisse/stacktrace
+
+copy_mission_output=$("${agenc_test}" mission new mieubrisse/stacktrace --headless --no-focus 2>&1) || true
+copy_mission_short_id=$(echo "${copy_mission_output}" | grep -oE '[0-9a-f]{8}' | head -1)
+
+total=$((total + 1))
+printf "  %-50s " "repo-backed mission gets the full repo copy..."
+if [ -z "${copy_mission_short_id}" ]; then
+    echo "FAIL (could not create repo-backed mission)"
+    echo "    Output: ${copy_mission_output}" | head -5
+    failed=$((failed + 1))
+else
+    copy_mission_dirpath=$("${agenc_test}" mission inspect "${copy_mission_short_id}" --dir)
+    copy_agent_dirpath="${copy_mission_dirpath}/agent"
+    library_repo_dirpath="${repo_dirpath}/_test-env/repos/github.com/mieubrisse/stacktrace"
+    # Same HEAD commit resolvable in both places proves the .git directory
+    # arrived intact and complete, whichever copy backend ran.
+    library_head=$(git -C "${library_repo_dirpath}" rev-parse HEAD 2>/dev/null || echo "library-head-unreadable")
+    mission_head=$(git -C "${copy_agent_dirpath}" rev-parse HEAD 2>/dev/null || echo "mission-head-unreadable")
+    if [ "${library_head}" = "${mission_head}" ] && [ "${library_head}" != "library-head-unreadable" ]; then
+        echo "PASS"
+        passed=$((passed + 1))
+    else
+        echo "FAIL (library HEAD '${library_head}' vs mission HEAD '${mission_head}')"
+        failed=$((failed + 1))
+    fi
+fi
+
+run_test "repo rm cleans up CopyRepo-test repo" \
+    0 \
+    "${agenc_test}" repo rm github.com/mieubrisse/stacktrace
+
+echo ""
 echo "--- Mission commands (requires server) ---"
 run_test_no_crash "mission ls does not crash" \
     "${agenc_test}" mission ls


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

This is @ro0mquy's #40 with a hardening commit on top. The first commit is Yannik's, unchanged and under his authorship — the measurement, the clonefile approach, and the test suite are all his work. Opening this rather than asking him for another round, since we both just want the fix in.

## The original change (#40)

`CopyRepo`/`CopyAgentDir` switch from `rsync -a` to APFS copy-on-write clones (`cp -c`), with rsync as the fallback. Before touching anything I reproduced the headline: on a 1.4 GB library repo, 0.29 s cloned vs 7.37 s rsync'd (~25×). The isolation story checks out empirically too — clones get their own inodes, writes on either side never cross, deleting the source leaves the clone intact, and `git fsck --strict` is clean inside a clone before and after mutating its source. Yannik's PR body is right that this is not "tricky hardlinking stuff."

## What the follow-up commit fixes

Everything below came out of an adversarial multi-agent review of the branch, findings probe-verified on a real machine:

1. **`/bin/cp` instead of a PATH lookup.** GNU coreutils `cp` rejects `-c` ("invalid option"), and Homebrew's gnubin commonly sits ahead on PATH (this machine has coreutils 9.9 installed). A daemon inheriting that PATH would fail the clone attempt on every copy — silently, forever.
2. **`-p` added.** On a destination that can't clone (non-APFS, cross-volume), cp degrades per-file to copyfile(2) and still exits 0 — the rsync fallback never sees this case. Without `-p` that degraded tree arrives with fresh mtimes and a default destination-root mode: with `TMPDIR` pointed at a mounted HFS+ image, 3 of the branch's own tests fail. With `-p` they pass, and cloning on APFS stays instant (0.34 s on the same 1.4 GB repo).
3. **Whole-second fixture mtimes.** rsync -a truncates mtimes to whole seconds where clonefile preserves nanoseconds (probed: `...123456789` → `...000000000`). Only one fixture file was pinned to a whole second, so the new tests failed deterministically wherever the rsync path actually runs — including any Linux `go test`. Every fixture file is now pinned.
4. **The cp→rsync fallback logs.** cp's error and stderr were discarded, so a systematic cp failure would cost the full rsync price on every mission creation with zero signal. The server's logger now threads through `CreateMissionDir`/`CopyRepo`/`CopyAgentDir` (every call site lives in the server, which already owns one), and a new test pins the whole chain: cp fails → warning logged → rsync runs → the both-fail error carries the rsync detail.
5. **Timeouts.** Both invocations now use `exec.CommandContext` with a 10-minute cap — matching this file's own convention (every git call in it is context-capped) and sized for multi-gigabyte fallback copies.
6. **Destination root mode asserted.** rsync -a applies the source root's mode to the destination root; bare `cp` left `MkdirAll`'s 0755, so a restrictively-permissioned library clone would silently widen. `-p` restores parity (probed), and `assertTreesMatch` now asserts root modes match, with a 0750 fixture root so "copied" is distinguishable from "MkdirAll default".
7. **Test-helper FIFO guard.** `assertEntryMatches` ReadFiles every non-dir, non-symlink entry; a FIFO fixture would block open(2) forever and hang the suite (and the pre-commit hook) to the go-test timeout. Non-regular files now stop at the mode comparison.
8. **Docs made consistent.** The two rewritten architecture-doc lines described different fallback semantics (error-triggered vs platform-selected), and neither mentioned the exit-0 copyfile degradation. Both now say the same, true thing.
9. **E2E coverage.** Repo CLAUDE.md mandates E2E for behavioral changes, and every existing mission test uses `--blank`, which never reaches `CopyRepo`. New section: adds a repo, creates a repo-backed headless mission, and asserts the same HEAD commit resolves in both the library clone and the mission's agent dir. Yannik was right that nothing existing covered this — this is the test he offered to write.

## Accepted divergences, documented rather than fixed

cp and rsync genuinely differ on: Unix sockets (cp skips them while exiting 0), BSD file flags and xattrs (cp preserves both, rsync strips them — includes `uchg` and `com.apple.quarantine`), and setuid/setgid on regular files (clonefile refuses to carry them, by design). None occur in any AgenC copy source today and none are producible by a git checkout. They're documented in `copyDirContents`'s comment, with dispositions tracked in beads `agenc-rmeo` (divergence handling) and `agenc-vlum` (making both backends testable on one machine — today macOS tests can only ever exercise the cp branch).

## Verification

- `make check` green; `make e2e` 178/181, 0 failed, 2 pre-existing environment skips — including the new CopyRepo E2E case.
- Unit tests pass with `-race` on APFS (clone path) and with `TMPDIR` on a mounted HFS+ image (copyfile-degradation path).
- The rsync branch runs on no macOS machine by design, and CI is macOS-only — its mtime fix is derived from the truncation probe rather than a green Linux run. Tracked in `agenc-vlum`.

Merging with a merge commit makes Yannik's 2528286 reachable from main, so GitHub should mark #40 merged automatically.