### PR TITLE
Count every e2e SKIP in the skipped tally, and fail loudly on counter drift

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -671,6 +671,7 @@ else
     total=$((total + 1))
     printf "  %-50s " "search-fzf finds mission by short ID..."
     echo "SKIP (could not create test mission)"
+    skipped=$((skipped + 1))
 fi
 
 # Regression: the attach picker reload command (search-fzf) still renders rows
@@ -1164,6 +1165,7 @@ PY
         # Environment could not launch Claude (no binary/token, or run failed).
         # Visible named skip — never a silent green.
         echo "SKIP: --settings union firing check — Claude did not launch in this env"
+        skipped=$((skipped + 1))
     else
         echo "FAIL (union did not fire: user_sentinel=$([ -f "${statey_union_user_sentinel}" ] && echo yes || echo no), settings_sentinel=$([ -f "${statey_union_settings_sentinel}" ] && echo yes || echo no))"
         failed=$((failed + 1))
@@ -1500,7 +1502,7 @@ else
     total=$((total + 1))
     printf "  %-50s " "FD count stays under 1000 (agenc-ku7h)"
     echo "SKIP (server PID file not found at ${server_pid_file})"
-    passed=$((passed + 1)) # skip counts as pass — no server means no regression
+    skipped=$((skipped + 1))
 fi
 
 # Clean up the writeable-copy config entry and the synthetic dir.
@@ -1537,7 +1539,7 @@ if [ -z "${detach_mission_pane}" ]; then
     total=$((total + 1))
     printf "  %-50s " "detach unlinks a window in another session..."
     echo "SKIP (could not create a mission with a tmux pane)"
-    passed=$((passed + 1))
+    skipped=$((skipped + 1))
 else
     detach_pool_session="agenc-${detach_namespace}-pool"
     detach_host_session="agenc-${detach_namespace}-e2e-host"
@@ -1940,6 +1942,18 @@ else
     echo "  E2E Results: ${passed}/${total} passed, ${failed} failed"
 fi
 echo "=========================================="
+
+# Counter coherence: every test that incremented 'total' must land in exactly
+# one outcome bucket. A SKIP (or any outcome) path that forgets its counter
+# silently inflates the denominator — the exact bug behind bead agenc-uhie —
+# so bookkeeping drift fails the suite loudly instead.
+accounted=$((passed + failed + skipped))
+if [ "${accounted}" -ne "${total}" ]; then
+    echo ""
+    echo "COUNTER BUG: ${passed} passed + ${failed} failed + ${skipped} skipped = ${accounted}, but total is ${total}."
+    echo "Some test path updated 'total' without updating exactly one outcome counter (or vice versa)."
+    exit 1
+fi
 
 if [ "${failed}" -gt 0 ]; then
     exit 1


### PR DESCRIPTION
(This post authored by my [AgenC](https://github.com/mieubrisse/agenc))

Kevin spotted that the e2e summary's buckets didn't sum: `178/181 passed, 0 failed, 2 skipped` — 178+0+2 = 180, one test unaccounted for. (Bead `agenc-uhie`.)

## The bug

The suite had eight code paths that print a SKIP outcome, in three inconsistent states:

- **Four** incremented `skipped` correctly.
- **Two** incremented nothing at all (the search-fzf could-not-create-mission skip and the State-Y `--settings` union check's Claude-didn't-launch skip) — these inflate `total` without landing in any bucket, which is the arithmetic gap Kevin saw. The State-Y one fired in the observed run.
- **Two** incremented `passed`, with a "skip counts as pass" comment (the FD-count and detach-across-sessions environment skips) — the sum stayed coherent, but a skip reported itself as a pass.

## The fix

Every SKIP path now increments `skipped` and nothing else — a skip is a skip. And because this bug was invisible precisely when no one re-added the arithmetic by hand, the summary now carries its own check-loop: if `passed + failed + skipped != total`, the suite prints a COUNTER BUG line naming the tallies and exits 1, so any future path that forgets its counter fails the run instead of quietly inflating the denominator.

## Verification

- Full `make e2e` on this branch: `190/194 passed, 0 failed, 4 skipped` — 190+0+4 = 194, exact.
- The coherence check was mutation-tested in isolation: fed a deliberately mismatched tally (3+0+1 vs total 5), it prints the COUNTER BUG line and exits 1.
- `bash -n` clean; every one of the eight SKIP echo sites verified to have an adjacent `skipped` increment.

Two skips that previously self-reported as passes now report as skips, so the passed count drops by up to 2 in environments where those fire — that's the honest number.