### PR TITLE
Reach every transcript a session writes: subagents, workflow runs, forks and compactions

### DIFF
--- a/cmd/command_str_consts.go
+++ b/cmd/command_str_consts.go
@@ -119,8 +119,13 @@ const (
 	dirFlagName = "dir"
 
 	// session/mission print flags
-	tailFlagName   = "tail"
-	formatFlagName = "format"
+	tailFlagName         = "tail"
+	formatFlagName       = "format"
+	agentsFlagName       = "agents"
+	agentFlagName        = "agent"
+	expandAgentsFlagName = "expand-agents"
+	verboseFlagName      = "verbose"
+	sessionFlagName      = "session"
 
 	// mission nuke flags
 	forceFlagName = "force"

--- a/cmd/flag_suggest.go
+++ b/cmd/flag_suggest.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// An unknown flag is the most common wrong invocation an agent makes, and
+// "unknown flag: --subagents" teaches nothing. When the misspelling is close to
+// a flag the command actually has, the error names it.
+
+// maxFlagSuggestionDistance bounds how far a typo may be from a real flag
+// before no suggestion is offered; beyond it, guessing misleads.
+const maxFlagSuggestionDistance = 3
+
+func init() {
+	rootCmd.SetFlagErrorFunc(suggestFlagOnError)
+}
+
+// suggestFlagOnError appends "(did you mean --x?)" to an unknown-flag error
+// when one of the command's flags is within editing distance, or shares the
+// typed prefix. Other flag errors pass through unchanged.
+func suggestFlagOnError(cmd *cobra.Command, err error) error {
+	const prefix = "unknown flag: --"
+	msg := err.Error()
+	if !strings.HasPrefix(msg, prefix) {
+		return err
+	}
+	typed := strings.SplitN(strings.TrimPrefix(msg, prefix), " ", 2)[0]
+	typed = strings.SplitN(typed, "=", 2)[0]
+	if best := closestFlagName(cmd, typed); best != "" {
+		return fmt.Errorf("%s (did you mean --%s?)", msg, best)
+	}
+	return err
+}
+
+// closestFlagName returns the command's flag nearest to typed, or "" when
+// nothing is close enough.
+func closestFlagName(cmd *cobra.Command, typed string) string {
+	best, bestDistance := "", maxFlagSuggestionDistance+1
+	consider := func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		d := editDistance(strings.ToLower(typed), f.Name)
+		if strings.HasPrefix(f.Name, strings.ToLower(typed)) || strings.HasPrefix(strings.ToLower(typed), f.Name) {
+			d = 1
+		}
+		if d < bestDistance || (d == bestDistance && f.Name < best) {
+			best, bestDistance = f.Name, d
+		}
+	}
+	cmd.Flags().VisitAll(consider)
+	cmd.InheritedFlags().VisitAll(consider)
+	if bestDistance > maxFlagSuggestionDistance {
+		return ""
+	}
+	return best
+}
+
+// editDistance is the Levenshtein distance between two strings.
+func editDistance(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	cur := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		cur[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			cur[j] = min(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(rb)]
+}

--- a/cmd/flag_suggest.go
+++ b/cmd/flag_suggest.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,9 +13,10 @@ import (
 // "unknown flag: --subagents" teaches nothing. When the misspelling is close to
 // a flag the command actually has, the error names it.
 
-// maxFlagSuggestionDistance bounds how far a typo may be from a real flag
-// before no suggestion is offered; beyond it, guessing misleads.
-const maxFlagSuggestionDistance = 3
+// minAffixLength is the shortest typed or real flag name the containment
+// rules consider: "--a" is not evidence for anything, and "--subagents"
+// contains "agents" only meaningfully because both are words.
+const minAffixLength = 4
 
 func init() {
 	rootCmd.SetFlagErrorFunc(suggestFlagOnError)
@@ -38,47 +40,84 @@ func suggestFlagOnError(cmd *cobra.Command, err error) error {
 }
 
 // closestFlagName returns the command's flag nearest to typed, or "" when
-// nothing is close enough.
+// nothing is close enough. Three rules, in priority order, each with a floor
+// that keeps it from firing on noise:
+//
+//   - a typo: edit distance (adjacent transposition counts one) within a
+//     quarter of the typed length, at least one — so "--sicne" reaches
+//     "--since", while "--tail" on a command that has "--all" (distance 2 on
+//     four letters) reaches nothing, because that flag belongs elsewhere;
+//   - a real name inside what was typed ("--subagents" holds "agents"), the
+//     longest such name winning;
+//   - what was typed inside a real name ("--expand" is in "--expand-agents"),
+//     the shortest such name winning.
 func closestFlagName(cmd *cobra.Command, typed string) string {
-	best, bestDistance := "", maxFlagSuggestionDistance+1
-	consider := func(f *pflag.Flag) {
-		if f.Hidden {
-			return
-		}
-		d := editDistance(strings.ToLower(typed), f.Name)
-		if strings.HasPrefix(f.Name, strings.ToLower(typed)) || strings.HasPrefix(strings.ToLower(typed), f.Name) {
-			d = 1
-		}
-		if d < bestDistance || (d == bestDistance && f.Name < best) {
-			best, bestDistance = f.Name, d
+	typed = strings.ToLower(typed)
+	var names []string
+	collect := func(f *pflag.Flag) {
+		if !f.Hidden {
+			names = append(names, f.Name)
 		}
 	}
-	cmd.Flags().VisitAll(consider)
-	cmd.InheritedFlags().VisitAll(consider)
-	if bestDistance > maxFlagSuggestionDistance {
-		return ""
+	cmd.Flags().VisitAll(collect)
+	cmd.InheritedFlags().VisitAll(collect)
+	sort.Strings(names)
+
+	allowed := len(typed) / 4
+	if allowed < 1 {
+		allowed = 1
+	}
+	best, bestDistance := "", allowed+1
+	for _, name := range names {
+		if d := editDistance(typed, name); d < bestDistance {
+			best, bestDistance = name, d
+		}
+	}
+	if best != "" {
+		return best
+	}
+	if len(typed) >= minAffixLength {
+		for _, name := range names {
+			if len(name) >= minAffixLength && strings.Contains(typed, name) && len(name) > len(best) {
+				best = name
+			}
+		}
+		if best != "" {
+			return best
+		}
+		for _, name := range names {
+			if strings.Contains(name, typed) && (best == "" || len(name) < len(best)) {
+				best = name
+			}
+		}
 	}
 	return best
 }
 
-// editDistance is the Levenshtein distance between two strings.
+// editDistance is the optimal string alignment distance: Levenshtein with an
+// adjacent transposition counted as one edit, so "sicne" is one step from
+// "since" rather than two.
 func editDistance(a, b string) int {
 	ra, rb := []rune(a), []rune(b)
-	prev := make([]int, len(rb)+1)
-	cur := make([]int, len(rb)+1)
-	for j := range prev {
-		prev[j] = j
+	d := make([][]int, len(ra)+1)
+	for i := range d {
+		d[i] = make([]int, len(rb)+1)
+		d[i][0] = i
+	}
+	for j := range d[0] {
+		d[0][j] = j
 	}
 	for i := 1; i <= len(ra); i++ {
-		cur[0] = i
 		for j := 1; j <= len(rb); j++ {
 			cost := 1
 			if ra[i-1] == rb[j-1] {
 				cost = 0
 			}
-			cur[j] = min(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+			d[i][j] = min(d[i-1][j]+1, d[i][j-1]+1, d[i-1][j-1]+cost)
+			if i > 1 && j > 1 && ra[i-1] == rb[j-2] && ra[i-2] == rb[j-1] {
+				d[i][j] = min(d[i][j], d[i-2][j-2]+1)
+			}
 		}
-		prev, cur = cur, prev
 	}
-	return prev[len(rb)]
+	return d[len(ra)][len(rb)]
 }

--- a/cmd/mission_print.go
+++ b/cmd/mission_print.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/mieubrisse/stacktrace"
@@ -12,8 +16,8 @@ import (
 	"github.com/odyssey/agenc/internal/session"
 )
 
-var missionPrintTailFlag int
-var missionPrintFormatFlag string
+var missionPrintOpts transcriptPrintOptions
+var missionPrintSessionFlag string
 
 var missionPrintCmd = &cobra.Command{
 	Use:   printCmdStr + " [mission-id]",
@@ -24,6 +28,16 @@ By default, outputs the entire session as human-readable text.
 Use --format=jsonl for raw JSONL output.
 Use --tail to limit output to the last N lines.
 
+A mission accumulates a session per reload, /clear or fork; this prints the most
+recently active one. Use --session to print a different one, and
+'agenc session ls --mission <id>' to list them.
+
+A session is not a single transcript either: every subagent it spawns writes its
+own. --agents lists that tree, --agent prints one subagent's transcript, and
+--expand-agents inlines them all at their spawn sites. --verbose additionally
+renders hooks, turn timings, attachments, thinking blocks and successful tool
+results.
+
 Without arguments, opens an interactive fzf picker to select a mission.
 With arguments, accepts a mission ID (short 8-char hex or full UUID).
 
@@ -31,20 +45,34 @@ Example:
   agenc mission print
   agenc mission print 2571d5d8
   agenc mission print 2571d5d8 --format=jsonl
-  agenc mission print 2571d5d8 --tail 50`,
+  agenc mission print 2571d5d8 --tail 50
+  agenc mission print 2571d5d8 --agents
+  agenc mission print 2571d5d8 --agent aa8d6202
+  agenc mission print 2571d5d8 --expand-agents
+  agenc mission print 2571d5d8 --session 18749fb5`,
 	Args: cobra.ArbitraryArgs,
 	RunE: runMissionPrint,
 }
 
 func init() {
-	missionPrintCmd.Flags().IntVar(&missionPrintTailFlag, tailFlagName, 0, "limit output to last N lines")
-	missionPrintCmd.Flags().StringVar(&missionPrintFormatFlag, formatFlagName, "text", "output format: text or jsonl")
+	missionPrintCmd.Flags().IntVar(&missionPrintOpts.tailLines, tailFlagName, 0, "limit output to last N lines")
+	missionPrintCmd.Flags().StringVar(&missionPrintOpts.format, formatFlagName, textFormat, "output format: text or jsonl")
+	missionPrintCmd.Flags().StringVar(&missionPrintSessionFlag, sessionFlagName, "", "print a specific session of the mission, by session ID or short ID")
+	registerTranscriptPrintFlags(missionPrintCmd, &missionPrintOpts)
 	missionCmd.AddCommand(missionPrintCmd)
 }
 
 func runMissionPrint(cmd *cobra.Command, args []string) error {
-	if missionPrintTailFlag < 0 {
-		return stacktrace.NewError("--tail value must be positive")
+	if missionPrintOpts.tailLines < 0 {
+		return stacktrace.NewError("--%s value must be positive", tailFlagName)
+	}
+	missionPrintOpts.all = missionPrintOpts.tailLines == 0
+
+	// Validate before touching the server so an unusable flag combination is
+	// reported as itself, rather than as whatever the mission lookup happens
+	// to fail with first.
+	if err := missionPrintOpts.validate(); err != nil {
+		return err
 	}
 
 	client, err := serverClient()
@@ -99,11 +127,6 @@ func runMissionPrint(cmd *cobra.Command, args []string) error {
 
 	missionID := result.Items[0].MissionID
 
-	// Locate the mission's active session JSONL. Use FindActiveJSONLPath
-	// rather than GetLastSessionID so that a freshly-spawned mission whose
-	// session contains only metadata entries (and would be filtered out by
-	// the conversation-data check in ListSessionIDs) is still printable —
-	// printSession reports an empty-session message in that case.
 	agencDirpath, err := config.GetAgencDirpath()
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to get agenc directory path")
@@ -112,10 +135,69 @@ func runMissionPrint(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return stacktrace.Propagate(err, "failed to get project directory for mission %s", missionID)
 	}
-	jsonlFilepath := session.FindActiveJSONLPath(projectDirpath)
-	if jsonlFilepath == "" {
-		return stacktrace.NewError("no current session found for mission %s", missionID)
+
+	jsonlFilepath, err := resolveMissionSessionJSONL(client, projectDirpath, missionID, missionPrintSessionFlag)
+	if err != nil {
+		return err
 	}
 
-	return printSession(jsonlFilepath, missionPrintTailFlag, missionPrintTailFlag == 0, missionPrintFormatFlag)
+	warnOnUnprintedSessions(projectDirpath, jsonlFilepath, missionPrintSessionFlag, os.Stderr)
+
+	return printTranscript(jsonlFilepath, missionPrintOpts)
+}
+
+// sessionIDResolver is the slice of the server client that session selection
+// needs: turning a short session ID into a full UUID. Narrowing it to an
+// interface keeps the selection logic testable without a live server.
+type sessionIDResolver interface {
+	ResolveSessionID(id string) (string, error)
+}
+
+// resolveMissionSessionJSONL picks which of a mission's session transcripts to
+// print. Without --session it takes the most recently modified one.
+//
+// It deliberately uses the newest JSONL on disk rather than the mission's last
+// recorded session ID: a freshly-spawned mission's transcript contains only
+// metadata entries and is filtered out of the session listing, and printing it
+// with an explanatory empty-session message beats reporting that no session
+// exists.
+func resolveMissionSessionJSONL(client sessionIDResolver, projectDirpath string, missionID string, sessionFlag string) (string, error) {
+	if sessionFlag == "" {
+		jsonlFilepath := session.FindActiveJSONLPath(projectDirpath)
+		if jsonlFilepath == "" {
+			return "", stacktrace.NewError("no current session found for mission %s", missionID)
+		}
+		return jsonlFilepath, nil
+	}
+
+	resolvedID, err := client.ResolveSessionID(sessionFlag)
+	if err != nil {
+		return "", stacktrace.Propagate(err, "failed to resolve --%s '%s'", sessionFlagName, sessionFlag)
+	}
+
+	jsonlFilepath := filepath.Join(projectDirpath, resolvedID+".jsonl")
+	if _, err := os.Stat(jsonlFilepath); err != nil {
+		// The session resolved, but not to a transcript inside this mission.
+		// Saying so is more useful than printing another mission's transcript
+		// under this mission's ID.
+		return "", stacktrace.Propagate(err, "session '%s' has no transcript in mission %s", resolvedID, missionID)
+	}
+	return jsonlFilepath, nil
+}
+
+// warnOnUnprintedSessions notes on stderr that the mission holds sessions other
+// than the one being printed. A mission accumulates one per reload, /clear or
+// fork, and printing only the newest silently hides the rest.
+func warnOnUnprintedSessions(projectDirpath string, printedFilepath string, sessionFlag string, stderr io.Writer) {
+	if sessionFlag != "" {
+		return
+	}
+	sessionIDs := session.ListSessionIDs(projectDirpath)
+	if len(sessionIDs) <= 1 {
+		return
+	}
+	printedID := strings.TrimSuffix(filepath.Base(printedFilepath), ".jsonl")
+	fmt.Fprintf(stderr,
+		"(mission has %d sessions; printing %s - --%s <id> to print another, 'agenc session ls --mission' to list them)\n",
+		len(sessionIDs), printedID, sessionFlagName)
 }

--- a/cmd/mission_print.go
+++ b/cmd/mission_print.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/odyssey/agenc/internal/claudeconfig"
 	"github.com/odyssey/agenc/internal/config"
+	"github.com/odyssey/agenc/internal/database"
 	"github.com/odyssey/agenc/internal/server"
 	"github.com/odyssey/agenc/internal/session"
 )
@@ -143,6 +144,10 @@ func runMissionPrint(cmd *cobra.Command, args []string) error {
 
 	warnOnUnprintedSessions(projectDirpath, jsonlFilepath, missionPrintSessionFlag, os.Stderr)
 
+	missionPrintOpts.listCommand = fmt.Sprintf("agenc mission print %s --%s", database.ShortID(missionID), agentsFlagName)
+	if missionPrintSessionFlag != "" {
+		missionPrintOpts.listCommand += fmt.Sprintf(" --%s %s", sessionFlagName, missionPrintSessionFlag)
+	}
 	return printTranscript(jsonlFilepath, missionPrintOpts)
 }
 

--- a/cmd/session_ls.go
+++ b/cmd/session_ls.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/mieubrisse/stacktrace"
 	"github.com/spf13/cobra"
 
 	"github.com/odyssey/agenc/internal/database"
+	"github.com/odyssey/agenc/internal/session"
 	"github.com/odyssey/agenc/internal/tableprinter"
 )
 
@@ -44,6 +47,10 @@ func runSessionLs(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	if sessionLsMissionFlag != "" {
+		return printMissionSessions(sessions, session.FindSessionJSONLPath, os.Stdout, os.Stderr)
+	}
+
 	tbl := tableprinter.NewTable("UPDATED", "MISSION", "SESSION", "TITLE", "SUMMARY")
 	for _, s := range sessions {
 		title := resolveSessionTitle(s)
@@ -68,4 +75,38 @@ func resolveSessionTitle(s *database.Session) string {
 		return s.CustomTitle
 	}
 	return s.AgencCustomTitle
+}
+
+// printMissionSessions lists one mission's sessions with what their transcripts
+// hold, so a reader can tell which session to open before opening any: when it
+// started, how much conversation it carries, whether it was compacted, which
+// session it was forked from, how many subagents it spawned and its size.
+// The unfiltered listing keeps its cheap shape: reading every session's
+// transcript is affordable for one mission, not for a whole machine.
+//
+// lookup resolves a session ID to its JSONL path; a session whose transcript
+// cannot be found is still listed, with dashes, and the reason goes to stderr.
+func printMissionSessions(sessions []*database.Session, lookup func(string) (string, error), stdout io.Writer, stderr io.Writer) error {
+	tbl := tableprinter.NewTable("UPDATED", "SESSION", "STARTED", "MSGS", "TOOLS", "ERR", "COMPACT", "AGENTS", "FORKED-FROM", "SIZE", "TITLE").WithWriter(stdout)
+	for _, s := range sessions {
+		row := []string{"-", "-", "-", "-", "-", "-", "-", "-"}
+		if jsonlFilepath, err := lookup(s.ID); err != nil {
+			fmt.Fprintf(stderr, "warning: session %s: %v\n", database.ShortID(s.ID), err)
+		} else if facts, err := describeSessionTranscript(jsonlFilepath); err != nil {
+			fmt.Fprintf(stderr, "warning: session %s: %v\n", database.ShortID(s.ID), err)
+		} else {
+			row = facts.cells()
+		}
+		tbl.AddRow(append(append([]interface{}{s.UpdatedAt.Local().Format("2006-01-02 15:04"), database.ShortID(s.ID)}, toCells(row)...), truncatePrompt(resolveSessionTitle(s), 40))...)
+	}
+	tbl.Print()
+	return nil
+}
+
+func toCells(values []string) []interface{} {
+	out := make([]interface{}, len(values))
+	for i, v := range values {
+		out[i] = v
+	}
+	return out
 }

--- a/cmd/session_ls_test.go
+++ b/cmd/session_ls_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/odyssey/agenc/internal/database"
+)
+
+func TestPrintMissionSessionsDescribesEachTranscript(t *testing.T) {
+	withAgents := sessionWithAgentAndWorkflow(t)
+	forked := writeFakeSession(t, []string{
+		`{"type":"user","uuid":"f1","timestamp":"2026-02-02T00:00:00.000Z","forkedFrom":{"sessionId":"aaaaaaaa-1111-2222-3333-444444444444","messageUuid":"x"},"message":{"role":"user","content":"forked"}}`,
+		`{"type":"system","subtype":"compact_boundary","uuid":"f2","timestamp":"2026-02-02T00:01:00.000Z","compactMetadata":{"trigger":"auto","preTokens":1,"postTokens":1}}`,
+	}, nil)
+	paths := map[string]string{"11111111-2222-3333-4444-555555555555": withAgents, "22222222-0000-0000-0000-000000000000": forked}
+	lookup := func(id string) (string, error) {
+		if p, ok := paths[id]; ok {
+			return p, nil
+		}
+		return "", errors.New("no transcript on disk")
+	}
+	sessions := []*database.Session{
+		{ID: "11111111-2222-3333-4444-555555555555", UpdatedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC), CustomTitle: "with agents"},
+		{ID: "22222222-0000-0000-0000-000000000000", UpdatedAt: time.Date(2026, 2, 2, 12, 0, 0, 0, time.UTC)},
+		{ID: "33333333-0000-0000-0000-000000000000", UpdatedAt: time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC), AgencCustomTitle: "missing"},
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := printMissionSessions(sessions, lookup, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	out := stdout.String()
+
+	if !strings.HasPrefix(out, "UPDATED") || !strings.Contains(strings.SplitN(out, "\n", 2)[0], "FORKED-FROM") {
+		t.Errorf("header = %q", strings.SplitN(out, "\n", 2)[0])
+	}
+	// Whitespace-split tokens: UPDATED(2) SESSION STARTED(2) MSGS TOOLS ERR
+	// COMPACT AGENTS "(N" "wf)" FORKED-FROM SIZE(2) TITLE...
+	row := rowContaining(t, out, "11111111")
+	if row[5] != "4" || row[6] != "2" || row[7] != "0" || row[8] != "0" || row[9] != "3" || row[10] != "(1" || row[11] != "wf)" || row[12] != "-" {
+		t.Errorf("with-agents row = %v", row)
+	}
+	row = rowContaining(t, out, "22222222")
+	if row[8] != "1" || row[9] != "0" || row[10] != "aaaaaaaa" {
+		t.Errorf("forked row = %v", row)
+	}
+	row = rowContaining(t, out, "33333333")
+	if row[3] != "-" || row[len(row)-1] != "missing" {
+		t.Errorf("missing-transcript row must still list with dashes and its title, got %v", row)
+	}
+	if !strings.Contains(stderr.String(), "warning: session 33333333: no transcript on disk") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}

--- a/cmd/session_print.go
+++ b/cmd/session_print.go
@@ -1,40 +1,15 @@
 package cmd
 
 import (
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/mieubrisse/stacktrace"
 	"github.com/spf13/cobra"
 
 	"github.com/odyssey/agenc/internal/session"
 )
 
-// emptySessionMessage is shown when a session JSONL exists but contains no
-// formatted conversation content (e.g., only metadata entries from a
-// freshly-spawned mission that has not yet produced user/assistant messages).
-const emptySessionMessage = "(session has no conversation messages yet)\n"
-
-// countingWriter wraps an io.Writer and tracks the number of bytes written.
-// It allows printSession to detect that a formatter produced no output
-// without buffering the entire transcript in memory.
-type countingWriter struct {
-	w     io.Writer
-	count int64
-}
-
-func (c *countingWriter) Write(p []byte) (int, error) {
-	n, err := c.w.Write(p)
-	c.count += int64(n)
-	return n, err
-}
-
 const defaultTailLines = 20
 
-var sessionPrintTailFlag int
-var sessionPrintAllFlag bool
-var sessionPrintFormatFlag string
+var sessionPrintOpts transcriptPrintOptions
 
 var sessionPrintCmd = &cobra.Command{
 	Use:   printCmdStr + " <session-id>",
@@ -49,28 +24,45 @@ raw JSONL output.
 Outputs the last 20 lines by default. Use --tail to change the line count,
 or --all to print the entire session.
 
+A session is not a single transcript: every subagent it spawns writes its own,
+and those subagents spawn subagents. --agents lists that tree, --agent prints
+one subagent's transcript, and --expand-agents inlines them all at their spawn
+sites. --verbose additionally renders hooks, turn timings, attachments,
+thinking blocks and successful tool results.
+
 Example:
   agenc session print 18749fb5
   agenc session print 18749fb5-02ba-4b19-b989-4e18fbf8ea92
   agenc session print 18749fb5 --format=jsonl
   agenc session print 18749fb5 --tail 50
-  agenc session print 18749fb5 --all`,
+  agenc session print 18749fb5 --all
+  agenc session print 18749fb5 --agents
+  agenc session print 18749fb5 --agent aa8d6202
+  agenc session print 18749fb5 --all --expand-agents`,
 	Args: cobra.ExactArgs(1),
 	RunE: runSessionPrint,
 }
 
 func init() {
-	sessionPrintCmd.Flags().IntVar(&sessionPrintTailFlag, tailFlagName, defaultTailLines, "number of lines to print from end of session")
-	sessionPrintCmd.Flags().BoolVar(&sessionPrintAllFlag, allFlagName, false, "print entire session")
-	sessionPrintCmd.Flags().StringVar(&sessionPrintFormatFlag, formatFlagName, "text", "output format: text or jsonl")
+	sessionPrintCmd.Flags().IntVar(&sessionPrintOpts.tailLines, tailFlagName, defaultTailLines, "number of lines to print from end of session")
+	sessionPrintCmd.Flags().BoolVar(&sessionPrintOpts.all, allFlagName, false, "print entire session")
+	sessionPrintCmd.Flags().StringVar(&sessionPrintOpts.format, formatFlagName, textFormat, "output format: text or jsonl")
+	registerTranscriptPrintFlags(sessionPrintCmd, &sessionPrintOpts)
 	sessionCmd.AddCommand(sessionPrintCmd)
 }
 
 func runSessionPrint(cmd *cobra.Command, args []string) error {
 	sessionID := args[0]
 
-	if !sessionPrintAllFlag && sessionPrintTailFlag <= 0 {
-		return stacktrace.NewError("--tail value must be positive")
+	if !sessionPrintOpts.all && sessionPrintOpts.tailLines <= 0 {
+		return stacktrace.NewError("--%s value must be positive", tailFlagName)
+	}
+
+	// Validate before touching the server so an unusable flag combination is
+	// reported as itself, rather than as whatever the session lookup happens
+	// to fail with first.
+	if err := sessionPrintOpts.validate(); err != nil {
+		return err
 	}
 
 	// Resolve short IDs to full UUIDs via the server
@@ -88,46 +80,5 @@ func runSessionPrint(cmd *cobra.Command, args []string) error {
 		return stacktrace.Propagate(err, "")
 	}
 
-	return printSession(jsonlFilepath, sessionPrintTailFlag, sessionPrintAllFlag, sessionPrintFormatFlag)
-}
-
-// printSession is the shared printing logic used by both
-// session print and mission print commands.
-//
-// A session JSONL may exist but contain only metadata entries (e.g.,
-// file-history-snapshot, progress) when a freshly-spawned mission has not
-// yet produced any user or assistant messages. In that case the formatter
-// writes nothing; printSession detects this and emits an explanatory message
-// to stderr so callers see something instead of silent empty output.
-func printSession(jsonlFilepath string, tailLines int, all bool, format string) error {
-	return printSessionTo(jsonlFilepath, tailLines, all, format, os.Stdout, os.Stderr)
-}
-
-// printSessionTo is the testable core of printSession with explicit writers.
-// It uses a counting wrapper to detect zero-byte output without buffering
-// the entire (potentially large) transcript in memory.
-func printSessionTo(jsonlFilepath string, tailLines int, all bool, format string, stdout io.Writer, stderr io.Writer) error {
-	n := tailLines
-	if all {
-		n = 0
-	}
-
-	cw := &countingWriter{w: stdout}
-	switch format {
-	case "text":
-		if err := session.FormatConversation(jsonlFilepath, n, cw); err != nil {
-			return stacktrace.Propagate(err, "")
-		}
-	case "jsonl":
-		if _, err := session.TailJSONLFile(jsonlFilepath, n, cw); err != nil {
-			return stacktrace.Propagate(err, "")
-		}
-	default:
-		return stacktrace.NewError("invalid format %q: must be %q or %q", format, "text", "jsonl")
-	}
-
-	if cw.count == 0 {
-		fmt.Fprint(stderr, emptySessionMessage)
-	}
-	return nil
+	return printTranscript(jsonlFilepath, sessionPrintOpts)
 }

--- a/cmd/session_print.go
+++ b/cmd/session_print.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/mieubrisse/stacktrace"
 	"github.com/spf13/cobra"
 
+	"github.com/odyssey/agenc/internal/database"
 	"github.com/odyssey/agenc/internal/session"
 )
 
@@ -80,5 +82,6 @@ func runSessionPrint(cmd *cobra.Command, args []string) error {
 		return stacktrace.Propagate(err, "")
 	}
 
+	sessionPrintOpts.listCommand = fmt.Sprintf("agenc session print %s --%s", database.ShortID(resolvedID), agentsFlagName)
 	return printTranscript(jsonlFilepath, sessionPrintOpts)
 }

--- a/cmd/session_print.go
+++ b/cmd/session_print.go
@@ -59,6 +59,11 @@ func runSessionPrint(cmd *cobra.Command, args []string) error {
 	if !sessionPrintOpts.all && sessionPrintOpts.tailLines <= 0 {
 		return stacktrace.NewError("--%s value must be positive", tailFlagName)
 	}
+	// A time window is a selection of its own; the default tail would cut it
+	// again silently. An explicit --tail still applies.
+	if (sessionPrintOpts.since != "" || sessionPrintOpts.until != "") && !cmd.Flags().Changed(tailFlagName) {
+		sessionPrintOpts.all = true
+	}
 
 	// Validate before touching the server so an unusable flag combination is
 	// reported as itself, rather than as whatever the session lookup happens

--- a/cmd/session_print.go
+++ b/cmd/session_print.go
@@ -59,11 +59,7 @@ func runSessionPrint(cmd *cobra.Command, args []string) error {
 	if !sessionPrintOpts.all && sessionPrintOpts.tailLines <= 0 {
 		return stacktrace.NewError("--%s value must be positive", tailFlagName)
 	}
-	// A time window is a selection of its own; the default tail would cut it
-	// again silently. An explicit --tail still applies.
-	if (sessionPrintOpts.since != "" || sessionPrintOpts.until != "") && !cmd.Flags().Changed(tailFlagName) {
-		sessionPrintOpts.all = true
-	}
+	applyWindowDefault(cmd, &sessionPrintOpts)
 
 	// Validate before touching the server so an unusable flag combination is
 	// reported as itself, rather than as whatever the session lookup happens
@@ -89,4 +85,13 @@ func runSessionPrint(cmd *cobra.Command, args []string) error {
 
 	sessionPrintOpts.listCommand = fmt.Sprintf("agenc session print %s --%s", database.ShortID(resolvedID), agentsFlagName)
 	return printTranscript(jsonlFilepath, sessionPrintOpts)
+}
+
+// applyWindowDefault makes a time window print everything inside it. The
+// window is a selection of its own; the default tail would cut it again in
+// silence. An explicit --tail still applies.
+func applyWindowDefault(cmd *cobra.Command, opts *transcriptPrintOptions) {
+	if (opts.since != "" || opts.until != "") && !cmd.Flags().Changed(tailFlagName) {
+		opts.all = true
+	}
 }

--- a/cmd/session_print_test.go
+++ b/cmd/session_print_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-// TestPrintSessionMetadataOnly verifies that printSessionTo emits the
+// TestPrintSessionMetadataOnly verifies that printTranscriptTo emits the
 // empty-session message to stderr (and nothing to stdout) when the JSONL
 // contains only metadata entries — the bug previously masqueraded as
 // "agenc mission print | tail produces empty output" during the brief
@@ -27,7 +27,7 @@ func TestPrintSessionMetadataOnly(t *testing.T) {
 	for _, format := range []string{"text", "jsonl"} {
 		t.Run(format, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			if err := printSessionTo(jsonlFilepath, 0, true, format, &stdout, &stderr); err != nil {
+			if err := printTranscriptTo(jsonlFilepath, transcriptPrintOptions{all: true, format: format}, &stdout, &stderr); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -61,7 +61,7 @@ func TestPrintSessionWithConversation(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := printSessionTo(jsonlFilepath, 0, true, "text", &stdout, &stderr); err != nil {
+	if err := printTranscriptTo(jsonlFilepath, transcriptPrintOptions{all: true, format: textFormat}, &stdout, &stderr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -94,8 +94,8 @@ func TestPrintSessionOversizedLine(t *testing.T) {
 	for _, format := range []string{"text", "jsonl"} {
 		t.Run(format, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			if err := printSessionTo(jsonlFilepath, 0, true, format, &stdout, &stderr); err != nil {
-				t.Fatalf("printSessionTo returned error: %v", err)
+			if err := printTranscriptTo(jsonlFilepath, transcriptPrintOptions{all: true, format: format}, &stdout, &stderr); err != nil {
+				t.Fatalf("printTranscriptTo returned error: %v", err)
 			}
 			if stdout.Len() == 0 {
 				t.Fatalf("expected non-empty stdout for format=%s, got empty output", format)

--- a/cmd/transcript_overview.go
+++ b/cmd/transcript_overview.go
@@ -1,0 +1,402 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/mieubrisse/stacktrace"
+	"github.com/rodaine/table"
+
+	"github.com/odyssey/agenc/internal/session"
+	"github.com/odyssey/agenc/internal/tableprinter"
+)
+
+// The --agents view is the session's overview: what the session is, what it
+// spawned, and what each part costs to read. It is bounded by the number of
+// workflow RUNS, never by their agents — a run row is built from its manifest
+// and directory listing without opening a single agent transcript, so a
+// session with 7214 agents in 60 runs lists in 99 rows, not 7253.
+
+const (
+	// maxResultPreviewBytes caps the run result shown by --workflow in text
+	// mode; --json carries the whole manifest.
+	maxResultPreviewBytes = 4000
+
+	// workflowRowType labels a workflow run's row in the TYPE column.
+	workflowRowType = "workflow"
+
+	// maxWorkflowLabelLen caps a run row's LABEL cell. It is wider than an
+	// agent's because the run's summary is the one field that says what the
+	// run was for, and the overview is where a reader chooses what to open.
+	maxWorkflowLabelLen = 120
+)
+
+// sessionJSON is the session block of the --agents --json document.
+type sessionJSON struct {
+	ID                  string `json:"id"`
+	Path                string `json:"path"`
+	Messages            int    `json:"messages"`
+	ToolCalls           int    `json:"tool_calls"`
+	ToolErrors          int    `json:"tool_errors"`
+	Compactions         int    `json:"compactions"`
+	FirstTimestamp      string `json:"first_timestamp,omitempty"`
+	LastTimestamp       string `json:"last_timestamp,omitempty"`
+	Bytes               int64  `json:"bytes"`
+	ForkedFromSessionID string `json:"forked_from_session,omitempty"`
+}
+
+// agentJSON is one subagent in the JSON views.
+type agentJSON struct {
+	ID            string `json:"id"`
+	Type          string `json:"type"`
+	Model         string `json:"model,omitempty"`
+	Label         string `json:"label,omitempty"`
+	ParentID      string `json:"parent_id,omitempty"`
+	WorkflowRunID string `json:"workflow_run_id,omitempty"`
+	Depth         int    `json:"depth"`
+	StartedAt     string `json:"started_at,omitempty"`
+	Bytes         int64  `json:"bytes"`
+	Messages      int    `json:"messages"`
+	ToolCalls     int    `json:"tool_calls"`
+	ToolErrors    int    `json:"tool_errors"`
+	Orphaned      bool   `json:"orphaned"`
+	MetadataFound bool   `json:"metadata_found"`
+	Path          string `json:"path"`
+}
+
+// workflowJSON is one workflow run in the JSON views.
+type workflowJSON struct {
+	RunID            string `json:"run_id"`
+	TaskID           string `json:"task_id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	Summary          string `json:"summary,omitempty"`
+	Status           string `json:"status"`
+	StartedAt        string `json:"started_at,omitempty"`
+	DurationMs       int64  `json:"duration_ms"`
+	TotalTokens      int64  `json:"total_tokens"`
+	TotalToolCalls   int64  `json:"total_tool_calls"`
+	AgentCount       int    `json:"agent_count"`
+	JournaledResults int    `json:"journaled_results"`
+	Bytes            int64  `json:"bytes"`
+	ManifestFound    bool   `json:"manifest_found"`
+	Path             string `json:"path,omitempty"`
+}
+
+// overviewJSON is the --agents --json document.
+type overviewJSON struct {
+	Session   sessionJSON    `json:"session"`
+	Agents    []agentJSON    `json:"agents"`
+	Workflows []workflowJSON `json:"workflows"`
+}
+
+// workflowRunJSON is the --workflow --json document: the run, its whole
+// manifest, and its agents with their transcript statistics.
+type workflowRunJSON struct {
+	Run      workflowJSON           `json:"run"`
+	Manifest map[string]interface{} `json:"manifest,omitempty"`
+	Agents   []agentJSON            `json:"agents"`
+}
+
+func sessionIDFromPath(jsonlFilepath string) string {
+	return strings.TrimSuffix(filepath.Base(jsonlFilepath), ".jsonl")
+}
+
+// summarizeOrWarn computes a transcript's statistics, warning on stderr when
+// the file cannot be read. The row is still emitted: an absent row would claim
+// the agent does not exist, which is a different and wrong statement.
+func summarizeOrWarn(path string, stderr io.Writer) session.TranscriptStats {
+	stats, err := session.SummarizeTranscript(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "warning: could not read transcript '%s': %v\n", path, err)
+	}
+	return stats
+}
+
+func agentToJSON(node *session.Transcript, stats session.TranscriptStats) agentJSON {
+	out := agentJSON{
+		ID:            node.AgentID,
+		Type:          node.Meta.DisplayType(),
+		Model:         node.Meta.Model,
+		Label:         node.Meta.DisplayLabel(),
+		ParentID:      node.Meta.ParentAgentID,
+		Depth:         node.Depth,
+		StartedAt:     node.StartedAt,
+		Bytes:         node.Bytes,
+		Messages:      stats.UserMessages + stats.AssistantMessages,
+		ToolCalls:     stats.ToolCalls,
+		ToolErrors:    stats.ToolErrors,
+		Orphaned:      node.Orphaned,
+		MetadataFound: node.MetaFound,
+		Path:          node.Filepath,
+	}
+	if node.Workflow != nil {
+		out.WorkflowRunID = node.Workflow.RunID
+	}
+	return out
+}
+
+func workflowToJSON(run *session.WorkflowRun) workflowJSON {
+	return workflowJSON{
+		RunID:            run.RunID,
+		TaskID:           run.TaskID,
+		Name:             run.Name,
+		Summary:          run.Summary,
+		Status:           run.Status,
+		StartedAt:        run.StartedAt,
+		DurationMs:       run.DurationMs,
+		TotalTokens:      run.TotalTokens,
+		TotalToolCalls:   run.TotalToolCalls,
+		AgentCount:       len(run.Agents),
+		JournaledResults: run.JournaledResults,
+		Bytes:            run.Bytes,
+		ManifestFound:    run.ManifestFound,
+		Path:             run.Dirpath,
+	}
+}
+
+// printAgentOverview renders the --agents view: a header describing the
+// session, then one row per directly spawned agent (indented by nesting) and
+// one row per workflow run.
+func printAgentOverview(root *session.Transcript, opts transcriptPrintOptions, stdout io.Writer, stderr io.Writer) error {
+	mainStats := summarizeOrWarn(root.Filepath, stderr)
+	loose := root.Flatten()[1:]
+
+	if opts.jsonOutput {
+		doc := overviewJSON{
+			Session:   sessionToJSON(root, mainStats),
+			Agents:    []agentJSON{},
+			Workflows: []workflowJSON{},
+		}
+		for _, node := range loose {
+			doc.Agents = append(doc.Agents, agentToJSON(node, summarizeOrWarn(node.Filepath, stderr)))
+		}
+		for _, run := range root.Workflows {
+			doc.Workflows = append(doc.Workflows, workflowToJSON(run))
+		}
+		return writeJSON(stdout, doc)
+	}
+
+	writeOverviewHeader(root, mainStats, stdout)
+	if len(loose) == 0 && len(root.Workflows) == 0 {
+		fmt.Fprintln(stdout, "No subagent transcripts for this session.")
+		return nil
+	}
+
+	tbl := newAgentTable(stdout)
+	tbl.AddRow(mainTranscriptLabel, "session", "-",
+		fmt.Sprintf("%d", mainStats.UserMessages+mainStats.AssistantMessages),
+		fmt.Sprintf("%d", mainStats.ToolCalls), fmt.Sprintf("%d", mainStats.ToolErrors),
+		formatTranscriptTimestamp(root.StartedAt), formatBytes(root.Bytes), "")
+	for _, node := range loose {
+		addAgentRow(tbl, node, summarizeOrWarn(node.Filepath, stderr))
+	}
+	for _, run := range root.Workflows {
+		tbl.AddRow(run.RunID, workflowRowType, "-",
+			fmt.Sprintf("%d agents", len(run.Agents)),
+			orDash(nonZero(run.TotalToolCalls)), "-",
+			formatTranscriptTimestamp(run.StartedAt), formatBytes(run.Bytes),
+			truncatePrompt(workflowLabel(run), maxWorkflowLabelLen))
+	}
+	tbl.Print()
+	return nil
+}
+
+func sessionToJSON(root *session.Transcript, stats session.TranscriptStats) sessionJSON {
+	return sessionJSON{
+		ID:                  sessionIDFromPath(root.Filepath),
+		Path:                root.Filepath,
+		Messages:            stats.UserMessages + stats.AssistantMessages,
+		ToolCalls:           stats.ToolCalls,
+		ToolErrors:          stats.ToolErrors,
+		Compactions:         stats.CompactBoundaries,
+		FirstTimestamp:      stats.FirstTimestamp,
+		LastTimestamp:       stats.LastTimestamp,
+		Bytes:               root.Bytes,
+		ForkedFromSessionID: stats.ForkedFromSessionID,
+	}
+}
+
+// writeOverviewHeader prints the three lines that tell a reader what they are
+// looking at and what it would cost to read: the session, its lineage, and its
+// subagents with their sizes on disk.
+func writeOverviewHeader(root *session.Transcript, stats session.TranscriptStats, w io.Writer) {
+	fmt.Fprintf(w, "session %s: %d messages, %d tool calls, %d errors, %d compactions, %s, %s - %s\n",
+		sessionIDFromPath(root.Filepath), stats.UserMessages+stats.AssistantMessages, stats.ToolCalls, stats.ToolErrors,
+		stats.CompactBoundaries, formatBytes(root.Bytes), formatTranscriptTimestamp(stats.FirstTimestamp), formatTranscriptTimestamp(stats.LastTimestamp))
+	if stats.ForkedFromSessionID != "" {
+		fmt.Fprintf(w, "forked from session %s\n", stats.ForkedFromSessionID)
+	}
+	loose := root.Flatten()[1:]
+	var looseBytes, workflowBytes int64
+	workflowAgents := 0
+	for _, n := range loose {
+		looseBytes += n.Bytes
+	}
+	for _, run := range root.Workflows {
+		workflowBytes += run.Bytes
+		workflowAgents += len(run.Agents)
+	}
+	var parts []string
+	if len(loose) > 0 {
+		parts = append(parts, fmt.Sprintf("%d spawned directly (%s)", len(loose), formatBytes(looseBytes)))
+	}
+	if len(root.Workflows) > 0 {
+		parts = append(parts, fmt.Sprintf("%d in %d workflow run(s) (%s)", workflowAgents, len(root.Workflows), formatBytes(workflowBytes)))
+	}
+	if len(parts) > 0 {
+		fmt.Fprintf(w, "subagents: %s\n", strings.Join(parts, "; "))
+	}
+}
+
+// workflowLabel is the LABEL cell of a run row: name, status, how many agents
+// never reported, duration, then the run's summary.
+func workflowLabel(run *session.WorkflowRun) string {
+	parts := []string{run.Status}
+	if run.DurationMs > 0 {
+		parts = append(parts, formatDurationMs(run.DurationMs))
+	}
+	label := fmt.Sprintf("%s: %s", run.DisplayName(), strings.Join(parts, ", "))
+	if run.Summary != "" {
+		label += " - " + run.Summary
+	}
+	return label
+}
+
+// printWorkflowRun renders the --workflow view: the run's manifest facts, its
+// phases and result, then its agents with transcript statistics. Only here are
+// a run's agent transcripts opened, and only this run's.
+func printWorkflowRun(run *session.WorkflowRun, opts transcriptPrintOptions, stdout io.Writer, stderr io.Writer) error {
+	run.LoadAgentDetails()
+	manifest, manifestErr := session.ReadWorkflowManifestJSON(run)
+	if manifestErr != nil && run.ManifestFilepath != "" {
+		fmt.Fprintf(stderr, "warning: %v\n", manifestErr)
+	}
+
+	agents := make([]agentJSON, 0, len(run.Agents))
+	stats := make([]session.TranscriptStats, 0, len(run.Agents))
+	for _, node := range run.Agents {
+		s := summarizeOrWarn(node.Filepath, stderr)
+		stats = append(stats, s)
+		agents = append(agents, agentToJSON(node, s))
+	}
+
+	if opts.jsonOutput {
+		return writeJSON(stdout, workflowRunJSON{Run: workflowToJSON(run), Manifest: manifest, Agents: agents})
+	}
+
+	fmt.Fprintf(stdout, "workflow %s (%s): %s\n", run.RunID, run.DisplayName(), strings.Join(runFacts(run), ", "))
+	if run.TaskID != "" || run.StartedAt != "" {
+		fmt.Fprintf(stdout, "task %s, started %s\n", orDash(run.TaskID), formatTranscriptTimestamp(run.StartedAt))
+	}
+	if run.Summary != "" {
+		fmt.Fprintf(stdout, "summary: %s\n", run.Summary)
+	}
+	if !run.ManifestFound {
+		fmt.Fprintln(stdout, "manifest: not found on disk")
+	}
+	if titles := phaseTitles(manifest); len(titles) > 0 {
+		fmt.Fprintf(stdout, "phases: %s\n", strings.Join(titles, ", "))
+	}
+	if result, ok := manifest["result"]; ok && result != nil {
+		encoded, err := json.Marshal(result)
+		if err == nil {
+			preview := string(encoded)
+			if len(preview) > maxResultPreviewBytes {
+				preview = preview[:maxResultPreviewBytes] + fmt.Sprintf("... (%d bytes; --%s for the whole manifest)", len(encoded), transcriptJSONFlagName)
+			}
+			fmt.Fprintf(stdout, "result: %s\n", preview)
+		}
+	}
+	if len(run.Agents) == 0 {
+		fmt.Fprintln(stdout, "No agent transcripts for this run.")
+		return nil
+	}
+	fmt.Fprintln(stdout)
+	tbl := newAgentTable(stdout)
+	for i, node := range run.Agents {
+		addAgentRow(tbl, node, stats[i])
+	}
+	tbl.Print()
+	return nil
+}
+
+func runFacts(run *session.WorkflowRun) []string {
+	facts := []string{run.Status}
+	if run.DurationMs > 0 {
+		facts = append(facts, formatDurationMs(run.DurationMs))
+	}
+	facts = append(facts, fmt.Sprintf("%d agents", len(run.Agents)))
+	if run.TotalToolCalls > 0 {
+		facts = append(facts, fmt.Sprintf("%d tool calls", run.TotalToolCalls))
+	}
+	if run.TotalTokens > 0 {
+		facts = append(facts, fmt.Sprintf("%d tok", run.TotalTokens))
+	}
+	return facts
+}
+
+// phaseTitles extracts phase titles from a manifest's phases array, tolerating
+// any shape it does not recognise.
+func phaseTitles(manifest map[string]interface{}) []string {
+	phases, _ := manifest["phases"].([]interface{})
+	var titles []string
+	for _, p := range phases {
+		if m, ok := p.(map[string]interface{}); ok {
+			if title, ok := m["title"].(string); ok && title != "" {
+				titles = append(titles, title)
+			}
+		}
+	}
+	return titles
+}
+
+func newAgentTable(w io.Writer) table.Table {
+	return tableprinter.NewTable("AGENT", "TYPE", "MODEL", "MSGS", "TOOLS", "ERR", "STARTED", "SIZE", "LABEL").WithWriter(w)
+}
+
+func addAgentRow(tbl table.Table, node *session.Transcript, stats session.TranscriptStats) {
+	tbl.AddRow(
+		agentTreeCell(node),
+		agentTypeCell(node),
+		orDash(node.Meta.Model),
+		fmt.Sprintf("%d", stats.UserMessages+stats.AssistantMessages),
+		fmt.Sprintf("%d", stats.ToolCalls),
+		fmt.Sprintf("%d", stats.ToolErrors),
+		formatTranscriptTimestamp(node.StartedAt),
+		formatBytes(node.Bytes),
+		truncatePrompt(agentLabelCell(node), maxAgentLabelLen),
+	)
+}
+
+func nonZero(n int64) string {
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+// formatDurationMs renders a millisecond duration the way the transcript
+// renderer does: 850ms, 12.3s, 24m48s.
+func formatDurationMs(ms int64) string {
+	switch {
+	case ms < 1000:
+		return fmt.Sprintf("%dms", ms)
+	case ms < 60000:
+		return fmt.Sprintf("%.1fs", float64(ms)/1000)
+	default:
+		total := ms / 1000
+		return fmt.Sprintf("%dm%02ds", total/60, total%60)
+	}
+}
+
+func writeJSON(w io.Writer, doc interface{}) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		return stacktrace.Propagate(err, "failed to encode JSON")
+	}
+	return nil
+}

--- a/cmd/transcript_overview.go
+++ b/cmd/transcript_overview.go
@@ -18,7 +18,7 @@ import (
 // spawned, and what each part costs to read. It is bounded by the number of
 // workflow RUNS, never by their agents — a run row is built from its manifest
 // and directory listing without opening a single agent transcript, so a
-// session with 7214 agents in 60 runs lists in 99 rows, not 7253.
+// session with 7214 agents in 60 runs lists as 99 table rows, not 7253.
 
 const (
 	// maxResultPreviewBytes caps the run result shown by --workflow in text
@@ -69,20 +69,25 @@ type agentJSON struct {
 
 // workflowJSON is one workflow run in the JSON views.
 type workflowJSON struct {
-	RunID            string `json:"run_id"`
-	TaskID           string `json:"task_id,omitempty"`
-	Name             string `json:"name,omitempty"`
-	Summary          string `json:"summary,omitempty"`
-	Status           string `json:"status"`
-	StartedAt        string `json:"started_at,omitempty"`
-	DurationMs       int64  `json:"duration_ms"`
-	TotalTokens      int64  `json:"total_tokens"`
-	TotalToolCalls   int64  `json:"total_tool_calls"`
-	AgentCount       int    `json:"agent_count"`
-	JournaledResults int    `json:"journaled_results"`
-	Bytes            int64  `json:"bytes"`
-	ManifestFound    bool   `json:"manifest_found"`
-	Path             string `json:"path,omitempty"`
+	RunID          string `json:"run_id"`
+	TaskID         string `json:"task_id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Summary        string `json:"summary,omitempty"`
+	Status         string `json:"status"`
+	StartedAt      string `json:"started_at,omitempty"`
+	CompletedAt    string `json:"completed_at,omitempty"`
+	DurationMs     int64  `json:"duration_ms"`
+	TotalTokens    int64  `json:"total_tokens"`
+	TotalToolCalls int64  `json:"total_tool_calls"`
+	AgentCount     int    `json:"agent_count"`
+	// ResumeCacheResults is the run journal's result-record count. The
+	// journal is the Workflow tool's resume cache, so this is how many agent
+	// results were cached, not how many agents finished; the name says so
+	// because a JSON field cannot carry a comment.
+	ResumeCacheResults int    `json:"resume_cache_results"`
+	Bytes              int64  `json:"bytes"`
+	ManifestFound      bool   `json:"manifest_found"`
+	Path               string `json:"path,omitempty"`
 }
 
 // overviewJSON is the --agents --json document.
@@ -140,20 +145,21 @@ func agentToJSON(node *session.Transcript, stats session.TranscriptStats) agentJ
 
 func workflowToJSON(run *session.WorkflowRun) workflowJSON {
 	return workflowJSON{
-		RunID:            run.RunID,
-		TaskID:           run.TaskID,
-		Name:             run.Name,
-		Summary:          run.Summary,
-		Status:           run.Status,
-		StartedAt:        run.StartedAt,
-		DurationMs:       run.DurationMs,
-		TotalTokens:      run.TotalTokens,
-		TotalToolCalls:   run.TotalToolCalls,
-		AgentCount:       len(run.Agents),
-		JournaledResults: run.JournaledResults,
-		Bytes:            run.Bytes,
-		ManifestFound:    run.ManifestFound,
-		Path:             run.Dirpath,
+		RunID:              run.RunID,
+		TaskID:             run.TaskID,
+		Name:               run.Name,
+		Summary:            run.Summary,
+		Status:             run.Status,
+		StartedAt:          run.StartedAt,
+		CompletedAt:        run.CompletedAt,
+		DurationMs:         run.DurationMs,
+		TotalTokens:        run.TotalTokens,
+		TotalToolCalls:     run.TotalToolCalls,
+		AgentCount:         len(run.Agents),
+		ResumeCacheResults: run.JournaledResults,
+		Bytes:              run.Bytes,
+		ManifestFound:      run.ManifestFound,
+		Path:               run.Dirpath,
 	}
 }
 
@@ -189,7 +195,7 @@ func printAgentOverview(root *session.Transcript, opts transcriptPrintOptions, s
 	tbl.AddRow(mainTranscriptLabel, "session", "-",
 		fmt.Sprintf("%d", mainStats.UserMessages+mainStats.AssistantMessages),
 		fmt.Sprintf("%d", mainStats.ToolCalls), fmt.Sprintf("%d", mainStats.ToolErrors),
-		formatTranscriptTimestamp(root.StartedAt), formatBytes(root.Bytes), "")
+		formatTranscriptTimestamp(root.StartedAt), session.FormatBytes(root.Bytes), "")
 	for _, node := range loose {
 		addAgentRow(tbl, node, summarizeOrWarn(node.Filepath, stderr))
 	}
@@ -197,7 +203,7 @@ func printAgentOverview(root *session.Transcript, opts transcriptPrintOptions, s
 		tbl.AddRow(run.RunID, workflowRowType, "-",
 			fmt.Sprintf("%d agents", len(run.Agents)),
 			orDash(nonZero(run.TotalToolCalls)), "-",
-			formatTranscriptTimestamp(run.StartedAt), formatBytes(run.Bytes),
+			formatTranscriptTimestamp(run.StartedAt), session.FormatBytes(run.Bytes),
 			truncatePrompt(workflowLabel(run), maxWorkflowLabelLen))
 	}
 	tbl.Print()
@@ -225,7 +231,7 @@ func sessionToJSON(root *session.Transcript, stats session.TranscriptStats) sess
 func writeOverviewHeader(root *session.Transcript, stats session.TranscriptStats, w io.Writer) {
 	fmt.Fprintf(w, "session %s: %d messages, %d tool calls, %d errors, %d compactions, %s, %s - %s\n",
 		sessionIDFromPath(root.Filepath), stats.UserMessages+stats.AssistantMessages, stats.ToolCalls, stats.ToolErrors,
-		stats.CompactBoundaries, formatBytes(root.Bytes), formatTranscriptTimestamp(stats.FirstTimestamp), formatTranscriptTimestamp(stats.LastTimestamp))
+		stats.CompactBoundaries, session.FormatBytes(root.Bytes), formatTranscriptTimestamp(stats.FirstTimestamp), formatTranscriptTimestamp(stats.LastTimestamp))
 	if stats.ForkedFromSessionID != "" {
 		fmt.Fprintf(w, "forked from session %s\n", stats.ForkedFromSessionID)
 	}
@@ -241,10 +247,10 @@ func writeOverviewHeader(root *session.Transcript, stats session.TranscriptStats
 	}
 	var parts []string
 	if len(loose) > 0 {
-		parts = append(parts, fmt.Sprintf("%d spawned directly (%s)", len(loose), formatBytes(looseBytes)))
+		parts = append(parts, fmt.Sprintf("%d spawned directly (%s)", len(loose), session.FormatBytes(looseBytes)))
 	}
 	if len(root.Workflows) > 0 {
-		parts = append(parts, fmt.Sprintf("%d in %d workflow run(s) (%s)", workflowAgents, len(root.Workflows), formatBytes(workflowBytes)))
+		parts = append(parts, fmt.Sprintf("%d in %d workflow run(s) (%s)", workflowAgents, len(root.Workflows), session.FormatBytes(workflowBytes)))
 	}
 	if len(parts) > 0 {
 		fmt.Fprintf(w, "subagents: %s\n", strings.Join(parts, "; "))
@@ -289,7 +295,11 @@ func printWorkflowRun(run *session.WorkflowRun, opts transcriptPrintOptions, std
 
 	fmt.Fprintf(stdout, "workflow %s (%s): %s\n", run.RunID, run.DisplayName(), strings.Join(runFacts(run), ", "))
 	if run.TaskID != "" || run.StartedAt != "" {
-		fmt.Fprintf(stdout, "task %s, started %s\n", orDash(run.TaskID), formatTranscriptTimestamp(run.StartedAt))
+		line := fmt.Sprintf("task %s, started %s", orDash(run.TaskID), formatTranscriptTimestamp(run.StartedAt))
+		if run.CompletedAt != "" {
+			line += ", completed " + formatTranscriptTimestamp(run.CompletedAt)
+		}
+		fmt.Fprintln(stdout, line)
 	}
 	if run.Summary != "" {
 		fmt.Fprintf(stdout, "summary: %s\n", run.Summary)
@@ -366,7 +376,7 @@ func addAgentRow(tbl table.Table, node *session.Transcript, stats session.Transc
 		fmt.Sprintf("%d", stats.ToolCalls),
 		fmt.Sprintf("%d", stats.ToolErrors),
 		formatTranscriptTimestamp(node.StartedAt),
-		formatBytes(node.Bytes),
+		session.FormatBytes(node.Bytes),
 		truncatePrompt(agentLabelCell(node), maxAgentLabelLen),
 	)
 }
@@ -450,7 +460,7 @@ func (f sessionTranscriptFacts) cells() []string {
 		fmt.Sprintf("%d", f.stats.CompactBoundaries),
 		agents,
 		forkedFrom,
-		formatBytes(f.bytes),
+		session.FormatBytes(f.bytes),
 	}
 }
 

--- a/cmd/transcript_overview.go
+++ b/cmd/transcript_overview.go
@@ -400,3 +400,64 @@ func writeJSON(w io.Writer, doc interface{}) error {
 	}
 	return nil
 }
+
+// sessionTranscriptFacts is what `session ls --mission` shows per session: the
+// main transcript's statistics plus how much hangs below it.
+type sessionTranscriptFacts struct {
+	stats        session.TranscriptStats
+	bytes        int64
+	agents       int
+	workflowRuns int
+	startedAt    string
+}
+
+// describeSessionTranscript discovers a session's tree and summarizes its main
+// transcript. Subagent transcripts are counted, not read.
+func describeSessionTranscript(jsonlFilepath string) (sessionTranscriptFacts, error) {
+	root, err := session.DiscoverTranscriptsForFile(jsonlFilepath)
+	if err != nil {
+		return sessionTranscriptFacts{}, err
+	}
+	stats, err := session.SummarizeTranscript(root.Filepath)
+	if err != nil {
+		return sessionTranscriptFacts{}, err
+	}
+	return sessionTranscriptFacts{
+		stats:        stats,
+		bytes:        root.Bytes,
+		agents:       len(root.AllAgents()),
+		workflowRuns: len(root.Workflows),
+		startedAt:    root.StartedAt,
+	}, nil
+}
+
+// cells renders the facts as the STARTED, MSGS, TOOLS, ERR, COMPACT, AGENTS,
+// FORKED-FROM and SIZE columns.
+func (f sessionTranscriptFacts) cells() []string {
+	agents := fmt.Sprintf("%d", f.agents)
+	if f.workflowRuns > 0 {
+		agents += fmt.Sprintf(" (%d wf)", f.workflowRuns)
+	}
+	forkedFrom := "-"
+	if f.stats.ForkedFromSessionID != "" {
+		forkedFrom = shortSessionID(f.stats.ForkedFromSessionID)
+	}
+	return []string{
+		formatTranscriptTimestamp(f.startedAt),
+		fmt.Sprintf("%d", f.stats.UserMessages+f.stats.AssistantMessages),
+		fmt.Sprintf("%d", f.stats.ToolCalls),
+		fmt.Sprintf("%d", f.stats.ToolErrors),
+		fmt.Sprintf("%d", f.stats.CompactBoundaries),
+		agents,
+		forkedFrom,
+		formatBytes(f.bytes),
+	}
+}
+
+// shortSessionID abbreviates a session UUID the way the listings do.
+func shortSessionID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}

--- a/cmd/transcript_overview_test.go
+++ b/cmd/transcript_overview_test.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// addFakeWorkflowRun writes a workflow run next to a fake session: its agent
+// transcripts under subagents/workflows/<runID>/, a journal in which the first
+// `finished` agents reported, and its manifest under workflows/<runID>.json.
+func addFakeWorkflowRun(t *testing.T, mainFilepath string, runID string, manifestJSON string, agents map[string]string, finished int) {
+	t.Helper()
+	sessionDir := strings.TrimSuffix(mainFilepath, ".jsonl")
+	runDir := filepath.Join(sessionDir, "subagents", "workflows", runID)
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	var journal []string
+	var ids []string
+	for id := range agents {
+		ids = append(ids, id)
+	}
+	for _, id := range ids {
+		if err := os.WriteFile(filepath.Join(runDir, "agent-"+id+".jsonl"), []byte(agents[id]+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(runDir, "agent-"+id+".meta.json"), []byte(`{"agentType":"workflow-subagent","spawnDepth":1}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		journal = append(journal, `{"type":"started","key":"k","agentId":"`+id+`"}`)
+	}
+	for _, id := range ids[:finished] {
+		journal = append(journal, `{"type":"result","key":"k","agentId":"`+id+`","result":{"ok":true}}`)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "journal.jsonl"), []byte(strings.Join(journal, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if manifestJSON != "" {
+		manifestDir := filepath.Join(sessionDir, "workflows")
+		if err := os.MkdirAll(manifestDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(manifestDir, runID+".json"), []byte(manifestJSON), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// sessionWithAgentAndWorkflow is the one-agent fixture plus a two-agent
+// workflow run whose spawn the main transcript records.
+func sessionWithAgentAndWorkflow(t *testing.T) string {
+	t.Helper()
+	mainFilepath := sessionWithOneAgent(t)
+	f, err := os.OpenFile(mainFilepath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spawn := `{"type":"assistant","timestamp":"2026-01-01T00:00:02.000Z","uuid":"wfu","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_wf","name":"Workflow","input":{"scriptPath":"/x/analyze.js"}}]}}` + "\n" +
+		`{"type":"user","timestamp":"2026-01-01T00:00:03.000Z","uuid":"wfr","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_wf","content":"Workflow launched in background. Task ID: w9gxz79on\nSummary: analyze threads"}]}}` + "\n"
+	if _, err := f.WriteString(spawn); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	addFakeWorkflowRun(t, mainFilepath, "wf_3a23189e-9d5",
+		`{"runId":"wf_3a23189e-9d5","timestamp":"2026-01-01T00:00:03.500Z","taskId":"w9gxz79on","workflowName":"analyze","summary":"one agent per thread","status":"completed","durationMs":"1487202","totalTokens":1741419,"totalToolCalls":"194","phases":[{"title":"Review"},{"title":"Verify"}],"result":{"dispatched":2}}`,
+		map[string]string{
+			"aw1": strings.Join([]string{
+				fakeUserLine("2026-01-01T00:01:00.000Z", "WF AGENT ONE PROMPT"),
+				`{"type":"assistant","uuid":"w1a","timestamp":"2026-01-01T00:01:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+			}, "\n"),
+			"aw2": fakeUserLine("2026-01-01T00:02:00.000Z", "WF AGENT TWO PROMPT"),
+		}, 1)
+	return mainFilepath
+}
+
+func runPrint(t *testing.T, mainFilepath string, opts transcriptPrintOptions) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	if opts.format == "" {
+		opts.format = textFormat
+	}
+	err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestOverviewListsWorkflowRunsAsOneRowEach(t *testing.T) {
+	out, _, err := runPrint(t, sessionWithAgentAndWorkflow(t), transcriptPrintOptions{listAgents: true, all: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"session 11111111-2222-3333-4444-555555555555: 4 messages, 2 tool calls, 0 errors, 0 compactions, ",
+		"subagents: 1 spawned directly (", "; 2 in 1 workflow run(s) (",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("header missing %q in:\n%s", want, out)
+		}
+	}
+	row := rowContaining(t, out, "wf_3a23189e-9d5")
+	if row[1] != "workflow" || row[3] != "2" || row[4] != "agents" || row[5] != "194" {
+		t.Errorf("run row = %v", row)
+	}
+	if !strings.Contains(out, "analyze: completed, 24m47s - one agent per thread") {
+		t.Errorf("run label missing, got:\n%s", out)
+	}
+	if strings.Contains(out, "WF AGENT ONE PROMPT") || strings.Contains(out, "aw1") {
+		t.Errorf("the overview must not list a run's agents individually:\n%s", out)
+	}
+	agentRow := rowContaining(t, out, "aa8d6202c85e084d7")
+	if !strings.Contains(strings.Join(agentRow, " "), " KB ") && !strings.Contains(strings.Join(agentRow, " "), " B ") {
+		t.Errorf("agent row must carry a SIZE cell: %v", agentRow)
+	}
+}
+
+func TestOverviewJSONIsCompleteAndParseable(t *testing.T) {
+	out, _, err := runPrint(t, sessionWithAgentAndWorkflow(t), transcriptPrintOptions{listAgents: true, jsonOutput: true, all: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc overviewJSON
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, out)
+	}
+	if doc.Session.Messages != 4 || doc.Session.ToolCalls != 2 || doc.Session.Bytes <= 0 {
+		t.Errorf("session = %+v", doc.Session)
+	}
+	if len(doc.Agents) != 1 || doc.Agents[0].ID != "aa8d6202c85e084d7" || doc.Agents[0].Messages != 7 || doc.Agents[0].ToolErrors != 2 || doc.Agents[0].Bytes <= 0 || doc.Agents[0].WorkflowRunID != "" {
+		t.Errorf("agents = %+v", doc.Agents)
+	}
+	if len(doc.Workflows) != 1 {
+		t.Fatalf("workflows = %+v", doc.Workflows)
+	}
+	wf := doc.Workflows[0]
+	if wf.RunID != "wf_3a23189e-9d5" || wf.TaskID != "w9gxz79on" || wf.AgentCount != 2 || wf.JournaledResults != 1 || wf.TotalTokens != 1741419 || wf.Bytes <= 0 || !wf.ManifestFound {
+		t.Errorf("workflow = %+v", wf)
+	}
+}
+
+func TestWorkflowViewShowsTheRunAndItsAgents(t *testing.T) {
+	mainFilepath := sessionWithAgentAndWorkflow(t)
+	for _, key := range []string{"wf_3a23189e-9d5", "3a23", "analyze", "w9gxz79on"} {
+		out, _, err := runPrint(t, mainFilepath, transcriptPrintOptions{workflowID: key, all: true})
+		if err != nil {
+			t.Fatalf("--workflow %s: %v", key, err)
+		}
+		for _, want := range []string{
+			"workflow wf_3a23189e-9d5 (analyze): completed, 24m47s, 2 agents, 194 tool calls, 1741419 tok",
+			"task w9gxz79on, started ",
+			"summary: one agent per thread",
+			"phases: Review, Verify",
+			`result: {"dispatched":2}`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("--workflow %s missing %q in:\n%s", key, want, out)
+			}
+		}
+		if row := rowContaining(t, out, "aw1"); row[1] != "workflow-subagent" || row[3] != "2" || row[4] != "1" {
+			t.Errorf("agent row = %v", row)
+		}
+		rowContaining(t, out, "aw2")
+	}
+}
+
+func TestWorkflowViewJSONCarriesTheWholeManifest(t *testing.T) {
+	out, _, err := runPrint(t, sessionWithAgentAndWorkflow(t), transcriptPrintOptions{workflowID: "analyze", jsonOutput: true, all: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc workflowRunJSON
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	if doc.Run.RunID != "wf_3a23189e-9d5" || len(doc.Agents) != 2 || doc.Manifest["result"] == nil || doc.Manifest["phases"] == nil {
+		t.Errorf("doc = %+v", doc)
+	}
+	if doc.Agents[0].ID != "aw1" || doc.Agents[0].WorkflowRunID != "wf_3a23189e-9d5" || doc.Agents[0].ToolCalls != 1 {
+		t.Errorf("agents = %+v", doc.Agents)
+	}
+}
+
+func TestWorkflowViewRefusesUnknownRunAndNamesTheListing(t *testing.T) {
+	_, _, err := runPrint(t, sessionWithAgentAndWorkflow(t), transcriptPrintOptions{workflowID: "nosuch", all: true})
+	if err == nil || !strings.Contains(err.Error(), "no matching workflow run") || !strings.Contains(err.Error(), "--agents lists the runs") {
+		t.Errorf("want a refusal that names --agents, got %v", err)
+	}
+	_, _, err = runPrint(t, sessionWithAgentAndWorkflow(t), transcriptPrintOptions{agentID: "nosuch", all: true})
+	if err == nil || !strings.Contains(err.Error(), "--agents lists the agents") {
+		t.Errorf("want a refusal that names --agents, got %v", err)
+	}
+}
+
+func TestJSONFlagOutsideItsViewsTeachesTheAlternative(t *testing.T) {
+	err := transcriptPrintOptions{format: textFormat, all: true, jsonOutput: true}.validate()
+	if err == nil || !strings.Contains(err.Error(), "--json applies to --agents and --workflow") || !strings.Contains(err.Error(), "--format=jsonl") {
+		t.Errorf("got %v", err)
+	}
+	for _, opts := range []transcriptPrintOptions{
+		{format: textFormat, all: true, workflowID: "x", listAgents: true},
+		{format: textFormat, all: true, workflowID: "x", agentID: "y"},
+		{format: textFormat, all: true, workflowID: "x", expandAgents: true},
+	} {
+		if err := opts.validate(); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("%+v: got %v", opts, err)
+		}
+	}
+}
+
+func TestExpansionBudgetSkipsTheAgentWithTheNumberAndTheFlag(t *testing.T) {
+	big := strings.Repeat("x", 1200*1024)
+	mainFilepath := writeFakeSession(t,
+		[]string{
+			fakeUserLine("2026-01-01T00:00:00.000Z", "go"),
+			`{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_big","name":"Agent","input":{"description":"big one"}}]}}`,
+		},
+		map[string][2]string{"abig": {
+			`{"type":"assistant","uuid":"b","timestamp":"2026-01-01T00:01:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"` + big + `"}]}}`,
+			`{"agentType":"Explore","toolUseId":"toolu_big"}`,
+		}})
+
+	out, _, err := runPrint(t, mainFilepath, transcriptPrintOptions{expandAgents: true, all: true, maxExpandMB: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"[agent abig not expanded: 1.2 MB would exceed the 1.0 MB expansion budget; raise --max-expand-mb, or print it alone with --agent abig]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("note missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "xxxxxxxxxx") {
+		t.Errorf("the over-budget agent must not be inlined")
+	}
+	out, _, err = runPrint(t, mainFilepath, transcriptPrintOptions{expandAgents: true, all: true, maxExpandMB: 0})
+	if err != nil || !strings.Contains(out, "xxxxxxxxxx") {
+		t.Errorf("0 must mean unlimited, got err=%v inlined=%v", err, strings.Contains(out, "xxxxxxxxxx"))
+	}
+	out, _, err = runPrint(t, mainFilepath, transcriptPrintOptions{expandAgents: true, all: true, maxExpandMB: 2})
+	if err != nil || !strings.Contains(out, "xxxxxxxxxx") {
+		t.Errorf("under budget must inline, got err=%v", err)
+	}
+}
+
+func TestUnknownFlagSuggestsTheNearestOne(t *testing.T) {
+	for typed, want := range map[string]string{"subagents": "agents", "agnets": "agents", "jsno": "json", "expand": "expand-agents", "workflows": "workflow", "zzzzzzzz": ""} {
+		if got := closestFlagName(sessionPrintCmd, typed); got != want {
+			t.Errorf("closestFlagName(%q) = %q, want %q", typed, got, want)
+		}
+	}
+	rootCmd.SetArgs([]string{"session", "print", "abc", "--subagents"})
+	defer rootCmd.SetArgs(nil)
+	err := rootCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --subagents (did you mean --agents?)") {
+		t.Errorf("got %v", err)
+	}
+}

--- a/cmd/transcript_overview_test.go
+++ b/cmd/transcript_overview_test.go
@@ -135,7 +135,7 @@ func TestOverviewJSONIsCompleteAndParseable(t *testing.T) {
 		t.Fatalf("workflows = %+v", doc.Workflows)
 	}
 	wf := doc.Workflows[0]
-	if wf.RunID != "wf_3a23189e-9d5" || wf.TaskID != "w9gxz79on" || wf.AgentCount != 2 || wf.JournaledResults != 1 || wf.TotalTokens != 1741419 || wf.Bytes <= 0 || !wf.ManifestFound {
+	if wf.RunID != "wf_3a23189e-9d5" || wf.TaskID != "w9gxz79on" || wf.AgentCount != 2 || wf.ResumeCacheResults != 1 || wf.TotalTokens != 1741419 || wf.Bytes <= 0 || !wf.ManifestFound {
 		t.Errorf("workflow = %+v", wf)
 	}
 }
@@ -244,15 +244,45 @@ func TestExpansionBudgetSkipsTheAgentWithTheNumberAndTheFlag(t *testing.T) {
 }
 
 func TestUnknownFlagSuggestsTheNearestOne(t *testing.T) {
-	for typed, want := range map[string]string{"subagents": "agents", "agnets": "agents", "jsno": "json", "expand": "expand-agents", "workflows": "workflow", "zzzzzzzz": ""} {
+	for typed, want := range map[string]string{
+		"subagents": "agents", "agnets": "agents", "jsno": "json", "expand": "expand-agents", "workflows": "workflow",
+		"sicne": "since", "tial": "tail", "verbos": "verbose", "ALL": "all", "agentsxyz": "agents",
+		"zzzzzzzz": "", "a": "", "ag": "",
+	} {
 		if got := closestFlagName(sessionPrintCmd, typed); got != want {
 			t.Errorf("closestFlagName(%q) = %q, want %q", typed, got, want)
 		}
+	}
+	// A real flag of a sibling command is not a typo of this command's flags.
+	if got := closestFlagName(missionLsCmd, "tail"); got != "" {
+		t.Errorf("closestFlagName(mission ls, %q) = %q, want no suggestion", "tail", got)
 	}
 	rootCmd.SetArgs([]string{"session", "print", "abc", "--subagents"})
 	defer rootCmd.SetArgs(nil)
 	err := rootCmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "unknown flag: --subagents (did you mean --agents?)") {
 		t.Errorf("got %v", err)
+	}
+}
+
+func TestRawJSONLExpansionHonoursTheBudgetOnStderr(t *testing.T) {
+	big := strings.Repeat("x", 1200*1024)
+	mainFilepath := writeFakeSession(t,
+		[]string{fakeUserLine("2026-01-01T00:00:00.000Z", "go")},
+		map[string][2]string{"abig": {`{"type":"assistant","uuid":"b","timestamp":"2026-01-01T00:01:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"` + big + `"}]}}`, `{"agentType":"Explore"}`}})
+
+	out, stderr, err := runPrint(t, mainFilepath, transcriptPrintOptions{format: jsonlFormat, expandAgents: true, all: true, maxExpandMB: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "xxxxxxxxxx") {
+		t.Errorf("the raw stream must not emit an agent over the budget")
+	}
+	if !strings.Contains(stderr, "warning: agent abig (1.2 MB) not emitted: over the --max-expand-mb=1 budget; raise it, or print it alone with --agent abig") {
+		t.Errorf("stderr = %q", stderr)
+	}
+	out, _, err = runPrint(t, mainFilepath, transcriptPrintOptions{format: jsonlFormat, expandAgents: true, all: true, maxExpandMB: 0})
+	if err != nil || !strings.Contains(out, "xxxxxxxxxx") {
+		t.Errorf("0 must mean unlimited on the raw path too")
 	}
 }

--- a/cmd/transcript_print.go
+++ b/cmd/transcript_print.go
@@ -46,6 +46,8 @@ const (
 	workflowFlagName       = "workflow"
 	transcriptJSONFlagName = "json"
 	maxExpandMBFlagName    = "max-expand-mb"
+	sinceFlagName          = "since"
+	untilFlagName          = "until"
 
 	// defaultMaxExpandMB is the --expand-agents budget in subagent JSONL bytes.
 	// Rendered text runs about a tenth of the JSONL it comes from, so 16 MB of
@@ -109,6 +111,13 @@ type transcriptPrintOptions struct {
 	// unlimited.
 	maxExpandMB int
 
+	// since and until bound the render in time. Each accepts an RFC3339
+	// timestamp, a local date or date-time (2026-09-07, 2026-09-07 14:00), a
+	// local time of day on the transcript's last day (14:00), or a duration
+	// back from the transcript's last record (2h, 45m).
+	since string
+	until string
+
 	// listCommand is the copy-pasteable command that lists this session's
 	// subagents, printed in the render's footer. Set by the calling command,
 	// which knows its own name and the ID the user typed.
@@ -143,7 +152,42 @@ func (o transcriptPrintOptions) validate() error {
 	if o.maxExpandMB < 0 {
 		return stacktrace.NewError("--%s must be zero (unlimited) or positive", maxExpandMBFlagName)
 	}
+	if (o.since != "" || o.until != "") && (o.listAgents || o.workflowID != "") {
+		return stacktrace.NewError("--%s/--%s apply to a transcript render, not to --%s or --%s", sinceFlagName, untilFlagName, agentsFlagName, workflowFlagName)
+	}
 	return nil
+}
+
+// timeWindow resolves the --since/--until flags against the transcript being
+// printed. Relative forms need the transcript's last timestamp, which costs a
+// pass over the file, so it is read only when one is used.
+func (o transcriptPrintOptions) timeWindow(jsonlFilepath string) (time.Time, time.Time, error) {
+	if o.since == "" && o.until == "" {
+		return time.Time{}, time.Time{}, nil
+	}
+	var reference time.Time
+	if needsReference(o.since) || needsReference(o.until) {
+		stats, err := session.SummarizeTranscript(jsonlFilepath)
+		if err != nil {
+			return time.Time{}, time.Time{}, stacktrace.Propagate(err, "failed to read the transcript's last timestamp for a relative --%s/--%s", sinceFlagName, untilFlagName)
+		}
+		if reference, err = time.Parse(time.RFC3339Nano, stats.LastTimestamp); err != nil {
+			return time.Time{}, time.Time{}, stacktrace.NewError("the transcript has no timestamped record to anchor a relative --%s/--%s", sinceFlagName, untilFlagName)
+		}
+		reference = reference.Local()
+	}
+	since, err := parseTimeBound(o.since, reference, false)
+	if err != nil {
+		return time.Time{}, time.Time{}, stacktrace.Propagate(err, "invalid --%s", sinceFlagName)
+	}
+	until, err := parseTimeBound(o.until, reference, true)
+	if err != nil {
+		return time.Time{}, time.Time{}, stacktrace.Propagate(err, "invalid --%s", untilFlagName)
+	}
+	if !since.IsZero() && !until.IsZero() && until.Before(since) {
+		return time.Time{}, time.Time{}, stacktrace.NewError("--%s %s is before --%s %s", untilFlagName, until.Format(time.RFC3339), sinceFlagName, since.Format(time.RFC3339))
+	}
+	return since, until, nil
 }
 
 // formatOptions converts the CLI flags into renderer options.
@@ -196,6 +240,11 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 		}
 		return printWorkflowRun(run, opts, stdout, stderr)
 	}
+	since, until, err := opts.timeWindow(jsonlFilepath)
+	if err != nil {
+		return err
+	}
+
 	target := root
 	if opts.agentID != "" {
 		target, err = session.ResolveAgent(root, opts.agentID)
@@ -207,11 +256,13 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 	cw := &countingWriter{w: stdout}
 	switch opts.format {
 	case textFormat:
-		if err := session.FormatTranscript(target, opts.formatOptions(root), cw); err != nil {
+		formatOpts := opts.formatOptions(root)
+		formatOpts.Since, formatOpts.Until = since, until
+		if err := session.FormatTranscript(target, formatOpts, cw); err != nil {
 			return stacktrace.Propagate(err, "")
 		}
 	case jsonlFormat:
-		if err := writeRawJSONL(target, opts, cw); err != nil {
+		if err := writeRawJSONL(target, opts, since, until, cw); err != nil {
 			return stacktrace.Propagate(err, "")
 		}
 	}
@@ -226,13 +277,17 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 // --expand-agents it concatenates the selected transcript and every descendant;
 // the records are self-identifying (each carries sessionId and, for subagents,
 // agentId), so a concatenated stream stays attributable.
-func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, w io.Writer) error {
+func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, since time.Time, until time.Time, w io.Writer) error {
 	tail := opts.tailLines
 	if opts.all {
 		tail = 0
 	}
 
-	if _, err := session.TailJSONLFile(target.Filepath, tail, w); err != nil {
+	if !since.IsZero() || !until.IsZero() {
+		if _, err := session.WriteJSONLWindow(target.Filepath, since, until, w); err != nil {
+			return err
+		}
+	} else if _, err := session.TailJSONLFile(target.Filepath, tail, w); err != nil {
 		return err
 	}
 	if !opts.expandAgents {
@@ -318,6 +373,48 @@ func registerTranscriptPrintFlags(cmd *cobra.Command, opts *transcriptPrintOptio
 	flags.StringVar(&opts.workflowID, workflowFlagName, "", "describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name")
 	flags.BoolVar(&opts.jsonOutput, transcriptJSONFlagName, false, "with --agents or --workflow: emit JSON instead of a table")
 	flags.IntVar(&opts.maxExpandMB, maxExpandMBFlagName, defaultMaxExpandMB, "stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited)")
+	flags.StringVar(&opts.since, sinceFlagName, "", "only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record)")
+	flags.StringVar(&opts.until, untilFlagName, "", "only records at or before this time; same forms as --since")
+}
+
+// needsReference reports whether a time bound is relative to the transcript.
+func needsReference(value string) bool {
+	if value == "" {
+		return false
+	}
+	if _, err := time.ParseDuration(value); err == nil {
+		return true
+	}
+	_, err := time.Parse("15:04", value)
+	return err == nil
+}
+
+// parseTimeBound turns one --since/--until value into a time. A bare date
+// means its start for --since and its end for --until, so `--since 2026-09-07
+// --until 2026-09-07` covers the whole day. Layouts without a zone are local.
+func parseTimeBound(value string, reference time.Time, endOfDay bool) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if d, err := time.ParseDuration(value); err == nil {
+		return reference.Add(-d), nil
+	}
+	if t, err := time.Parse("15:04", value); err == nil {
+		y, m, d := reference.Date()
+		return time.Date(y, m, d, t.Hour(), t.Minute(), 0, 0, time.Local), nil
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05", "2006-01-02T15:04", "2006-01-02 15:04:05", "2006-01-02 15:04"} {
+		if t, err := time.ParseInLocation(layout, value, time.Local); err == nil {
+			return t, nil
+		}
+	}
+	if t, err := time.ParseInLocation("2006-01-02", value, time.Local); err == nil {
+		if endOfDay {
+			return t.Add(24*time.Hour - time.Nanosecond), nil
+		}
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("%q is not a time: use RFC3339, '2026-09-07 14:00', '2026-09-07', '14:00' or a duration like '2h'", value)
 }
 
 // formatBytes renders a byte count for a table cell: whole bytes below 1 KB,

--- a/cmd/transcript_print.go
+++ b/cmd/transcript_print.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/odyssey/agenc/internal/session"
-	"github.com/odyssey/agenc/internal/tableprinter"
 )
 
 // A Claude session's transcript is a tree, not a file. The main conversation
@@ -40,6 +39,24 @@ const (
 
 	// maxAgentLabelLen caps the description column in the agent tree listing.
 	maxAgentLabelLen = 60
+
+	// workflowFlagName selects one workflow run; transcriptJSONFlagName switches
+	// the --agents and --workflow views to JSON; maxExpandMBFlagName bounds
+	// what --expand-agents may inline.
+	workflowFlagName       = "workflow"
+	transcriptJSONFlagName = "json"
+	maxExpandMBFlagName    = "max-expand-mb"
+
+	// defaultMaxExpandMB is the --expand-agents budget in subagent JSONL bytes.
+	// Rendered text runs about a tenth of the JSONL it comes from, so 16 MB of
+	// transcripts is roughly 1.6 MB of output — already far past any context
+	// window, and past it by design: the budget exists to stop an accidental
+	// flood, not to size a comfortable read. Past it, an agent is skipped with
+	// a note naming the flag.
+	defaultMaxExpandMB = 16
+
+	// bytesPerMB converts the --max-expand-mb budget to bytes.
+	bytesPerMB = 1024 * 1024
 )
 
 // countingWriter wraps an io.Writer and tracks the number of bytes written. It
@@ -80,6 +97,22 @@ type transcriptPrintOptions struct {
 	// verbose renders every record class, including hooks, turn timings,
 	// attachments, thinking blocks and successful tool results.
 	verbose bool
+
+	// workflowID selects one workflow run to describe: by run ID, ID prefix,
+	// task ID or workflow name.
+	workflowID string
+
+	// jsonOutput switches --agents and --workflow to a JSON document.
+	jsonOutput bool
+
+	// maxExpandMB bounds the subagent bytes --expand-agents may inline; 0 is
+	// unlimited.
+	maxExpandMB int
+
+	// listCommand is the copy-pasteable command that lists this session's
+	// subagents, printed in the render's footer. Set by the calling command,
+	// which knows its own name and the ID the user typed.
+	listCommand string
 }
 
 // validate rejects flag combinations that have no coherent meaning, before any
@@ -97,6 +130,19 @@ func (o transcriptPrintOptions) validate() error {
 	if o.listAgents && o.expandAgents {
 		return stacktrace.NewError("--%s and --%s are mutually exclusive", agentsFlagName, expandAgentsFlagName)
 	}
+	if o.workflowID != "" {
+		for name, set := range map[string]bool{agentsFlagName: o.listAgents, agentFlagName: o.agentID != "", expandAgentsFlagName: o.expandAgents} {
+			if set {
+				return stacktrace.NewError("--%s and --%s are mutually exclusive", workflowFlagName, name)
+			}
+		}
+	}
+	if o.jsonOutput && !o.listAgents && o.workflowID == "" {
+		return stacktrace.NewError("--%s applies to --%s and --%s; for the raw transcript records use --%s=%s", transcriptJSONFlagName, agentsFlagName, workflowFlagName, formatFlagName, jsonlFormat)
+	}
+	if o.maxExpandMB < 0 {
+		return stacktrace.NewError("--%s must be zero (unlimited) or positive", maxExpandMBFlagName)
+	}
 	return nil
 }
 
@@ -107,10 +153,12 @@ func (o transcriptPrintOptions) formatOptions(root *session.Transcript) session.
 		tail = 0
 	}
 	return session.FormatOptions{
-		TailLines:    tail,
-		Verbose:      o.verbose,
-		ExpandAgents: o.expandAgents,
-		Root:         root,
+		TailLines:      tail,
+		Verbose:        o.verbose,
+		ExpandAgents:   o.expandAgents,
+		Root:           root,
+		ListCommand:    o.listCommand,
+		MaxExpandBytes: int64(o.maxExpandMB) * bytesPerMB,
 	}
 }
 
@@ -139,14 +187,20 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 	}
 
 	if opts.listAgents {
-		return printAgentTree(root, stdout, stderr)
+		return printAgentOverview(root, opts, stdout, stderr)
 	}
-
+	if opts.workflowID != "" {
+		run, err := session.ResolveWorkflow(root, opts.workflowID)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to resolve --%s '%s' (--%s lists the runs)", workflowFlagName, opts.workflowID, agentsFlagName)
+		}
+		return printWorkflowRun(run, opts, stdout, stderr)
+	}
 	target := root
 	if opts.agentID != "" {
 		target, err = session.ResolveAgent(root, opts.agentID)
 		if err != nil {
-			return stacktrace.Propagate(err, "failed to resolve --%s '%s'", agentFlagName, opts.agentID)
+			return stacktrace.Propagate(err, "failed to resolve --%s '%s' (--%s lists the agents)", agentFlagName, opts.agentID, agentsFlagName)
 		}
 	}
 
@@ -165,7 +219,6 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 	if cw.count == 0 {
 		fmt.Fprint(stderr, emptySessionMessage)
 	}
-	writeAgentHint(target, opts, stderr)
 	return nil
 }
 
@@ -196,56 +249,6 @@ func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, w io
 			return err
 		}
 	}
-	return nil
-}
-
-// writeAgentHint tells the caller that subagent transcripts exist but were not
-// printed. Without it, a `--all` render looks complete while omitting every
-// subagent — which is exactly the blindness these flags exist to remove.
-func writeAgentHint(target *session.Transcript, opts transcriptPrintOptions, stderr io.Writer) {
-	if opts.expandAgents || opts.agentID != "" {
-		return
-	}
-	hidden := len(target.Flatten()) - 1
-	if hidden <= 0 {
-		return
-	}
-	fmt.Fprintf(stderr,
-		"(%d subagent transcript(s) not shown - --%s to list them, --%s <id> to print one, --%s to inline them)\n",
-		hidden, agentsFlagName, agentFlagName, expandAgentsFlagName)
-}
-
-// printAgentTree lists the session's transcript tree: the main conversation and
-// every subagent below it, indented by nesting depth.
-func printAgentTree(root *session.Transcript, stdout io.Writer, stderr io.Writer) error {
-	nodes := root.Flatten()
-	if len(nodes) <= 1 {
-		fmt.Fprintln(stdout, "No subagent transcripts for this session.")
-		return nil
-	}
-
-	tbl := tableprinter.NewTable("AGENT", "TYPE", "MODEL", "MSGS", "TOOLS", "ERR", "STARTED", "LABEL").WithWriter(stdout)
-	for _, node := range nodes {
-		stats, err := session.SummarizeTranscript(node.Filepath)
-		if err != nil {
-			// A transcript that cannot be read still belongs in the listing —
-			// its absence from the table would read as "this agent does not
-			// exist", which is a different and wrong claim.
-			fmt.Fprintf(stderr, "warning: could not read transcript '%s': %v\n", node.Filepath, err)
-		}
-
-		tbl.AddRow(
-			agentTreeCell(node),
-			agentTypeCell(node),
-			orDash(node.Meta.Model),
-			fmt.Sprintf("%d", stats.UserMessages+stats.AssistantMessages),
-			fmt.Sprintf("%d", stats.ToolCalls),
-			fmt.Sprintf("%d", stats.ToolErrors),
-			formatTranscriptTimestamp(node.StartedAt),
-			truncatePrompt(agentLabelCell(node), maxAgentLabelLen),
-		)
-	}
-	tbl.Print()
 	return nil
 }
 
@@ -312,4 +315,24 @@ func registerTranscriptPrintFlags(cmd *cobra.Command, opts *transcriptPrintOptio
 	flags.StringVar(&opts.agentID, agentFlagName, "", "print a subagent's transcript, by agent ID or unique ID prefix")
 	flags.BoolVar(&opts.expandAgents, expandAgentsFlagName, false, "inline each subagent's transcript at the point it was spawned")
 	flags.BoolVar(&opts.verbose, verboseFlagName, false, "render every record class: hooks, turn timings, attachments, thinking, successful tool results")
+	flags.StringVar(&opts.workflowID, workflowFlagName, "", "describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name")
+	flags.BoolVar(&opts.jsonOutput, transcriptJSONFlagName, false, "with --agents or --workflow: emit JSON instead of a table")
+	flags.IntVar(&opts.maxExpandMB, maxExpandMBFlagName, defaultMaxExpandMB, "stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited)")
+}
+
+// formatBytes renders a byte count for a table cell: whole bytes below 1 KB,
+// one decimal above.
+func formatBytes(n int64) string {
+	const kb, mb, gb = 1024.0, 1024.0 * 1024.0, 1024.0 * 1024.0 * 1024.0
+	f := float64(n)
+	switch {
+	case f >= gb:
+		return fmt.Sprintf("%.1f GB", f/gb)
+	case f >= mb:
+		return fmt.Sprintf("%.1f MB", f/mb)
+	case f >= kb:
+		return fmt.Sprintf("%.1f KB", f/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }

--- a/cmd/transcript_print.go
+++ b/cmd/transcript_print.go
@@ -262,7 +262,7 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 			return stacktrace.Propagate(err, "")
 		}
 	case jsonlFormat:
-		if err := writeRawJSONL(target, opts, since, until, cw); err != nil {
+		if err := writeRawJSONL(target, opts, since, until, cw, stderr); err != nil {
 			return stacktrace.Propagate(err, "")
 		}
 	}
@@ -277,7 +277,7 @@ func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout
 // --expand-agents it concatenates the selected transcript and every descendant;
 // the records are self-identifying (each carries sessionId and, for subagents,
 // agentId), so a concatenated stream stays attributable.
-func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, since time.Time, until time.Time, w io.Writer) error {
+func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, since time.Time, until time.Time, w io.Writer, stderr io.Writer) error {
 	tail := opts.tailLines
 	if opts.all {
 		tail = 0
@@ -294,10 +294,22 @@ func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, sinc
 		return nil
 	}
 
+	// The raw stream is records only, so the expansion budget cannot leave a
+	// note in it; a skipped agent is reported on stderr instead. Silently
+	// emitting 42 MB against a 1 MB budget, as this path once did, is worse
+	// than either.
+	budget := int64(opts.maxExpandMB) * bytesPerMB
+	var emitted int64
 	for _, node := range target.Flatten() {
 		if node == target {
 			continue
 		}
+		if budget > 0 && emitted+node.Bytes > budget {
+			fmt.Fprintf(stderr, "warning: agent %s (%s) not emitted: over the --%s=%d budget; raise it, or print it alone with --%s %s\n",
+				node.AgentID, session.FormatBytes(node.Bytes), maxExpandMBFlagName, opts.maxExpandMB, agentFlagName, node.AgentID)
+			continue
+		}
+		emitted += node.Bytes
 		// Subagent transcripts are emitted whole: a tail of a subagent omits
 		// the prompt that gives its output meaning.
 		if _, err := session.TailJSONLFile(node.Filepath, 0, w); err != nil {
@@ -373,8 +385,8 @@ func registerTranscriptPrintFlags(cmd *cobra.Command, opts *transcriptPrintOptio
 	flags.StringVar(&opts.workflowID, workflowFlagName, "", "describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name")
 	flags.BoolVar(&opts.jsonOutput, transcriptJSONFlagName, false, "with --agents or --workflow: emit JSON instead of a table")
 	flags.IntVar(&opts.maxExpandMB, maxExpandMBFlagName, defaultMaxExpandMB, "stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited)")
-	flags.StringVar(&opts.since, sinceFlagName, "", "only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record)")
-	flags.StringVar(&opts.until, untilFlagName, "", "only records at or before this time; same forms as --since")
+	flags.StringVar(&opts.since, sinceFlagName, "", "only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record); times without a zone are local, while rendered record timestamps are UTC")
+	flags.StringVar(&opts.until, untilFlagName, "", "only records at or before this time; same forms as --since, and a bare date means the end of that day")
 }
 
 // needsReference reports whether a time bound is relative to the transcript.
@@ -410,26 +422,12 @@ func parseTimeBound(value string, reference time.Time, endOfDay bool) (time.Time
 	}
 	if t, err := time.ParseInLocation("2006-01-02", value, time.Local); err == nil {
 		if endOfDay {
-			return t.Add(24*time.Hour - time.Nanosecond), nil
+			// The last instant of the local day, computed from the next
+			// midnight rather than by adding 24 hours: on a DST day the
+			// latter lands an hour early or late.
+			return time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, time.Local).Add(-time.Nanosecond), nil
 		}
 		return t, nil
 	}
 	return time.Time{}, fmt.Errorf("%q is not a time: use RFC3339, '2026-09-07 14:00', '2026-09-07', '14:00' or a duration like '2h'", value)
-}
-
-// formatBytes renders a byte count for a table cell: whole bytes below 1 KB,
-// one decimal above.
-func formatBytes(n int64) string {
-	const kb, mb, gb = 1024.0, 1024.0 * 1024.0, 1024.0 * 1024.0 * 1024.0
-	f := float64(n)
-	switch {
-	case f >= gb:
-		return fmt.Sprintf("%.1f GB", f/gb)
-	case f >= mb:
-		return fmt.Sprintf("%.1f MB", f/mb)
-	case f >= kb:
-		return fmt.Sprintf("%.1f KB", f/kb)
-	default:
-		return fmt.Sprintf("%d B", n)
-	}
 }

--- a/cmd/transcript_print.go
+++ b/cmd/transcript_print.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mieubrisse/stacktrace"
+	"github.com/spf13/cobra"
+
+	"github.com/odyssey/agenc/internal/session"
+	"github.com/odyssey/agenc/internal/tableprinter"
+)
+
+// A Claude session's transcript is a tree, not a file. The main conversation
+// lives in one JSONL; every subagent it spawns writes its own, and those
+// subagents spawn subagents. `session print` and `mission print` share the
+// logic below so that both reach the whole tree and render it identically.
+
+const (
+	// emptySessionMessage is shown when a transcript exists but contains no
+	// renderable content (e.g., only metadata entries from a freshly-spawned
+	// mission that has not yet produced user/assistant messages).
+	emptySessionMessage = "(session has no conversation messages yet)\n"
+
+	// textFormat and jsonlFormat are the accepted --format values.
+	textFormat  = "text"
+	jsonlFormat = "jsonl"
+
+	// mainTranscriptLabel names the session's own transcript in the agent
+	// tree listing, where every other row is a subagent ID.
+	mainTranscriptLabel = "(main)"
+
+	// agentTreeIndent prefixes an agent's ID once per level of nesting so the
+	// listing reads as a tree. The ID itself stays a whole whitespace-delimited
+	// word, so the column is still greppable.
+	agentTreeIndent = "  "
+
+	// maxAgentLabelLen caps the description column in the agent tree listing.
+	maxAgentLabelLen = 60
+)
+
+// countingWriter wraps an io.Writer and tracks the number of bytes written. It
+// lets the print path detect that a renderer produced no output without
+// buffering a potentially huge transcript in memory.
+type countingWriter struct {
+	w     io.Writer
+	count int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.count += int64(n)
+	return n, err
+}
+
+// transcriptPrintOptions holds the flags shared by `session print` and
+// `mission print`.
+type transcriptPrintOptions struct {
+	// tailLines, when > 0, limits output to the last N JSONL records.
+	tailLines int
+
+	// all prints the entire transcript, overriding tailLines.
+	all bool
+
+	// format is textFormat or jsonlFormat.
+	format string
+
+	// listAgents prints the session's subagent tree instead of a transcript.
+	listAgents bool
+
+	// agentID selects a subagent's transcript by ID or unique ID prefix.
+	agentID string
+
+	// expandAgents inlines subagent transcripts at their spawn sites.
+	expandAgents bool
+
+	// verbose renders every record class, including hooks, turn timings,
+	// attachments, thinking blocks and successful tool results.
+	verbose bool
+}
+
+// validate rejects flag combinations that have no coherent meaning, before any
+// file is read, so the user gets the error rather than partial output.
+func (o transcriptPrintOptions) validate() error {
+	if o.format != textFormat && o.format != jsonlFormat {
+		return stacktrace.NewError("invalid --%s %q: must be %q or %q", formatFlagName, o.format, textFormat, jsonlFormat)
+	}
+	if !o.all && o.tailLines < 0 {
+		return stacktrace.NewError("--%s value must be positive", tailFlagName)
+	}
+	if o.listAgents && o.agentID != "" {
+		return stacktrace.NewError("--%s and --%s are mutually exclusive", agentsFlagName, agentFlagName)
+	}
+	if o.listAgents && o.expandAgents {
+		return stacktrace.NewError("--%s and --%s are mutually exclusive", agentsFlagName, expandAgentsFlagName)
+	}
+	return nil
+}
+
+// formatOptions converts the CLI flags into renderer options.
+func (o transcriptPrintOptions) formatOptions(root *session.Transcript) session.FormatOptions {
+	tail := o.tailLines
+	if o.all {
+		tail = 0
+	}
+	return session.FormatOptions{
+		TailLines:    tail,
+		Verbose:      o.verbose,
+		ExpandAgents: o.expandAgents,
+		Root:         root,
+	}
+}
+
+// printTranscript renders a session's transcript to stdout under the given
+// options.
+func printTranscript(jsonlFilepath string, opts transcriptPrintOptions) error {
+	return printTranscriptTo(jsonlFilepath, opts, os.Stdout, os.Stderr)
+}
+
+// printTranscriptTo is the testable core of printTranscript with explicit
+// writers.
+//
+// A transcript may exist but contain only metadata entries (file-history
+// snapshots, mode records) when a freshly-spawned mission has not yet produced
+// any conversation. The renderer writes nothing in that case; rather than
+// return silently, this reports the reason on stderr so a caller piping stdout
+// still sees why it got nothing.
+func printTranscriptTo(jsonlFilepath string, opts transcriptPrintOptions, stdout io.Writer, stderr io.Writer) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	root, err := session.DiscoverTranscriptsForFile(jsonlFilepath)
+	if err != nil {
+		return stacktrace.Propagate(err, "failed to discover transcripts for '%s'", jsonlFilepath)
+	}
+
+	if opts.listAgents {
+		return printAgentTree(root, stdout, stderr)
+	}
+
+	target := root
+	if opts.agentID != "" {
+		target, err = session.ResolveAgent(root, opts.agentID)
+		if err != nil {
+			return stacktrace.Propagate(err, "failed to resolve --%s '%s'", agentFlagName, opts.agentID)
+		}
+	}
+
+	cw := &countingWriter{w: stdout}
+	switch opts.format {
+	case textFormat:
+		if err := session.FormatTranscript(target, opts.formatOptions(root), cw); err != nil {
+			return stacktrace.Propagate(err, "")
+		}
+	case jsonlFormat:
+		if err := writeRawJSONL(target, opts, cw); err != nil {
+			return stacktrace.Propagate(err, "")
+		}
+	}
+
+	if cw.count == 0 {
+		fmt.Fprint(stderr, emptySessionMessage)
+	}
+	writeAgentHint(target, opts, stderr)
+	return nil
+}
+
+// writeRawJSONL emits the raw JSONL for the selected transcript. Under
+// --expand-agents it concatenates the selected transcript and every descendant;
+// the records are self-identifying (each carries sessionId and, for subagents,
+// agentId), so a concatenated stream stays attributable.
+func writeRawJSONL(target *session.Transcript, opts transcriptPrintOptions, w io.Writer) error {
+	tail := opts.tailLines
+	if opts.all {
+		tail = 0
+	}
+
+	if _, err := session.TailJSONLFile(target.Filepath, tail, w); err != nil {
+		return err
+	}
+	if !opts.expandAgents {
+		return nil
+	}
+
+	for _, node := range target.Flatten() {
+		if node == target {
+			continue
+		}
+		// Subagent transcripts are emitted whole: a tail of a subagent omits
+		// the prompt that gives its output meaning.
+		if _, err := session.TailJSONLFile(node.Filepath, 0, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeAgentHint tells the caller that subagent transcripts exist but were not
+// printed. Without it, a `--all` render looks complete while omitting every
+// subagent — which is exactly the blindness these flags exist to remove.
+func writeAgentHint(target *session.Transcript, opts transcriptPrintOptions, stderr io.Writer) {
+	if opts.expandAgents || opts.agentID != "" {
+		return
+	}
+	hidden := len(target.Flatten()) - 1
+	if hidden <= 0 {
+		return
+	}
+	fmt.Fprintf(stderr,
+		"(%d subagent transcript(s) not shown - --%s to list them, --%s <id> to print one, --%s to inline them)\n",
+		hidden, agentsFlagName, agentFlagName, expandAgentsFlagName)
+}
+
+// printAgentTree lists the session's transcript tree: the main conversation and
+// every subagent below it, indented by nesting depth.
+func printAgentTree(root *session.Transcript, stdout io.Writer, stderr io.Writer) error {
+	nodes := root.Flatten()
+	if len(nodes) <= 1 {
+		fmt.Fprintln(stdout, "No subagent transcripts for this session.")
+		return nil
+	}
+
+	tbl := tableprinter.NewTable("AGENT", "TYPE", "MODEL", "MSGS", "TOOLS", "ERR", "STARTED", "LABEL").WithWriter(stdout)
+	for _, node := range nodes {
+		stats, err := session.SummarizeTranscript(node.Filepath)
+		if err != nil {
+			// A transcript that cannot be read still belongs in the listing —
+			// its absence from the table would read as "this agent does not
+			// exist", which is a different and wrong claim.
+			fmt.Fprintf(stderr, "warning: could not read transcript '%s': %v\n", node.Filepath, err)
+		}
+
+		tbl.AddRow(
+			agentTreeCell(node),
+			agentTypeCell(node),
+			orDash(node.Meta.Model),
+			fmt.Sprintf("%d", stats.UserMessages+stats.AssistantMessages),
+			fmt.Sprintf("%d", stats.ToolCalls),
+			fmt.Sprintf("%d", stats.ToolErrors),
+			formatTranscriptTimestamp(node.StartedAt),
+			truncatePrompt(agentLabelCell(node), maxAgentLabelLen),
+		)
+	}
+	tbl.Print()
+	return nil
+}
+
+// agentTreeCell renders the AGENT column: the main transcript's placeholder, or
+// a subagent ID indented once per level of nesting.
+func agentTreeCell(node *session.Transcript) string {
+	if node.IsMain() {
+		return mainTranscriptLabel
+	}
+	return strings.Repeat(agentTreeIndent, node.Depth-1) + node.AgentID
+}
+
+// agentTypeCell renders the TYPE column, flagging the two states that explain
+// an otherwise confusing tree: a subagent whose parent transcript is missing,
+// and one whose sidecar metadata was never written.
+func agentTypeCell(node *session.Transcript) string {
+	if node.IsMain() {
+		return "session"
+	}
+	suffix := ""
+	if node.Orphaned {
+		suffix = " (orphaned)"
+	} else if !node.MetaFound {
+		suffix = " (no metadata)"
+	}
+	return node.Meta.DisplayType() + suffix
+}
+
+// agentLabelCell renders the LABEL column: the agent's name or the description
+// its spawner wrote.
+func agentLabelCell(node *session.Transcript) string {
+	if node.IsMain() {
+		return ""
+	}
+	return node.Meta.DisplayLabel()
+}
+
+// formatTranscriptTimestamp renders a JSONL ISO-8601 timestamp in local time,
+// falling back to the raw value when it does not parse.
+func formatTranscriptTimestamp(timestamp string) string {
+	if timestamp == "" {
+		return "-"
+	}
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return timestamp
+	}
+	return parsed.Local().Format("2006-01-02 15:04")
+}
+
+// orDash substitutes a placeholder for an empty table cell.
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// registerTranscriptPrintFlags adds the transcript-tree flags shared by
+// `session print` and `mission print` to a command.
+func registerTranscriptPrintFlags(cmd *cobra.Command, opts *transcriptPrintOptions) {
+	flags := cmd.Flags()
+	flags.BoolVar(&opts.listAgents, agentsFlagName, false, "list the session's subagent transcripts instead of printing a conversation")
+	flags.StringVar(&opts.agentID, agentFlagName, "", "print a subagent's transcript, by agent ID or unique ID prefix")
+	flags.BoolVar(&opts.expandAgents, expandAgentsFlagName, false, "inline each subagent's transcript at the point it was spawned")
+	flags.BoolVar(&opts.verbose, verboseFlagName, false, "render every record class: hooks, turn timings, attachments, thinking, successful tool results")
+}

--- a/cmd/transcript_print_test.go
+++ b/cmd/transcript_print_test.go
@@ -393,8 +393,18 @@ func TestPrintTranscriptTellsTheCallerAboutUnprintedSubagents(t *testing.T) {
 		t.Fatalf("printTranscriptTo: %v", err)
 	}
 
-	if !strings.Contains(stderr.String(), "1 subagent transcript(s) not shown") {
-		t.Errorf("expected a hint on stderr, got %q", stderr.String())
+	// The footer is on STDOUT and carries the exact command: a caller that
+	// captured only stdout, and never read --help, still learns the next step.
+	opts.listCommand = "agenc session print 11111111 --agents"
+	stdout.Reset()
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "[SUBAGENTS] 1 transcript(s) not shown: 1 spawned directly - --agents to list them, --agent <id> or --workflow <id> to open one - agenc session print 11111111 --agents") {
+		t.Errorf("expected the footer on stdout, got %q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "not shown") {
+		t.Errorf("the hint moved to stdout; stderr must not repeat it, got %q", stderr.String())
 	}
 	if strings.Contains(stdout.String(), "SUBAGENT PROMPT TEXT") {
 		t.Errorf("the default render should not inline subagents")
@@ -413,8 +423,8 @@ func TestPrintTranscriptDoesNotHintWhenSubagentsAreShown(t *testing.T) {
 	if !strings.Contains(stdout.String(), "SUBAGENT PROMPT TEXT") {
 		t.Fatalf("--expand-agents should inline the subagent, got %q", stdout.String())
 	}
-	if strings.Contains(stderr.String(), "not shown") {
-		t.Errorf("no hint should be printed once subagents are inlined, got %q", stderr.String())
+	if strings.Contains(stdout.String()+stderr.String(), "not shown") {
+		t.Errorf("no footer should be printed once subagents are inlined, got %q", stdout.String())
 	}
 }
 

--- a/cmd/transcript_print_test.go
+++ b/cmd/transcript_print_test.go
@@ -1,0 +1,579 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/odyssey/agenc/internal/session"
+)
+
+// ansiEscapeByte is the byte every ANSI escape sequence starts with. Command
+// output is consumed by agents, so a colour code in a table cell breaks a
+// comparison silently — see the no-ANSI convention in CLAUDE.md.
+const ansiEscapeByte = "\033"
+
+// writeFakeSession lays out a Claude project directory the way Claude Code
+// does: a main transcript plus a subagents directory beside it. It returns the
+// main transcript's path, which is what the print path is handed.
+func writeFakeSession(t *testing.T, mainLines []string, agents map[string][2]string) string {
+	t.Helper()
+	projectDir := t.TempDir()
+	sessionID := "11111111-2222-3333-4444-555555555555"
+
+	mainFilepath := filepath.Join(projectDir, sessionID+".jsonl")
+	if err := os.WriteFile(mainFilepath, []byte(strings.Join(mainLines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write main transcript: %v", err)
+	}
+
+	if len(agents) > 0 {
+		subagentsDir := filepath.Join(projectDir, sessionID, "subagents")
+		if err := os.MkdirAll(subagentsDir, 0755); err != nil {
+			t.Fatalf("mkdir subagents: %v", err)
+		}
+		for agentID, pair := range agents {
+			transcript, meta := pair[0], pair[1]
+			if err := os.WriteFile(filepath.Join(subagentsDir, "agent-"+agentID+".jsonl"), []byte(transcript+"\n"), 0644); err != nil {
+				t.Fatalf("write agent transcript: %v", err)
+			}
+			if meta == "" {
+				continue
+			}
+			if err := os.WriteFile(filepath.Join(subagentsDir, "agent-"+agentID+".meta.json"), []byte(meta), 0644); err != nil {
+				t.Fatalf("write agent meta: %v", err)
+			}
+		}
+	}
+	return mainFilepath
+}
+
+func fakeUserLine(timestamp string, text string) string {
+	encoded, _ := json.Marshal(text)
+	return `{"type":"user","timestamp":"` + timestamp + `","message":{"role":"user","content":` + string(encoded) + `}}`
+}
+
+// sessionWithOneAgent is the fixture the print tests share: a main transcript
+// that spawns one Explore subagent, plus that subagent's transcript.
+//
+// The subagent's transcript deliberately carries a DIFFERENT number of
+// messages, tool calls and tool errors, and a start time an hour after the
+// session's. A fixture where those counts coincide makes a right answer and a
+// wrong answer render identically, so swapping two columns would pass.
+func sessionWithOneAgent(t *testing.T) string {
+	t.Helper()
+	return writeFakeSession(t,
+		[]string{
+			fakeUserLine("2026-01-01T00:00:00.000Z", "do the thing"),
+			`{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"scout the repo","subagent_type":"Explore"}}]}}`,
+		},
+		map[string][2]string{
+			"aa8d6202c85e084d7": {
+				strings.Join([]string{
+					fakeUserLine("2026-01-01T01:00:10.000Z", "SUBAGENT PROMPT TEXT"),
+					// 3 tool calls, 2 tool errors, 4 assistant + 3 user messages.
+					`{"type":"assistant","uuid":"s1","timestamp":"2026-01-01T01:00:11.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}},{"type":"tool_use","name":"Read","input":{"file_path":"/x"}}]}}`,
+					`{"type":"user","uuid":"s2","timestamp":"2026-01-01T01:00:12.000Z","message":{"role":"user","content":[{"type":"tool_result","is_error":true,"content":"boom one"}]}}`,
+					`{"type":"assistant","uuid":"s3","timestamp":"2026-01-01T01:00:13.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Glob","input":{"pattern":"*.go"}}]}}`,
+					`{"type":"user","uuid":"s4","timestamp":"2026-01-01T01:00:14.000Z","message":{"role":"user","content":[{"type":"tool_result","is_error":true,"content":"boom two"}]}}`,
+					`{"type":"assistant","uuid":"s5","timestamp":"2026-01-01T01:00:15.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`,
+					`{"type":"assistant","uuid":"s6","timestamp":"2026-01-01T01:00:16.000Z","message":{"role":"assistant","content":[{"type":"text","text":"really done"}]}}`,
+				}, "\n"),
+				`{"agentType":"Explore","description":"scout the repo","toolUseId":"toolu_1","spawnDepth":1,"model":"haiku"}`,
+			},
+		})
+}
+
+func TestTranscriptPrintOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    transcriptPrintOptions
+		wantErr string
+	}{
+		{
+			name: "text format is valid",
+			opts: transcriptPrintOptions{format: textFormat, all: true},
+		},
+		{
+			name: "jsonl format is valid",
+			opts: transcriptPrintOptions{format: jsonlFormat, all: true},
+		},
+		{
+			name:    "unknown format",
+			opts:    transcriptPrintOptions{format: "yaml", all: true},
+			wantErr: "invalid --format",
+		},
+		{
+			name:    "negative tail",
+			opts:    transcriptPrintOptions{format: textFormat, tailLines: -1},
+			wantErr: "must be positive",
+		},
+		{
+			name:    "agents and agent together",
+			opts:    transcriptPrintOptions{format: textFormat, all: true, listAgents: true, agentID: "abc"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "agents and expand-agents together",
+			opts:    transcriptPrintOptions{format: textFormat, all: true, listAgents: true, expandAgents: true},
+			wantErr: "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPrintTranscriptListsTheAgentTree(t *testing.T) {
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, listAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+	got := stdout.String()
+
+	for _, want := range []string{"AGENT", "TYPE", mainTranscriptLabel, "aa8d6202c85e084d7", "Explore", "haiku", "scout the repo"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("agent tree missing %q\n%s", want, got)
+		}
+	}
+
+	// Assert the numbers by position on the subagent's row. Checking that the
+	// digits appear somewhere in the table would pass with two columns swapped.
+	row := rowContaining(t, got, "aa8d6202c85e084d7")
+	// AGENT TYPE MODEL MSGS TOOLS ERR STARTED(date time) LABEL...
+	if len(row) < 8 {
+		t.Fatalf("subagent row has %d fields, want at least 8: %q", len(row), row)
+	}
+	if row[3] != "7" {
+		t.Errorf("MSGS = %q, want 7 (3 user + 4 assistant): %q", row[3], row)
+	}
+	if row[4] != "3" {
+		t.Errorf("TOOLS = %q, want 3: %q", row[4], row)
+	}
+	if row[5] != "2" {
+		t.Errorf("ERR = %q, want 2: %q", row[5], row)
+	}
+	if !strings.HasPrefix(row[6], "2026-01-01") {
+		t.Errorf("STARTED = %q, want the subagent's own start date: %q", row[6], row)
+	}
+}
+
+// rowContaining returns the whitespace-split fields of the single table row
+// holding the given token, failing the test when it is absent or ambiguous.
+func rowContaining(t *testing.T, table string, token string) []string {
+	t.Helper()
+	var found []string
+	matches := 0
+	for _, line := range strings.Split(table, "\n") {
+		if strings.Contains(line, token) {
+			matches++
+			found = strings.Fields(line)
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("expected exactly one row containing %q, found %d\n%s", token, matches, table)
+	}
+	return found
+}
+
+func TestPrintAgentTreeIndentsByNestingDepth(t *testing.T) {
+	// The AGENT column encodes the tree by indenting once per level. With only
+	// depth-1 agents in a fixture, removing the indentation entirely changes
+	// nothing, so the tree shape needs a nested agent to be observable.
+	mainFilepath := writeFakeSession(t,
+		[]string{fakeUserLine("2026-01-01T00:00:00.000Z", "go")},
+		map[string][2]string{
+			"aparent": {
+				fakeUserLine("2026-01-01T00:01:00.000Z", "parent"),
+				`{"agentType":"Explore"}`,
+			},
+			"achild": {
+				fakeUserLine("2026-01-01T00:02:00.000Z", "child"),
+				`{"agentType":"general-purpose","parentAgentId":"aparent"}`,
+			},
+		})
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, listAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	var parentIndent, childIndent int
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		switch {
+		case strings.Contains(line, "aparent"):
+			parentIndent = len(line) - len(strings.TrimLeft(line, " "))
+		case strings.Contains(line, "achild"):
+			childIndent = len(line) - len(strings.TrimLeft(line, " "))
+		}
+	}
+	if childIndent <= parentIndent {
+		t.Errorf("a nested agent must be indented deeper than its parent: parent=%d child=%d\n%s",
+			parentIndent, childIndent, stdout.String())
+	}
+}
+
+func TestPrintAgentTreeFlagsAgentsThatNeedExplaining(t *testing.T) {
+	// An agent whose parent transcript is missing, and one whose sidecar was
+	// never written, both sit flush with real siblings. Without a marker the
+	// tree silently misrepresents where they came from.
+	mainFilepath := writeFakeSession(t,
+		[]string{fakeUserLine("2026-01-01T00:00:00.000Z", "go")},
+		map[string][2]string{
+			"aorphan":   {fakeUserLine("2026-01-01T00:01:00.000Z", "x"), `{"agentType":"Explore","parentAgentId":"agone"}`},
+			"abaremeta": {fakeUserLine("2026-01-01T00:02:00.000Z", "y"), ""},
+			"aforked":   {fakeUserLine("2026-01-01T00:03:00.000Z", "z"), `{"agentType":"general-purpose","isFork":true}`},
+		})
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, listAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+	got := stdout.String()
+
+	for _, want := range []string{"(orphaned)", "(no metadata)", "(fork)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("agent tree missing the %s marker\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintTranscriptPassesVerboseThroughToTheRenderer(t *testing.T) {
+	// --verbose is registered, documented and tested at the library level, but
+	// nothing crossed the CLI boundary — the whole flag could have been dead in
+	// the shipped binary with every test still green.
+	mainFilepath := writeFakeSession(t,
+		[]string{
+			fakeUserLine("2026-01-01T00:00:00.000Z", "go"),
+			`{"type":"assistant","uuid":"a1","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"WEIGHING THE OPTIONS"},{"type":"text","text":"answer"}]}}`,
+		}, nil)
+
+	var quietOut, quietErr bytes.Buffer
+	if err := printTranscriptTo(mainFilepath, transcriptPrintOptions{format: textFormat, all: true}, &quietOut, &quietErr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+	var verboseOut, verboseErr bytes.Buffer
+	if err := printTranscriptTo(mainFilepath, transcriptPrintOptions{format: textFormat, all: true, verbose: true}, &verboseOut, &verboseErr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	if strings.Contains(quietOut.String(), "WEIGHING THE OPTIONS") {
+		t.Errorf("thinking must be hidden without --verbose\n%s", quietOut.String())
+	}
+	if !strings.Contains(verboseOut.String(), "WEIGHING THE OPTIONS") {
+		t.Errorf("--verbose must reach the renderer\n%s", verboseOut.String())
+	}
+}
+
+func TestPrintTranscriptAllOverridesTail(t *testing.T) {
+	// Every other test passes all:true with tailLines:0, where the override is
+	// a no-op — so deleting it changed nothing.
+	mainFilepath := writeFakeSession(t,
+		[]string{
+			fakeUserLine("2026-01-01T00:00:00.000Z", "THE FIRST TURN"),
+			fakeUserLine("2026-01-01T00:00:01.000Z", "the second turn"),
+			fakeUserLine("2026-01-01T00:00:02.000Z", "the third turn"),
+		}, nil)
+
+	for _, format := range []string{textFormat, jsonlFormat} {
+		t.Run(format, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			opts := transcriptPrintOptions{format: format, all: true, tailLines: 1}
+			if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+				t.Fatalf("printTranscriptTo: %v", err)
+			}
+			if !strings.Contains(stdout.String(), "THE FIRST TURN") {
+				t.Errorf("--all must override --tail, got %q", stdout.String())
+			}
+		})
+	}
+}
+
+// The agent tree is command output, not TUI chrome, so it must carry no ANSI
+// escapes. It cannot be covered by the e2e ANSI sweep, which has no session
+// transcripts to render, so this is the check that holds it.
+func TestPrintAgentTreeEmitsNoAnsi(t *testing.T) {
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, listAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	// Positive control: a table that rendered nothing would also contain no
+	// escape byte, so assert the rows are actually there first.
+	if !strings.Contains(stdout.String(), "aa8d6202c85e084d7") {
+		t.Fatalf("agent tree did not render its rows, so the ANSI check would inspect nothing:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), ansiEscapeByte) {
+		t.Errorf("agent tree must not emit ANSI escapes, got %q", stdout.String())
+	}
+}
+
+func TestPrintAgentTreeSaysSoWhenThereAreNoSubagents(t *testing.T) {
+	mainFilepath := writeFakeSession(t, []string{fakeUserLine("2026-01-01T00:00:00.000Z", "hi")}, nil)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, listAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "No subagent transcripts") {
+		t.Errorf("expected an explicit empty-state line, got %q", stdout.String())
+	}
+}
+
+func TestPrintTranscriptSelectsASubagentByIDPrefix(t *testing.T) {
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, agentID: "aa8d6202"}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "SUBAGENT PROMPT TEXT") {
+		t.Errorf("expected the subagent's transcript, got %q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "do the thing") {
+		t.Errorf("--agent should print the subagent only, not the main transcript")
+	}
+}
+
+func TestPrintTranscriptReportsAnUnknownAgent(t *testing.T) {
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, agentID: "nosuchagent"}
+	err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr)
+
+	if err == nil {
+		t.Fatal("expected an error for an unknown agent ID")
+	}
+	if !strings.Contains(err.Error(), "nosuchagent") {
+		t.Errorf("error should name the requested ID, got %v", err)
+	}
+}
+
+func TestPrintTranscriptTellsTheCallerAboutUnprintedSubagents(t *testing.T) {
+	// The default render omits subagents. Saying nothing would let a --all
+	// print look complete while hiding everything the subagents did, which is
+	// the blindness these flags exist to remove.
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "1 subagent transcript(s) not shown") {
+		t.Errorf("expected a hint on stderr, got %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "SUBAGENT PROMPT TEXT") {
+		t.Errorf("the default render should not inline subagents")
+	}
+}
+
+func TestPrintTranscriptDoesNotHintWhenSubagentsAreShown(t *testing.T) {
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: textFormat, all: true, expandAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "SUBAGENT PROMPT TEXT") {
+		t.Fatalf("--expand-agents should inline the subagent, got %q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "not shown") {
+		t.Errorf("no hint should be printed once subagents are inlined, got %q", stderr.String())
+	}
+}
+
+func TestPrintTranscriptJSONLExpansionConcatenatesEveryTranscript(t *testing.T) {
+	mainFilepath := sessionWithOneAgent(t)
+
+	var stdout, stderr bytes.Buffer
+	opts := transcriptPrintOptions{format: jsonlFormat, all: true, expandAgents: true}
+	if err := printTranscriptTo(mainFilepath, opts, &stdout, &stderr); err != nil {
+		t.Fatalf("printTranscriptTo: %v", err)
+	}
+	got := stdout.String()
+
+	if !strings.Contains(got, "do the thing") || !strings.Contains(got, "SUBAGENT PROMPT TEXT") {
+		t.Errorf("expected main and subagent records in the stream, got %q", got)
+	}
+	for i, line := range strings.Split(strings.TrimSpace(got), "\n") {
+		var probe map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &probe); err != nil {
+			t.Errorf("line %d is not valid JSON: %v", i, err)
+		}
+	}
+}
+
+// stubSessionResolver stands in for the server's session-ID resolution.
+type stubSessionResolver struct {
+	resolved string
+	err      error
+}
+
+func (s stubSessionResolver) ResolveSessionID(id string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.resolved, nil
+}
+
+func TestResolveMissionSessionJSONLWithoutTheFlagTakesTheMostRecent(t *testing.T) {
+	projectDir := t.TempDir()
+	older := filepath.Join(projectDir, "aaaaaaaa-0000-0000-0000-000000000000.jsonl")
+	newer := filepath.Join(projectDir, "bbbbbbbb-0000-0000-0000-000000000000.jsonl")
+	for _, path := range []string{older, newer} {
+		if err := os.WriteFile(path, []byte(fakeUserLine("2026-01-01T00:00:00.000Z", "hi")+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// FindActiveJSONLPath picks by modification time, so make the ordering explicit.
+	touchOlder(t, older)
+
+	got, err := resolveMissionSessionJSONL(stubSessionResolver{}, projectDir, "mission-1", "")
+	if err != nil {
+		t.Fatalf("resolveMissionSessionJSONL: %v", err)
+	}
+
+	if got != newer {
+		t.Errorf("got %q, want the most recently modified transcript %q", got, newer)
+	}
+}
+
+func TestResolveMissionSessionJSONLWithTheFlagPicksThatSession(t *testing.T) {
+	projectDir := t.TempDir()
+	target := "cccccccc-0000-0000-0000-000000000000"
+	if err := os.WriteFile(filepath.Join(projectDir, target+".jsonl"), []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveMissionSessionJSONL(stubSessionResolver{resolved: target}, projectDir, "mission-1", "cccccccc")
+	if err != nil {
+		t.Fatalf("resolveMissionSessionJSONL: %v", err)
+	}
+
+	if filepath.Base(got) != target+".jsonl" {
+		t.Errorf("got %q, want the transcript for session %s", got, target)
+	}
+}
+
+func TestResolveMissionSessionJSONLRejectsASessionFromAnotherMission(t *testing.T) {
+	// The server resolves session IDs globally. Printing another mission's
+	// transcript under this mission's ID would be a wrong answer that looks
+	// like a right one.
+	projectDir := t.TempDir()
+
+	_, err := resolveMissionSessionJSONL(stubSessionResolver{resolved: "dddddddd-0000-0000-0000-000000000000"}, projectDir, "mission-1", "dddddddd")
+
+	if err == nil {
+		t.Fatal("expected an error when the session has no transcript in this mission")
+	}
+	if !strings.Contains(err.Error(), "mission-1") {
+		t.Errorf("error should name the mission, got %v", err)
+	}
+}
+
+func TestWarnOnUnprintedSessions(t *testing.T) {
+	projectDir := t.TempDir()
+	var paths []string
+	for _, id := range []string{"aaaaaaaa-0000-0000-0000-000000000000", "bbbbbbbb-0000-0000-0000-000000000000"} {
+		path := filepath.Join(projectDir, id+".jsonl")
+		if err := os.WriteFile(path, []byte(fakeUserLine("2026-01-01T00:00:00.000Z", "hi")+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, path)
+	}
+	// ListSessionIDs skips transcripts with no conversation records, so the
+	// fixture above deliberately writes a real user message into both.
+	if got := len(session.ListSessionIDs(projectDir)); got != 2 {
+		t.Fatalf("fixture should expose 2 sessions, got %d", got)
+	}
+
+	t.Run("warns when other sessions exist", func(t *testing.T) {
+		var stderr bytes.Buffer
+		warnOnUnprintedSessions(projectDir, paths[1], "", &stderr)
+		if !strings.Contains(stderr.String(), "mission has 2 sessions") {
+			t.Errorf("expected a multi-session warning, got %q", stderr.String())
+		}
+	})
+
+	t.Run("stays quiet when the caller chose the session", func(t *testing.T) {
+		var stderr bytes.Buffer
+		warnOnUnprintedSessions(projectDir, paths[1], "bbbbbbbb", &stderr)
+		if stderr.Len() != 0 {
+			t.Errorf("expected no warning when --session was given, got %q", stderr.String())
+		}
+	})
+
+	t.Run("stays quiet for a single-session mission", func(t *testing.T) {
+		single := t.TempDir()
+		if err := os.WriteFile(filepath.Join(single, "eeeeeeee-0000-0000-0000-000000000000.jsonl"),
+			[]byte(fakeUserLine("2026-01-01T00:00:00.000Z", "hi")+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		var stderr bytes.Buffer
+		warnOnUnprintedSessions(single, filepath.Join(single, "eeeeeeee-0000-0000-0000-000000000000.jsonl"), "", &stderr)
+		if stderr.Len() != 0 {
+			t.Errorf("expected no warning for a single-session mission, got %q", stderr.String())
+		}
+	})
+}
+
+func TestFormatTranscriptTimestamp(t *testing.T) {
+	if got := formatTranscriptTimestamp(""); got != "-" {
+		t.Errorf("empty timestamp = %q, want %q", got, "-")
+	}
+	if got := formatTranscriptTimestamp("not a timestamp"); got != "not a timestamp" {
+		t.Errorf("unparseable timestamp should pass through, got %q", got)
+	}
+	if got := formatTranscriptTimestamp("2026-01-01T00:00:00.000Z"); !strings.HasPrefix(got, "202") {
+		t.Errorf("parsed timestamp = %q, want a formatted date", got)
+	}
+}
+
+// touchOlder rewinds a file's modification time so "most recent" is unambiguous.
+func touchOlder(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	older := info.ModTime().Add(-time.Hour)
+	if err := os.Chtimes(path, older, older); err != nil {
+		t.Fatal(fmt.Errorf("chtimes: %w", err))
+	}
+}

--- a/cmd/transcript_window_test.go
+++ b/cmd/transcript_window_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseTimeBoundAcceptsEveryDocumentedForm(t *testing.T) {
+	reference := time.Date(2026, 9, 7, 15, 12, 0, 0, time.Local)
+	cases := []struct {
+		value    string
+		endOfDay bool
+		want     time.Time
+	}{
+		{"2026-09-07T14:00:00Z", false, time.Date(2026, 9, 7, 14, 0, 0, 0, time.UTC)},
+		{"2026-09-07 14:00", false, time.Date(2026, 9, 7, 14, 0, 0, 0, time.Local)},
+		{"2026-09-07T14:00", false, time.Date(2026, 9, 7, 14, 0, 0, 0, time.Local)},
+		{"2026-09-07", false, time.Date(2026, 9, 7, 0, 0, 0, 0, time.Local)},
+		{"2026-09-07", true, time.Date(2026, 9, 7, 23, 59, 59, 999999999, time.Local)},
+		{"14:00", false, time.Date(2026, 9, 7, 14, 0, 0, 0, time.Local)},
+		{"2h", false, reference.Add(-2 * time.Hour)},
+		{"45m", true, reference.Add(-45 * time.Minute)},
+	}
+	for _, c := range cases {
+		got, err := parseTimeBound(c.value, reference, c.endOfDay)
+		if err != nil {
+			t.Errorf("parseTimeBound(%q): %v", c.value, err)
+			continue
+		}
+		if !got.Equal(c.want) {
+			t.Errorf("parseTimeBound(%q) = %s, want %s", c.value, got, c.want)
+		}
+	}
+	if _, err := parseTimeBound("yesterday-ish", reference, false); err == nil || !strings.Contains(err.Error(), "is not a time") || !strings.Contains(err.Error(), "'2h'") {
+		t.Errorf("an unparseable value must name the accepted forms, got %v", err)
+	}
+	if z, _ := parseTimeBound("", reference, false); !z.IsZero() {
+		t.Errorf("empty must be unbounded")
+	}
+}
+
+func TestTimeWindowRelativeFormsAnchorOnTheTranscriptsLastRecord(t *testing.T) {
+	mainFilepath := writeFakeSession(t, []string{
+		fakeUserLine("2026-01-01T10:00:00.000Z", "EARLY"),
+		fakeUserLine("2026-01-01T11:30:00.000Z", "MIDDLE"),
+		fakeUserLine("2026-01-01T12:00:00.000Z", "LAST"),
+	}, nil)
+
+	out, _, err := runPrint(t, mainFilepath, transcriptPrintOptions{all: true, since: "1h"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "MIDDLE") || !strings.Contains(out, "LAST") || strings.Contains(out, "EARLY") {
+		t.Errorf("--since 1h back from 12:00 must keep 11:30 and 12:00 only, got:\n%s", out)
+	}
+
+	out, _, err = runPrint(t, mainFilepath, transcriptPrintOptions{all: true, format: jsonlFormat, since: "2026-01-01T11:00:00Z", until: "2026-01-01T11:59:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(out, "\n") != 1 || !strings.Contains(out, "MIDDLE") {
+		t.Errorf("jsonl window must emit exactly the in-window record, got %q", out)
+	}
+
+	_, _, err = runPrint(t, mainFilepath, transcriptPrintOptions{all: true, since: "2026-01-01T12:00:00Z", until: "2026-01-01T11:00:00Z"})
+	if err == nil || !strings.Contains(err.Error(), "is before --since") {
+		t.Errorf("an inverted window must be refused, got %v", err)
+	}
+	if err := (transcriptPrintOptions{format: textFormat, all: true, since: "1h", listAgents: true}).validate(); err == nil || !strings.Contains(err.Error(), "apply to a transcript render") {
+		t.Errorf("--since with --agents must be refused, got %v", err)
+	}
+}

--- a/cmd/transcript_window_test.go
+++ b/cmd/transcript_window_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 func TestParseTimeBoundAcceptsEveryDocumentedForm(t *testing.T) {
@@ -69,5 +71,55 @@ func TestTimeWindowRelativeFormsAnchorOnTheTranscriptsLastRecord(t *testing.T) {
 	}
 	if err := (transcriptPrintOptions{format: textFormat, all: true, since: "1h", listAgents: true}).validate(); err == nil || !strings.Contains(err.Error(), "apply to a transcript render") {
 		t.Errorf("--since with --agents must be refused, got %v", err)
+	}
+}
+
+func TestUntilBareDateEndsAtTheNextLocalMidnight(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Skip("no tz database")
+	}
+	saved := time.Local
+	time.Local = berlin
+	defer func() { time.Local = saved }()
+
+	for _, day := range []string{"2026-10-25", "2026-03-29", "2026-09-07"} {
+		got, err := parseTimeBound(day, time.Time{}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		y, m, d := got.Date()
+		if got.Format("2006-01-02") != day || got.Hour() != 23 || got.Minute() != 59 || got.Second() != 59 {
+			t.Errorf("--until %s = %s (%d-%02d-%02d), want the last instant of that local day", day, got, y, m, d)
+		}
+	}
+}
+
+func TestWindowImpliesAllUnlessTailWasGiven(t *testing.T) {
+	newCmd := func() (*cobra.Command, *transcriptPrintOptions) {
+		opts := &transcriptPrintOptions{}
+		cmd := &cobra.Command{Use: "print", Run: func(*cobra.Command, []string) {}}
+		cmd.Flags().IntVar(&opts.tailLines, tailFlagName, defaultTailLines, "")
+		registerTranscriptPrintFlags(cmd, opts)
+		return cmd, opts
+	}
+	cmd, opts := newCmd()
+	cmd.SetArgs([]string{"--since", "1h"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	applyWindowDefault(cmd, opts)
+	if !opts.all {
+		t.Errorf("a window with the default tail must print everything inside it")
+	}
+
+	cmd, opts = newCmd()
+	cmd.SetArgs([]string{"--since", "1h", "--tail", "5"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	applyWindowDefault(cmd, opts)
+	if opts.all || opts.tailLines != 5 {
+		t.Errorf("an explicit --tail must still apply: all=%v tail=%d", opts.all, opts.tailLines)
 	}
 }

--- a/docs/cli/agenc_mission_print.md
+++ b/docs/cli/agenc_mission_print.md
@@ -48,9 +48,9 @@ agenc mission print [mission-id] [flags]
       --json                with --agents or --workflow: emit JSON instead of a table
       --max-expand-mb int   stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited) (default 16)
       --session string      print a specific session of the mission, by session ID or short ID
-      --since string        only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record)
+      --since string        only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record); times without a zone are local, while rendered record timestamps are UTC
       --tail int            limit output to last N lines
-      --until string        only records at or before this time; same forms as --since
+      --until string        only records at or before this time; same forms as --since, and a bare date means the end of that day
       --verbose             render every record class: hooks, turn timings, attachments, thinking, successful tool results
       --workflow string     describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name
 ```

--- a/docs/cli/agenc_mission_print.md
+++ b/docs/cli/agenc_mission_print.md
@@ -40,14 +40,19 @@ agenc mission print [mission-id] [flags]
 ### Options
 
 ```
-      --agent string     print a subagent's transcript, by agent ID or unique ID prefix
-      --agents           list the session's subagent transcripts instead of printing a conversation
-      --expand-agents    inline each subagent's transcript at the point it was spawned
-      --format string    output format: text or jsonl (default "text")
-  -h, --help             help for print
-      --session string   print a specific session of the mission, by session ID or short ID
-      --tail int         limit output to last N lines
-      --verbose          render every record class: hooks, turn timings, attachments, thinking, successful tool results
+      --agent string        print a subagent's transcript, by agent ID or unique ID prefix
+      --agents              list the session's subagent transcripts instead of printing a conversation
+      --expand-agents       inline each subagent's transcript at the point it was spawned
+      --format string       output format: text or jsonl (default "text")
+  -h, --help                help for print
+      --json                with --agents or --workflow: emit JSON instead of a table
+      --max-expand-mb int   stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited) (default 16)
+      --session string      print a specific session of the mission, by session ID or short ID
+      --since string        only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record)
+      --tail int            limit output to last N lines
+      --until string        only records at or before this time; same forms as --since
+      --verbose             render every record class: hooks, turn timings, attachments, thinking, successful tool results
+      --workflow string     describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name
 ```
 
 ### SEE ALSO

--- a/docs/cli/agenc_mission_print.md
+++ b/docs/cli/agenc_mission_print.md
@@ -10,6 +10,16 @@ By default, outputs the entire session as human-readable text.
 Use --format=jsonl for raw JSONL output.
 Use --tail to limit output to the last N lines.
 
+A mission accumulates a session per reload, /clear or fork; this prints the most
+recently active one. Use --session to print a different one, and
+'agenc session ls --mission <id>' to list them.
+
+A session is not a single transcript either: every subagent it spawns writes its
+own. --agents lists that tree, --agent prints one subagent's transcript, and
+--expand-agents inlines them all at their spawn sites. --verbose additionally
+renders hooks, turn timings, attachments, thinking blocks and successful tool
+results.
+
 Without arguments, opens an interactive fzf picker to select a mission.
 With arguments, accepts a mission ID (short 8-char hex or full UUID).
 
@@ -18,6 +28,10 @@ Example:
   agenc mission print 2571d5d8
   agenc mission print 2571d5d8 --format=jsonl
   agenc mission print 2571d5d8 --tail 50
+  agenc mission print 2571d5d8 --agents
+  agenc mission print 2571d5d8 --agent aa8d6202
+  agenc mission print 2571d5d8 --expand-agents
+  agenc mission print 2571d5d8 --session 18749fb5
 
 ```
 agenc mission print [mission-id] [flags]
@@ -26,9 +40,14 @@ agenc mission print [mission-id] [flags]
 ### Options
 
 ```
-      --format string   output format: text or jsonl (default "text")
-  -h, --help            help for print
-      --tail int        limit output to last N lines
+      --agent string     print a subagent's transcript, by agent ID or unique ID prefix
+      --agents           list the session's subagent transcripts instead of printing a conversation
+      --expand-agents    inline each subagent's transcript at the point it was spawned
+      --format string    output format: text or jsonl (default "text")
+  -h, --help             help for print
+      --session string   print a specific session of the mission, by session ID or short ID
+      --tail int         limit output to last N lines
+      --verbose          render every record class: hooks, turn timings, attachments, thinking, successful tool results
 ```
 
 ### SEE ALSO

--- a/docs/cli/agenc_session_print.md
+++ b/docs/cli/agenc_session_print.md
@@ -45,9 +45,9 @@ agenc session print <session-id> [flags]
   -h, --help                help for print
       --json                with --agents or --workflow: emit JSON instead of a table
       --max-expand-mb int   stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited) (default 16)
-      --since string        only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record)
+      --since string        only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record); times without a zone are local, while rendered record timestamps are UTC
       --tail int            number of lines to print from end of session (default 20)
-      --until string        only records at or before this time; same forms as --since
+      --until string        only records at or before this time; same forms as --since, and a bare date means the end of that day
       --verbose             render every record class: hooks, turn timings, attachments, thinking, successful tool results
       --workflow string     describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name
 ```

--- a/docs/cli/agenc_session_print.md
+++ b/docs/cli/agenc_session_print.md
@@ -14,12 +14,21 @@ raw JSONL output.
 Outputs the last 20 lines by default. Use --tail to change the line count,
 or --all to print the entire session.
 
+A session is not a single transcript: every subagent it spawns writes its own,
+and those subagents spawn subagents. --agents lists that tree, --agent prints
+one subagent's transcript, and --expand-agents inlines them all at their spawn
+sites. --verbose additionally renders hooks, turn timings, attachments,
+thinking blocks and successful tool results.
+
 Example:
   agenc session print 18749fb5
   agenc session print 18749fb5-02ba-4b19-b989-4e18fbf8ea92
   agenc session print 18749fb5 --format=jsonl
   agenc session print 18749fb5 --tail 50
   agenc session print 18749fb5 --all
+  agenc session print 18749fb5 --agents
+  agenc session print 18749fb5 --agent aa8d6202
+  agenc session print 18749fb5 --all --expand-agents
 
 ```
 agenc session print <session-id> [flags]
@@ -28,10 +37,14 @@ agenc session print <session-id> [flags]
 ### Options
 
 ```
+      --agent string    print a subagent's transcript, by agent ID or unique ID prefix
+      --agents          list the session's subagent transcripts instead of printing a conversation
       --all             print entire session
+      --expand-agents   inline each subagent's transcript at the point it was spawned
       --format string   output format: text or jsonl (default "text")
   -h, --help            help for print
       --tail int        number of lines to print from end of session (default 20)
+      --verbose         render every record class: hooks, turn timings, attachments, thinking, successful tool results
 ```
 
 ### SEE ALSO

--- a/docs/cli/agenc_session_print.md
+++ b/docs/cli/agenc_session_print.md
@@ -37,14 +37,19 @@ agenc session print <session-id> [flags]
 ### Options
 
 ```
-      --agent string    print a subagent's transcript, by agent ID or unique ID prefix
-      --agents          list the session's subagent transcripts instead of printing a conversation
-      --all             print entire session
-      --expand-agents   inline each subagent's transcript at the point it was spawned
-      --format string   output format: text or jsonl (default "text")
-  -h, --help            help for print
-      --tail int        number of lines to print from end of session (default 20)
-      --verbose         render every record class: hooks, turn timings, attachments, thinking, successful tool results
+      --agent string        print a subagent's transcript, by agent ID or unique ID prefix
+      --agents              list the session's subagent transcripts instead of printing a conversation
+      --all                 print entire session
+      --expand-agents       inline each subagent's transcript at the point it was spawned
+      --format string       output format: text or jsonl (default "text")
+  -h, --help                help for print
+      --json                with --agents or --workflow: emit JSON instead of a table
+      --max-expand-mb int   stop --expand-agents inlining past this many MB of subagent transcripts (0 = unlimited) (default 16)
+      --since string        only records at or after this time: RFC3339, '2026-09-07 14:00', '14:00' (on the transcript's last day) or '2h' (back from its last record)
+      --tail int            number of lines to print from end of session (default 20)
+      --until string        only records at or before this time; same forms as --since
+      --verbose             render every record class: hooks, turn timings, attachments, thinking, successful tool results
+      --workflow string     describe one workflow run and list its agents, by run ID, ID prefix, task ID or workflow name
 ```
 
 ### SEE ALSO

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -297,7 +297,9 @@ Directory Structure
 │   ├── session.go                # `session` command group
 │   ├── session_print.go          # `session print` — print a session's transcript
 │   ├── mission_print.go          # `mission print` — print a mission's session transcript
-│   ├── transcript_print.go       # Shared transcript print path: agent tree listing, subagent selection, expansion
+│   ├── transcript_print.go       # Shared transcript print path: option validation, subagent/workflow selection, time window, expansion budget
+│   ├── transcript_overview.go    # `--agents` overview (text and JSON), `--workflow` run view, per-session facts for `session ls --mission`
+│   ├── flag_suggest.go           # "did you mean --x?" on unknown flags, for every command
 │   ├── gendocs/                  # Build-time CLI doc generator
 │   └── genprime/                 # Build-time CLI quick reference generator (agenc prime)
 ├── internal/
@@ -476,7 +478,7 @@ Per-mission Claude child process management.
 
 - `internal/version/` — single `Version` string set via ldflags at build time (`version.go`)
 - `internal/history/` — `FindFirstPrompt` extracts the first user prompt from Claude's `history.jsonl` for a given mission UUID (`history.go`)
-- `internal/session/` — `FindSessionName` resolves a mission's session name from Claude metadata (priority: custom-title > sessions-index.json summary > JSONL summary) (`session.go`), `FindCustomTitle` returns only the /rename custom title (`session.go`), `FindSessionJSONLPath` locates the JSONL transcript file for a session UUID by searching all project directories under `~/.claude/projects/` (`session.go`), `ListSessionIDs` returns all session UUIDs for a mission sorted by modification time (most recent first) by scanning the mission's project directory for `.jsonl` files (`session.go`), `TailJSONLFile` reads the last N lines from a JSONL file and writes them to a given writer, or writes the entire file when N is zero (`session.go`), `ExtractRecentUserMessages` extracts user message contents from session JSONL for AI summarization (`conversation.go`), `ScanJSONLLines` iterates a JSONL file with no per-line size ceiling (`jsonl.go`), `DiscoverSessionTranscripts` / `DiscoverTranscriptsForFile` build a session's transcript tree from the main JSONL plus its subagent sidecar directory, `ResolveAgent` selects one subagent by ID prefix, and `SummarizeTranscript` counts a transcript's records (`transcript.go`), `FormatTranscript` / `FormatTranscriptFile` / `FormatConversation` render a transcript to human-readable text under `FormatOptions` (`format.go`), with the non-conversation record classes rendered by `format_events.go`
+- `internal/session/` — `FindSessionName` resolves a mission's session name from Claude metadata (priority: custom-title > sessions-index.json summary > JSONL summary) (`session.go`), `FindCustomTitle` returns only the /rename custom title (`session.go`), `FindSessionJSONLPath` locates the JSONL transcript file for a session UUID by searching all project directories under `~/.claude/projects/` (`session.go`), `ListSessionIDs` returns all session UUIDs for a mission sorted by modification time (most recent first) by scanning the mission's project directory for `.jsonl` files (`session.go`), `TailJSONLFile` reads the last N lines from a JSONL file and writes them to a given writer, or writes the entire file when N is zero (`session.go`), `ExtractRecentUserMessages` extracts user message contents from session JSONL for AI summarization (`conversation.go`), `ScanJSONLLines` iterates a JSONL file with no per-line size ceiling (`jsonl.go`), `DiscoverSessionTranscripts` / `DiscoverTranscriptsForFile` build a session's transcript tree from the main JSONL, its flat subagent directory and its workflow run directories, `ResolveAgent` selects one subagent by ID prefix, name or description, and `SummarizeTranscript` counts a transcript's records and notes its fork source (`transcript.go`), `WorkflowRun` models one Workflow tool invocation from its manifest, journal and agent directory, with `ResolveWorkflow` and `ReadWorkflowManifestJSON` (`workflow.go`), `WriteJSONLWindow` copies the records inside a time window (`session.go`), `FormatTranscript` / `FormatTranscriptFile` render a transcript to human-readable text under `FormatOptions` — spawn-site anchors, the hidden-transcripts footer, the expansion budget and the time window live here (`format.go`), with the non-conversation record classes rendered by `format_events.go`
 - `internal/sleep/` — sleep mode types and validation (`sleep.go`). Defines `WindowDef` (days + start/end times) and validation functions (`ValidateDays`, `ValidateTime`, `ValidateWindow`). Used by `internal/config/` for config validation and `internal/server/` for the sleep guard middleware.
 - `internal/tableprinter/` — ANSI-aware table formatting using `rodaine/table` with `runewidth` for wide character support (`tableprinter.go`)
 
@@ -491,9 +493,34 @@ A Claude session writes more than one transcript. The main conversation is
 session spawns gets its own transcript beside it, in
 `~/.claude/projects/<encoded-cwd>/<session-id>/subagents/`, written as a pair:
 `agent-<agent-id>.jsonl` and a sidecar `agent-<agent-id>.meta.json`. Subagents
-nest — a subagent can spawn subagents — but the directory stays flat, so the
+nest — a subagent can spawn subagents — but that directory stays flat, so the
 tree is reconstructed from each sidecar's `parentAgentId` rather than from the
 filesystem layout.
+
+Agents spawned by the Workflow tool are written one level down instead, in
+`<session-id>/subagents/workflows/<run-id>/`, beside a `journal.jsonl` that is
+the tool's resume cache (a `started` record per agent; a `result` record only
+for results it cached, so it says nothing about completion). The run's own
+manifest — name, summary, status, duration, token totals, phases, structured
+result, and the task ID its spawn reported — is at
+`<session-id>/workflows/<run-id>.json`. On one long-lived machine that layer
+held 55% of all subagent transcripts; `internal/session/workflow.go` owns it.
+A run is not a node in the agent tree: it has no conversation, and a single run
+can hold hundreds of agents, so runs hang off the session root and their agents
+are reached through the run. Every listing is therefore bounded by the number
+of runs, and a run's row is built from its manifest and directory listing
+without opening an agent transcript. The nested sidecars carry no parent, name
+or `toolUseId`; a run is linked to its spawn site through the manifest's
+`taskId`, which the Workflow tool's `tool_result` reports as `Task ID`. Agent
+counts come from the directory, never the manifest, whose `agentCount`
+disagrees with disk in a third of runs.
+
+Discovery is verified against an independent instrument: a test counts agent
+files with `filepath.WalkDir` and requires discovery to agree, on a nested
+fixture always and, when pointed at a real session or a whole
+`~/.claude/projects`, on the disk. The sweep that first "verified" discovery
+walked directories the same non-recursive way the code did and confirmed the
+bug; an instrument that shares the code's assumptions cannot catch them.
 
 `internal/session/transcript.go` owns that reconstruction. Only the main
 transcript is required; everything below it degrades rather than disappears. A
@@ -509,6 +536,15 @@ A *named* agent gets no `toolUseId` and its spawn's tool result reports
 only link; reused names are disambiguated by start time, and an ambiguous case
 is left unlinked rather than attributed to the wrong call. Anything still
 unlinked is listed explicitly at the end of an expanded render.
+
+The rendered transcript teaches its own drill-down. A spawn line carries an
+anchor naming what it produced and how big it is; a render of the main
+transcript ends with a stdout footer saying how many transcripts were not shown
+and the exact command that lists them; `--agents` is an overview whose rows
+carry sizes; and misses, ambiguity and misspelt flags each answer with the next
+command to type. Expansion never inlines a workflow run and stops past a byte
+budget with a note naming the flag, because the largest session on that machine
+would otherwise render to hundreds of megabytes.
 
 A transcript also carries record types beyond `user` and `assistant` that change
 how the conversation reads: `system/compact_boundary` (everything above it was

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -295,8 +295,9 @@ Directory Structure
 ├── AGENTS.md                     # Agent definitions
 ├── cmd/                          # CLI commands (Cobra); see docs/cli/ for full reference
 │   ├── session.go                # `session` command group
-│   ├── session_print.go          # `session print` — print raw JSONL transcript for a session
-│   ├── mission_print.go          # `mission print` — print JSONL for a mission's current session
+│   ├── session_print.go          # `session print` — print a session's transcript
+│   ├── mission_print.go          # `mission print` — print a mission's session transcript
+│   ├── transcript_print.go       # Shared transcript print path: agent tree listing, subagent selection, expansion
 │   ├── gendocs/                  # Build-time CLI doc generator
 │   └── genprime/                 # Build-time CLI quick reference generator (agenc prime)
 ├── internal/
@@ -308,7 +309,7 @@ Directory Structure
 │   ├── tmux/                     # Tmux keybindings generation
 │   ├── wrapper/                  # Claude child process management
 │   ├── history/                  # Prompt extraction from history.jsonl
-│   ├── session/                  # Session name resolution and transcript access
+│   ├── session/                  # Session name resolution, transcript tree discovery and rendering
 │   ├── version/                  # Build-time version string
 │   └── tableprinter/             # ANSI-aware table formatting
 ├── docs/                         # Documentation
@@ -475,13 +476,48 @@ Per-mission Claude child process management.
 
 - `internal/version/` — single `Version` string set via ldflags at build time (`version.go`)
 - `internal/history/` — `FindFirstPrompt` extracts the first user prompt from Claude's `history.jsonl` for a given mission UUID (`history.go`)
-- `internal/session/` — `FindSessionName` resolves a mission's session name from Claude metadata (priority: custom-title > sessions-index.json summary > JSONL summary) (`session.go`), `FindCustomTitle` returns only the /rename custom title (`session.go`), `FindSessionJSONLPath` locates the JSONL transcript file for a session UUID by searching all project directories under `~/.claude/projects/` (`session.go`), `ListSessionIDs` returns all session UUIDs for a mission sorted by modification time (most recent first) by scanning the mission's project directory for `.jsonl` files (`session.go`), `TailJSONLFile` reads the last N lines from a JSONL file and writes them to a given writer, or writes the entire file when N is zero (`session.go`), `ExtractRecentUserMessages` extracts user message contents from session JSONL for AI summarization (`conversation.go`)
+- `internal/session/` — `FindSessionName` resolves a mission's session name from Claude metadata (priority: custom-title > sessions-index.json summary > JSONL summary) (`session.go`), `FindCustomTitle` returns only the /rename custom title (`session.go`), `FindSessionJSONLPath` locates the JSONL transcript file for a session UUID by searching all project directories under `~/.claude/projects/` (`session.go`), `ListSessionIDs` returns all session UUIDs for a mission sorted by modification time (most recent first) by scanning the mission's project directory for `.jsonl` files (`session.go`), `TailJSONLFile` reads the last N lines from a JSONL file and writes them to a given writer, or writes the entire file when N is zero (`session.go`), `ExtractRecentUserMessages` extracts user message contents from session JSONL for AI summarization (`conversation.go`), `ScanJSONLLines` iterates a JSONL file with no per-line size ceiling (`jsonl.go`), `DiscoverSessionTranscripts` / `DiscoverTranscriptsForFile` build a session's transcript tree from the main JSONL plus its subagent sidecar directory, `ResolveAgent` selects one subagent by ID prefix, and `SummarizeTranscript` counts a transcript's records (`transcript.go`), `FormatTranscript` / `FormatTranscriptFile` / `FormatConversation` render a transcript to human-readable text under `FormatOptions` (`format.go`), with the non-conversation record classes rendered by `format_events.go`
 - `internal/sleep/` — sleep mode types and validation (`sleep.go`). Defines `WindowDef` (days + start/end times) and validation functions (`ValidateDays`, `ValidateTime`, `ValidateWindow`). Used by `internal/config/` for config validation and `internal/server/` for the sleep guard middleware.
 - `internal/tableprinter/` — ANSI-aware table formatting using `rodaine/table` with `runewidth` for wide character support (`tableprinter.go`)
 
 
 Key Architectural Patterns
 --------------------------
+
+### Session transcripts are a tree, not a file
+
+A Claude session writes more than one transcript. The main conversation is
+`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, and every subagent the
+session spawns gets its own transcript beside it, in
+`~/.claude/projects/<encoded-cwd>/<session-id>/subagents/`, written as a pair:
+`agent-<agent-id>.jsonl` and a sidecar `agent-<agent-id>.meta.json`. Subagents
+nest — a subagent can spawn subagents — but the directory stays flat, so the
+tree is reconstructed from each sidecar's `parentAgentId` rather than from the
+filesystem layout.
+
+`internal/session/transcript.go` owns that reconstruction. Only the main
+transcript is required; everything below it degrades rather than disappears. A
+sidecar that is missing, unreadable, names a parent whose transcript is not on
+disk, or forms a cycle attaches its transcript to the session root instead of
+dropping it, because a transcript that exists on disk must be reachable in the
+tree.
+
+Linking a subagent back to the call that spawned it has two paths. The direct
+one is the sidecar's `toolUseId`, matched against the spawning `tool_use` block.
+A *named* agent gets no `toolUseId` and its spawn's tool result reports
+`status: "teammate_spawned"` with no agent ID, so the sidecar's `name` is the
+only link; reused names are disambiguated by start time, and an ambiguous case
+is left unlinked rather than attributed to the wrong call. Anything still
+unlinked is listed explicitly at the end of an expanded render.
+
+A transcript also carries record types beyond `user` and `assistant` that change
+how the conversation reads: `system/compact_boundary` (everything above it was
+dropped from the model's context), a `forkedFrom` reference on every record of a
+forked session, `queue-operation` records holding instructions typed mid-turn,
+and an `origin` field distinguishing a human turn from a peer agent's message or
+a background-task notification. `internal/session/format_events.go` splits these
+by whether a reader who cannot see them would misread the conversation:
+structural events render by default, bookkeeping renders under `--verbose`.
 
 ### Operational settings (State Y)
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -154,7 +154,7 @@ The server runs twelve concurrent background goroutines:
 **7. Idle timeout loop** (`internal/server/idle_timeout.go`)
 - Runs on a fixed interval
 - Scans all non-archived missions for running wrappers
-- Uses the active JSONL conversation log's modification time to determine idle duration, falling back to `created_at`
+- Uses the most recent modification time across every transcript the mission's sessions write — the main conversation log and every subagent transcript beneath it, in both layouts — to determine idle duration, falling back to `created_at`. The main log alone goes quiet for exactly as long as a subagent or workflow run works, which once stopped missions mid-run
 - Stops wrappers idle past the configured threshold and destroys their pool windows
 - Wrappers are automatically re-spawned on the next attach (lazy start)
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rjeczalik/notify v0.9.3
 	github.com/rodaine/table v1.3.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.44.3
@@ -29,7 +30,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect

--- a/internal/claudeconfig/adjutant_claude.md
+++ b/internal/claudeconfig/adjutant_claude.md
@@ -150,6 +150,50 @@ agenc cron ls
 
 **"How do I test a cron before scheduling it?"** — Use `agenc cron run <name>` to trigger it manually. This creates a mission with the same prompt and repo, tracked in history alongside scheduled runs.
 
+Reading Transcripts
+-------------------
+
+`agenc mission print <id>` prints a mission's most recent session transcript;
+`agenc session print <session-id>` prints a specific session. Both accept
+`--tail N`, `--all` and `--format=jsonl`.
+
+**A session is a tree of transcripts, not one file.** Every subagent a session
+spawns writes its own transcript, and those subagents spawn subagents. Printing
+the session alone shows the spawn calls and their one-line results, but none of
+the work the subagents did. The flags that reach the rest:
+
+```
+# List the session's subagent transcripts: type, model, message and tool counts
+agenc session print <id> --agents
+
+# Print one subagent's transcript (agent ID, or any unique prefix of it)
+agenc session print <id> --agent aa8d6202
+
+# Inline every subagent's transcript at the point it was spawned
+agenc session print <id> --all --expand-agents
+```
+
+Both commands print a note on stderr when subagent transcripts exist but were
+not shown, so a plain `--all` never looks complete when it is not.
+
+**Missions accumulate sessions.** A reload, a `/clear` or a fork each start a
+new one. `agenc mission print` shows the most recent and says on stderr how many
+others exist; `agenc session ls --mission <id>` lists them, and
+`agenc mission print <id> --session <session-id>` prints a specific one. A
+session forked from another opens with a `[FORK]` line naming its source.
+
+**What the default render includes beyond the conversation:** compaction
+boundaries (with how many tokens were dropped), the compaction summary labelled
+as such rather than as a user message, message origin (`USER human` vs
+`USER peer:<name>` vs `USER task-notification`), instructions queued while a
+turn was running, slash commands, API errors, killed agents, and failing hooks.
+`--verbose` adds thinking blocks, successful tool results, attachments, turn
+timings and clean hook runs.
+
+**Answering "did the user actually say that?"** — look for `USER human` in the
+transcript. Messages from peer agents and background-task notifications are
+written as user records too, and are indistinguishable without the origin tag.
+
 Sleep Mode
 ----------
 

--- a/internal/claudeconfig/adjutant_claude.md
+++ b/internal/claudeconfig/adjutant_claude.md
@@ -158,27 +158,46 @@ Reading Transcripts
 `--tail N`, `--all` and `--format=jsonl`.
 
 **A session is a tree of transcripts, not one file.** Every subagent a session
-spawns writes its own transcript, and those subagents spawn subagents. Printing
-the session alone shows the spawn calls and their one-line results, but none of
-the work the subagents did. The flags that reach the rest:
+spawns writes its own transcript, and those subagents spawn subagents. Agents
+spawned by the Workflow tool live one level further down, grouped by run — on a
+long-lived machine that layer held more than half of all subagent transcripts.
+Printing the session alone shows the spawn calls with an anchor naming what
+they produced (`[agent <id>]`, `[workflow <run-id> (name): N agents, status,
+duration]`), and ends with a footer saying how many transcripts were not shown
+and the exact command that lists them. Start there:
 
 ```
-# List the session's subagent transcripts: type, model, message and tool counts
+# The overview: session facts, then one row per subagent and ONE row per
+# workflow run, with sizes, so you can decide what you can afford to read
 agenc session print <id> --agents
+agenc session print <id> --agents --json      # same, as a document
 
-# Print one subagent's transcript (agent ID, or any unique prefix of it)
+# One subagent: agent ID, unique ID prefix, its name, or a description fragment
 agenc session print <id> --agent aa8d6202
+agenc session print <id> --agent reviewer-tests
 
-# Inline every subagent's transcript at the point it was spawned
+# One workflow run: status, phases, structured result, then its agents
+agenc session print <id> --workflow 3a23        # run ID prefix, task ID or name
+
+# A time window instead of a tail: RFC3339, '2026-09-07 14:00', '14:00', or
+# '2h' back from the transcript's last record
+agenc session print <id> --since 2h
+agenc session print <id> --since 14:00 --until 15:30 --format=jsonl
+
+# Inline directly spawned subagents at their spawn sites. Workflow runs are
+# never inlined, and inlining stops past --max-expand-mb (default 16) with a
+# note naming the agent, its size and the flag.
 agenc session print <id> --all --expand-agents
 ```
 
-Both commands print a note on stderr when subagent transcripts exist but were
-not shown, so a plain `--all` never looks complete when it is not.
+A miss on `--agent` or `--workflow` says so and names `--agents`; an ambiguous
+key lists every candidate; a misspelt flag suggests the nearest real one.
 
 **Missions accumulate sessions.** A reload, a `/clear` or a fork each start a
 new one. `agenc mission print` shows the most recent and says on stderr how many
-others exist; `agenc session ls --mission <id>` lists them, and
+others exist; `agenc session ls --mission <id>` lists them with when each
+started, its message and tool counts, compactions, which session it was forked
+from, how many subagents it spawned and its size on disk; and
 `agenc mission print <id> --session <session-id>` prints a specific one. A
 session forked from another opens with a `[FORK]` line naming its source.
 

--- a/internal/server/idle_timeout.go
+++ b/internal/server/idle_timeout.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"github.com/odyssey/agenc/internal/claudeconfig"
@@ -16,7 +15,8 @@ const (
 	idleTimeoutCheckInterval = 2 * time.Minute
 
 	// defaultIdleTimeout is how long a mission can be idle before its wrapper
-	// is stopped. Idle means the JSONL conversation log has not been modified.
+	// is stopped. Idle means none of the session's transcripts — the main
+	// conversation log or any subagent's — has been modified.
 	defaultIdleTimeout = 30 * time.Minute
 
 	// staleHeartbeatThreshold is how long after the last heartbeat before a
@@ -124,23 +124,22 @@ func (s *Server) isWrapperRunning(missionID string) bool {
 	return IsProcessRunning(pid)
 }
 
-// missionIdleDuration returns how long a mission has been idle by checking the
-// modification time of the active JSONL conversation log. Claude Code writes to
-// this file whenever it does anything (streaming, tool calls, thinking), so a
-// recently modified file means Claude is actively working.
+// missionIdleDuration returns how long a mission has been idle: the time since
+// any transcript of the mission's sessions was last modified. Claude Code
+// writes to the main conversation log whenever the main agent does anything,
+// and to a subagent's own log while that subagent works — which is exactly
+// when the main log goes quiet, so reading the main log alone once stopped
+// missions in the middle of long subagent and workflow runs.
 //
-// Falls back to created_at if the JSONL file cannot be located (mission has no
+// Falls back to created_at if no transcript can be located (mission has no
 // session yet, or the project directory doesn't exist).
 func (s *Server) missionIdleDuration(m *database.Mission, now time.Time) time.Duration {
 	projectDirpath, err := claudeconfig.GetMissionProjectDirpath(s.agencDirpath, m.ID)
 	if err != nil {
 		return now.Sub(m.CreatedAt)
 	}
-	jsonlFilepath := session.FindActiveJSONLPath(projectDirpath)
-	if jsonlFilepath != "" {
-		if info, err := os.Stat(jsonlFilepath); err == nil {
-			return now.Sub(info.ModTime())
-		}
+	if latest, ok := session.LatestTranscriptActivity(projectDirpath); ok {
+		return now.Sub(latest)
 	}
 	return now.Sub(m.CreatedAt)
 }

--- a/internal/session/format.go
+++ b/internal/session/format.go
@@ -870,9 +870,18 @@ func (f *conversationFormatter) expandAgent(agent *Transcript) string {
 		return nestedIndent + fmt.Sprintf("[agent %s not expanded: nesting limit %d reached]\n", agent.AgentID, maxExpansionDepth)
 	}
 	if budget := f.opts.MaxExpandBytes; budget > 0 && *f.expandedBytes+agent.Bytes > budget {
+		// Marking the agent inlined makes a second spawn record for the same
+		// agent — real files carry the same tool_use in several records —
+		// render nothing rather than a second note.
 		f.claimed[agent.AgentID] = true
-		return nestedIndent + fmt.Sprintf("[agent %s not expanded: %s would exceed the %s expansion budget; raise --max-expand-mb, or print it alone with --agent %s]\n",
-			agent.AgentID, formatByteCount(agent.Bytes), formatByteCount(budget), agent.AgentID)
+		f.inlined[agent.AgentID] = true
+		nested, runs := f.claimContentsOf(agent)
+		note := fmt.Sprintf("[agent %s not expanded: %s would exceed the %s expansion budget; raise --max-expand-mb, or print it alone with --agent %s",
+			agent.AgentID, FormatBytes(agent.Bytes), FormatBytes(budget), agent.AgentID)
+		if nested > 0 || runs > 0 {
+			note += fmt.Sprintf("; %d nested agent(s) and %d workflow run(s) spawned inside it are not shown either", nested, runs)
+		}
+		return nestedIndent + note + "]\n"
 	}
 	*f.expandedBytes += agent.Bytes
 	f.claimed[agent.AgentID] = true
@@ -912,6 +921,36 @@ func (f *conversationFormatter) expandAgent(agent *Transcript) string {
 		body = "(no conversation messages)\n"
 	}
 	return indentBlock(head+body+tail, nestedIndent)
+}
+
+// claimContentsOf accounts for everything spawned inside an agent that is not
+// being rendered: its descendants in the tree and the workflow runs whose
+// spawn sites are in its file. Without this the trailers would call them
+// "no spawn site in the printed range", which is false — the site exists, it
+// was skipped — and the skip note is where they are accounted for instead.
+// Finding the runs costs one streaming pass over the skipped file, looking
+// only at lines that carry the task-ID marker.
+func (f *conversationFormatter) claimContentsOf(agent *Transcript) (nested int, runs int) {
+	agent.Walk(func(n *Transcript) {
+		if n == agent || f.claimed[n.AgentID] {
+			return
+		}
+		f.claimed[n.AgentID] = true
+		nested++
+	})
+	_ = ScanJSONLLines(agent.Filepath, func(line []byte) error {
+		if !bytes.Contains(line, []byte(workflowTaskIDMarker)) {
+			return nil
+		}
+		for _, id := range workflowTaskIDPattern.FindAllSubmatch(line, -1) {
+			if run := f.byTaskID[string(id[1])]; run != nil && !f.claimedRuns[run.RunID] {
+				f.claimedRuns[run.RunID] = true
+				runs++
+			}
+		}
+		return nil
+	})
+	return nested, runs
 }
 
 // scanTranscriptFile makes one pass over a JSONL transcript, returning the last
@@ -1161,23 +1200,6 @@ func indentBlock(block string, indent string) string {
 // a new transcript entry.
 func indentContinuation(s string) string {
 	return strings.ReplaceAll(s, "\n", "\n    ")
-}
-
-// formatByteCount renders a byte count for a notice: whole bytes below 1 KB,
-// one decimal above.
-func formatByteCount(n int64) string {
-	const kb, mb, gb = 1024.0, 1024.0 * 1024.0, 1024.0 * 1024.0 * 1024.0
-	f := float64(n)
-	switch {
-	case f >= gb:
-		return fmt.Sprintf("%.1f GB", f/gb)
-	case f >= mb:
-		return fmt.Sprintf("%.1f MB", f/mb)
-	case f >= kb:
-		return fmt.Sprintf("%.1f KB", f/kb)
-	default:
-		return fmt.Sprintf("%d B", n)
-	}
 }
 
 // formatDurationMs renders a millisecond duration compactly: "820ms", "12.4s",

--- a/internal/session/format.go
+++ b/internal/session/format.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -192,6 +193,19 @@ type FormatOptions struct {
 	// annotated with the agent ID needed to print them, and ExpandAgents
 	// becomes available. When nil the formatter renders a single flat file.
 	Root *Transcript
+
+	// MaxExpandBytes bounds the subagent transcript bytes ExpandAgents may
+	// inline across the whole render; 0 is unlimited. Past the budget an agent
+	// is not inlined and a note in its place says so and names the flag. The
+	// budget is enforced where inlining happens, so a tailed render is only
+	// charged for the agents actually spawned inside the printed window.
+	MaxExpandBytes int64
+
+	// ListCommand, when set, is the copy-pasteable command that lists the
+	// session's subagents. It is appended to the footer that reports how many
+	// transcripts the render left out, so a reader who cannot see stderr and
+	// has never read --help still learns the exact next command.
+	ListCommand string
 }
 
 // FormatTranscriptFile renders one JSONL transcript file under the given
@@ -230,6 +244,17 @@ type conversationFormatter struct {
 	// for, so a reused agent name is not handed to two call sites and the
 	// unlinked-agents trailer only lists what genuinely has no anchor.
 	claimed map[string]bool
+	// byTaskID indexes workflow runs by the task ID their spawn's tool_result
+	// reported; runByToolUseID is filled per render from the file scan, which
+	// is the only place the tool_use ID and the task ID meet.
+	byTaskID       map[string]*WorkflowRun
+	runByToolUseID map[string]*WorkflowRun
+	// claimedRuns marks workflow runs whose spawn site was rendered, so the
+	// trailer lists only runs with no anchor in the printed range.
+	claimedRuns map[string]bool
+	// expandedBytes is the running total of subagent bytes inlined so far,
+	// shared with nested formatters so the budget is per render, not per level.
+	expandedBytes *int64
 	// inlined marks agents whose transcript has already been written out.
 	// Transcripts contain duplicate records (the same uuid written twice is
 	// present in real files), so a spawn can be rendered more than once;
@@ -240,14 +265,22 @@ type conversationFormatter struct {
 
 func newConversationFormatter(opts FormatOptions) *conversationFormatter {
 	f := &conversationFormatter{
-		opts:        opts,
-		byToolUseID: map[string]*Transcript{},
-		byAgentID:   map[string]*Transcript{},
-		byAgentName: map[string][]*Transcript{},
-		claimed:     map[string]bool{},
-		inlined:     map[string]bool{},
+		opts:          opts,
+		byToolUseID:   map[string]*Transcript{},
+		byAgentID:     map[string]*Transcript{},
+		byAgentName:   map[string][]*Transcript{},
+		claimed:       map[string]bool{},
+		inlined:       map[string]bool{},
+		byTaskID:      map[string]*WorkflowRun{},
+		claimedRuns:   map[string]bool{},
+		expandedBytes: new(int64),
 	}
 	if opts.Root != nil {
+		for _, run := range opts.Root.Workflows {
+			if run.TaskID != "" {
+				f.byTaskID[run.TaskID] = run
+			}
+		}
 		opts.Root.Walk(func(n *Transcript) {
 			if n.IsMain() {
 				return
@@ -272,9 +305,15 @@ func newConversationFormatter(opts FormatOptions) *conversationFormatter {
 // blank lines. A leading fork banner is emitted when the file carries fork
 // provenance.
 func (f *conversationFormatter) render(jsonlFilepath string, tailLines int, w io.Writer) error {
-	lines, fork, err := scanTranscriptFile(jsonlFilepath, tailLines)
+	lines, fork, taskIDs, err := scanTranscriptFile(jsonlFilepath, tailLines)
 	if err != nil {
 		return err
+	}
+	f.runByToolUseID = map[string]*WorkflowRun{}
+	for toolUseID, taskID := range taskIDs {
+		if run := f.byTaskID[taskID]; run != nil {
+			f.runByToolUseID[toolUseID] = run
+		}
 	}
 
 	var blocks []string
@@ -292,6 +331,12 @@ func (f *conversationFormatter) render(jsonlFilepath string, tailLines int, w io
 	}
 	if trailer := f.unexpandedAgentsTrailer(); trailer != "" {
 		blocks = append(blocks, trailer)
+	}
+	if trailer := f.unlinkedWorkflowsTrailer(); trailer != "" {
+		blocks = append(blocks, trailer)
+	}
+	if footer := f.hiddenTranscriptsFooter(); footer != "" {
+		blocks = append(blocks, footer)
 	}
 
 	for i, block := range blocks {
@@ -368,6 +413,75 @@ func (f *conversationFormatter) unexpandedAgentsTrailer() string {
 		fmt.Fprintf(&b, "  %s (%s) %s\n", n.AgentID, n.Meta.DisplayType(), truncate(n.Meta.DisplayLabel(), maxToolParamLen))
 	}
 	return b.String()
+}
+
+// unlinkedWorkflowsTrailer is the workflow-run counterpart of the agents
+// trailer: under expansion it lists runs whose Workflow spawn is outside the
+// printed range. It is bounded by the number of runs, never by their agents.
+func (f *conversationFormatter) unlinkedWorkflowsTrailer() string {
+	if !f.opts.ExpandAgents || f.depth > 0 || f.target == nil || !f.target.IsMain() || f.opts.Root == nil {
+		return ""
+	}
+	var missing []*WorkflowRun
+	for _, run := range f.opts.Root.Workflows {
+		if !f.claimedRuns[run.RunID] {
+			missing = append(missing, run)
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[UNLINKED WORKFLOWS] %d workflow run(s) with no spawn site in the printed range\n", len(missing))
+	for _, run := range missing {
+		fmt.Fprintf(&b, "  %s (%s): %d agent(s), %s\n", run.RunID, run.DisplayName(), len(run.Agents), run.Status)
+	}
+	return b.String()
+}
+
+// hiddenTranscriptsFooter closes a render of the session's main transcript
+// with what it left out and the command that shows it. It is the one line a
+// reader is guaranteed to reach, which is why it is on stdout and carries the
+// exact flags: a hint on stderr is invisible to every caller that captured
+// only stdout, and "see --help" is not a command.
+//
+// Workflow runs are never inlined, even under expansion — one real session
+// holds 7214 agents in 60 runs, and inlining them would turn a 1 MB render
+// into hundreds of megabytes — so under expansion the footer reports the runs.
+func (f *conversationFormatter) hiddenTranscriptsFooter() string {
+	if f.depth > 0 || f.target == nil || !f.target.IsMain() || f.opts.Root == nil {
+		return ""
+	}
+	root := f.opts.Root
+	loose := len(root.Flatten()) - 1
+	workflowAgents := 0
+	for _, run := range root.Workflows {
+		workflowAgents += len(run.Agents)
+	}
+	runs := len(root.Workflows)
+
+	if f.opts.ExpandAgents {
+		if workflowAgents == 0 {
+			return ""
+		}
+		return fmt.Sprintf("[WORKFLOWS] %d agent transcript(s) in %d workflow run(s) are not inlined - --workflow <id> to list a run\n", workflowAgents, runs)
+	}
+
+	if loose+workflowAgents == 0 {
+		return ""
+	}
+	var parts []string
+	if loose > 0 {
+		parts = append(parts, fmt.Sprintf("%d spawned directly", loose))
+	}
+	if runs > 0 {
+		parts = append(parts, fmt.Sprintf("%d in %d workflow run(s)", workflowAgents, runs))
+	}
+	line := fmt.Sprintf("[SUBAGENTS] %d transcript(s) not shown: %s - --agents to list them, --agent <id> or --workflow <id> to open one", loose+workflowAgents, strings.Join(parts, ", "))
+	if f.opts.ListCommand != "" {
+		line += " - " + f.opts.ListCommand
+	}
+	return line + "\n"
 }
 
 // formatLine parses a single JSONL record and returns its formatted
@@ -627,6 +741,11 @@ func (f *conversationFormatter) formatAssistantEntry(record jsonlRecord) string 
 func (f *conversationFormatter) formatToolUseBlock(b contentBlock, timestamp string) string {
 	line := formatToolCall(b.Name, b.Input)
 
+	if run := f.runByToolUseID[b.ID]; run != nil {
+		f.claimedRuns[run.RunID] = true
+		return line + "  " + workflowAnchor(run)
+	}
+
 	agent := f.resolveSpawnedAgent(b, timestamp)
 	if agent == nil {
 		return line
@@ -637,6 +756,19 @@ func (f *conversationFormatter) formatToolUseBlock(b contentBlock, timestamp str
 		return line + "\n" + nested
 	}
 	return line
+}
+
+// workflowAnchor renders the bracketed summary that follows a Workflow spawn:
+// the run ID a reader needs to open it, its name, how many agents it spawned
+// and how many of those never reported, its status and duration. Everything
+// here comes from the manifest and the directory listing, not from the agent
+// transcripts, so the anchor costs nothing per agent.
+func workflowAnchor(run *WorkflowRun) string {
+	parts := []string{fmt.Sprintf("%d agents", len(run.Agents)), run.Status}
+	if run.DurationMs > 0 {
+		parts = append(parts, formatDurationMs(float64(run.DurationMs)))
+	}
+	return fmt.Sprintf("[workflow %s (%s): %s]", run.RunID, run.DisplayName(), strings.Join(parts, ", "))
 }
 
 // resolveSpawnedAgent finds the transcript a spawn tool_use produced.
@@ -699,18 +831,27 @@ func (f *conversationFormatter) expandAgent(agent *Transcript) string {
 	if f.depth >= maxExpansionDepth {
 		return nestedIndent + fmt.Sprintf("[agent %s not expanded: nesting limit %d reached]\n", agent.AgentID, maxExpansionDepth)
 	}
+	if budget := f.opts.MaxExpandBytes; budget > 0 && *f.expandedBytes+agent.Bytes > budget {
+		f.claimed[agent.AgentID] = true
+		return nestedIndent + fmt.Sprintf("[agent %s not expanded: %s would exceed the %s expansion budget; raise --max-expand-mb, or print it alone with --agent %s]\n",
+			agent.AgentID, formatByteCount(agent.Bytes), formatByteCount(budget), agent.AgentID)
+	}
+	*f.expandedBytes += agent.Bytes
 	f.claimed[agent.AgentID] = true
 	f.inlined[agent.AgentID] = true
 
 	nested := &conversationFormatter{
-		opts:        FormatOptions{Verbose: f.opts.Verbose, ExpandAgents: true, Root: f.opts.Root},
-		target:      agent,
-		byToolUseID: f.byToolUseID,
-		byAgentID:   f.byAgentID,
-		byAgentName: f.byAgentName,
-		claimed:     f.claimed,
-		inlined:     f.inlined,
-		depth:       f.depth + 1,
+		opts:          FormatOptions{Verbose: f.opts.Verbose, ExpandAgents: true, Root: f.opts.Root, MaxExpandBytes: f.opts.MaxExpandBytes},
+		target:        agent,
+		byToolUseID:   f.byToolUseID,
+		byAgentID:     f.byAgentID,
+		byAgentName:   f.byAgentName,
+		byTaskID:      f.byTaskID,
+		claimed:       f.claimed,
+		claimedRuns:   f.claimedRuns,
+		inlined:       f.inlined,
+		expandedBytes: f.expandedBytes,
+		depth:         f.depth + 1,
 	}
 
 	var buf bytes.Buffer
@@ -743,9 +884,37 @@ func (f *conversationFormatter) expandAgent(agent *Transcript) string {
 // transcript — on one real file, records 1 through 2775 of 6049 — so scanning
 // only a tail loses it. `session print` tails by default, which is exactly the
 // invocation where a silent omission is least likely to be noticed.
-func scanTranscriptFile(jsonlFilepath string, n int) ([]string, *forkRef, error) {
+//
+// The same pass collects, for every Workflow spawn, the task ID its tool_result
+// reported ("Task ID: w9gxz79on"), keyed by tool_use ID. That result record is
+// the only place the spawn's tool_use ID and the run's task ID appear together,
+// and the run's manifest carries the same task ID, which is how a Workflow call
+// is linked to the run directory it produced.
+func scanTranscriptFile(jsonlFilepath string, n int) ([]string, *forkRef, map[string]string, error) {
 	var fork *forkRef
+	taskIDs := map[string]string{}
+	noteTaskID := func(line []byte) {
+		if !bytes.Contains(line, []byte(workflowTaskIDMarker)) {
+			return
+		}
+		var record struct {
+			Type    string          `json:"type"`
+			Message json.RawMessage `json:"message"`
+		}
+		if err := json.Unmarshal(line, &record); err != nil || record.Type != "user" {
+			return
+		}
+		for _, b := range decodeContentBlocks(record.Message) {
+			if b.Type != "tool_result" || b.ToolUseID == "" {
+				continue
+			}
+			if id := workflowTaskIDPattern.FindStringSubmatch(extractToolResultText(b)); id != nil {
+				taskIDs[b.ToolUseID] = id[1]
+			}
+		}
+	}
 	noteFork := func(line []byte) {
+		noteTaskID(line)
 		if fork != nil {
 			return
 		}
@@ -768,9 +937,9 @@ func scanTranscriptFile(jsonlFilepath string, n int) ([]string, *forkRef, error)
 			return nil
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return lines, fork, nil
+		return lines, fork, taskIDs, nil
 	}
 
 	// The ring grows to the requested size rather than being allocated up
@@ -788,7 +957,7 @@ func scanTranscriptFile(jsonlFilepath string, n int) ([]string, *forkRef, error)
 		return nil
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	count := total
@@ -800,8 +969,14 @@ func scanTranscriptFile(jsonlFilepath string, n int) ([]string, *forkRef, error)
 	for i := 0; i < count; i++ {
 		result[i] = ring[(startIdx+i)%n]
 	}
-	return result, fork, nil
+	return result, fork, taskIDs, nil
 }
+
+// workflowTaskIDMarker is the substring a Workflow spawn's tool_result carries
+// before the task ID; workflowTaskIDPattern extracts the ID itself.
+const workflowTaskIDMarker = "Task ID: "
+
+var workflowTaskIDPattern = regexp.MustCompile(`Task ID: ([A-Za-z0-9_-]+)`)
 
 // maxRingSeedCapacity bounds the up-front allocation of a tail buffer. The ring
 // still grows to whatever --tail asked for, but only as lines actually arrive,
@@ -948,6 +1123,23 @@ func indentBlock(block string, indent string) string {
 // a new transcript entry.
 func indentContinuation(s string) string {
 	return strings.ReplaceAll(s, "\n", "\n    ")
+}
+
+// formatByteCount renders a byte count for a notice: whole bytes below 1 KB,
+// one decimal above.
+func formatByteCount(n int64) string {
+	const kb, mb, gb = 1024.0, 1024.0 * 1024.0, 1024.0 * 1024.0 * 1024.0
+	f := float64(n)
+	switch {
+	case f >= gb:
+		return fmt.Sprintf("%.1f GB", f/gb)
+	case f >= mb:
+		return fmt.Sprintf("%.1f MB", f/mb)
+	case f >= kb:
+		return fmt.Sprintf("%.1f KB", f/kb)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 // formatDurationMs renders a millisecond duration compactly: "820ms", "12.4s",

--- a/internal/session/format.go
+++ b/internal/session/format.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 const (
@@ -194,6 +195,14 @@ type FormatOptions struct {
 	// becomes available. When nil the formatter renders a single flat file.
 	Root *Transcript
 
+	// Since and Until bound the render to records whose timestamp falls in
+	// [Since, Until]; the zero value on either side is unbounded. A record
+	// without a timestamp is dropped when a bound is set, since nothing places
+	// it. The window applies to the transcript named by the caller; inlined
+	// subagents are still rendered whole.
+	Since time.Time
+	Until time.Time
+
 	// MaxExpandBytes bounds the subagent transcript bytes ExpandAgents may
 	// inline across the whole render; 0 is unlimited. Past the budget an agent
 	// is not inlined and a note in its place says so and names the flag. The
@@ -325,6 +334,9 @@ func (f *conversationFormatter) render(jsonlFilepath string, tailLines int, w io
 		if isDuplicateRecord(line, seenUUIDs) {
 			continue
 		}
+		if f.depth == 0 && !inTimeWindow(line, f.opts.Since, f.opts.Until) {
+			continue
+		}
 		if formatted := f.formatLine(line); formatted != "" {
 			blocks = append(blocks, formatted)
 		}
@@ -346,6 +358,32 @@ func (f *conversationFormatter) render(jsonlFilepath string, tailLines int, w io
 		}
 	}
 	return nil
+}
+
+// inTimeWindow reports whether a record's timestamp falls within [since,
+// until]. With no bounds every record passes; with a bound, a record that
+// carries no timestamp fails, because nothing places it in time.
+func inTimeWindow(line string, since time.Time, until time.Time) bool {
+	if since.IsZero() && until.IsZero() {
+		return true
+	}
+	var record struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal([]byte(line), &record); err != nil || record.Timestamp == "" {
+		return false
+	}
+	at, err := time.Parse(time.RFC3339Nano, record.Timestamp)
+	if err != nil {
+		return false
+	}
+	if !since.IsZero() && at.Before(since) {
+		return false
+	}
+	if !until.IsZero() && at.After(until) {
+		return false
+	}
+	return true
 }
 
 // isDuplicateRecord reports whether a line repeats a record already rendered,

--- a/internal/session/format.go
+++ b/internal/session/format.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,13 +15,90 @@ const (
 
 	// maxErrorLen is the maximum length for tool result error messages before truncation.
 	maxErrorLen = 200
+
+	// maxEventContentLen caps the one-line rendering of an event record's
+	// content (hook output, queued prompt, system notice) in default mode.
+	maxEventContentLen = 300
+
+	// maxToolResultLen caps a successful tool result's body. Successful results
+	// only render under Verbose, where they are context rather than the point.
+	maxToolResultLen = 400
+
+	// nestedIndent prefixes every line of an inlined subagent transcript.
+	nestedIndent = "    "
 )
 
-// jsonlEntry is the minimal structure for dispatching JSONL lines by type.
-type jsonlEntry struct {
+// jsonlRecord is the union of every top-level field the formatter reads from a
+// JSONL record. Claude Code writes more than twenty record types into a single
+// transcript and a given record populates only a handful of these; every field
+// is therefore optional and absence is never an error.
+type jsonlRecord struct {
 	Type      string          `json:"type"`
+	Subtype   string          `json:"subtype"`
 	Message   json.RawMessage `json:"message"`
 	Timestamp string          `json:"timestamp"`
+
+	// Conversation-shaping flags.
+	IsMeta           bool `json:"isMeta"`
+	IsCompactSummary bool `json:"isCompactSummary"`
+
+	// Provenance. Origin distinguishes a real human turn from a peer agent's
+	// message or a background-task notification; ForkedFrom marks a record
+	// copied in when the session was forked off another one.
+	Origin     *recordOrigin `json:"origin"`
+	ForkedFrom *forkRef      `json:"forkedFrom"`
+
+	// Event payloads.
+	Content         json.RawMessage  `json:"content"`
+	Level           string           `json:"level"`
+	Operation       string           `json:"operation"`
+	CompactMetadata *compactMetadata `json:"compactMetadata"`
+	Attachment      json.RawMessage  `json:"attachment"`
+	ToolUseResult   json.RawMessage  `json:"toolUseResult"`
+	Summary         string           `json:"summary"`
+
+	// Payloads of the small single-purpose record types. Each of these carries
+	// its whole meaning in one field; without them a verbose render prints the
+	// record's existence and drops what it said.
+	CustomTitle      string `json:"customTitle"`
+	AgencCustomTitle string `json:"agencCustomTitle"`
+	AITitle          string `json:"aiTitle"`
+	AgentName        string `json:"agentName"`
+	Mode             string `json:"mode"`
+	PermissionMode   string `json:"permissionMode"`
+	LastPrompt       string `json:"lastPrompt"`
+
+	// Hook and error bookkeeping.
+	HookErrors            json.RawMessage `json:"hookErrors"`
+	HookInfos             json.RawMessage `json:"hookInfos"`
+	PreventedContinuation bool            `json:"preventedContinuation"`
+	StopReason            string          `json:"stopReason"`
+	DurationMs            float64         `json:"durationMs"`
+	MessageCount          int             `json:"messageCount"`
+	RetryAttempt          int             `json:"retryAttempt"`
+	MaxRetries            int             `json:"maxRetries"`
+}
+
+// recordOrigin identifies who or what produced a user record.
+type recordOrigin struct {
+	Kind string `json:"kind"`
+	From string `json:"from"`
+}
+
+// forkRef points at the session and message a forked session branched from.
+type forkRef struct {
+	SessionID   string `json:"sessionId"`
+	MessageUUID string `json:"messageUuid"`
+}
+
+// compactMetadata describes a compaction boundary: what triggered it and how
+// much context it discarded.
+type compactMetadata struct {
+	Trigger                 string  `json:"trigger"`
+	PreTokens               float64 `json:"preTokens"`
+	PostTokens              float64 `json:"postTokens"`
+	CumulativeDroppedTokens float64 `json:"cumulativeDroppedTokens"`
+	DurationMs              float64 `json:"durationMs"`
 }
 
 // apiMessage represents a Claude API message with role and content blocks.
@@ -33,11 +111,26 @@ type apiMessage struct {
 type contentBlock struct {
 	Type      string                 `json:"type"`
 	Text      string                 `json:"text"`
+	Thinking  string                 `json:"thinking"`
+	ID        string                 `json:"id"`
 	Name      string                 `json:"name"`
 	Input     map[string]interface{} `json:"input"`
 	ToolUseID string                 `json:"tool_use_id"`
 	Content   json.RawMessage        `json:"content"`
 	IsError   bool                   `json:"is_error"`
+}
+
+// agentToolUseResult is the toolUseResult a completed subagent spawn writes
+// back onto the tool_result record in the spawner's transcript. It is the only
+// place the spawner's transcript records which agent ID ran.
+type agentToolUseResult struct {
+	Status            string  `json:"status"`
+	AgentID           string  `json:"agentId"`
+	AgentType         string  `json:"agentType"`
+	ResolvedModel     string  `json:"resolvedModel"`
+	TotalDurationMs   float64 `json:"totalDurationMs"`
+	TotalTokens       float64 `json:"totalTokens"`
+	TotalToolUseCount float64 `json:"totalToolUseCount"`
 }
 
 // toolParamSpec defines which input fields to extract for a tool's one-line summary.
@@ -48,36 +141,157 @@ type toolParamSpec struct {
 
 // toolParamMap maps tool names to the input fields that should appear in their one-line summary.
 var toolParamMap = map[string]toolParamSpec{
-	"Bash":         {primary: "command"},
-	"Read":         {primary: "file_path"},
-	"Edit":         {primary: "file_path"},
-	"Write":        {primary: "file_path"},
-	"Glob":         {primary: "pattern"},
-	"Grep":         {primary: "pattern", secondary: "path"},
-	"WebSearch":    {primary: "query"},
-	"WebFetch":     {primary: "url"},
-	"Task":         {primary: "description"},
-	"NotebookEdit": {primary: "notebook_path"},
-	"Skill":        {primary: "skill"},
-	"TaskCreate":   {primary: "subject"},
-	"TaskUpdate":   {primary: "taskId", secondary: "status"},
+	"Bash":           {primary: "command"},
+	"Read":           {primary: "file_path"},
+	"Edit":           {primary: "file_path"},
+	"Write":          {primary: "file_path"},
+	"Glob":           {primary: "pattern"},
+	"Grep":           {primary: "pattern", secondary: "path"},
+	"WebSearch":      {primary: "query"},
+	"WebFetch":       {primary: "url"},
+	"Task":           {primary: "description"},
+	"Agent":          {primary: "description", secondary: "subagent_type"},
+	"SendMessage":    {primary: "to", secondary: "summary"},
+	"NotebookEdit":   {primary: "notebook_path"},
+	"Skill":          {primary: "skill"},
+	"SlashCommand":   {primary: "command"},
+	"TaskCreate":     {primary: "subject"},
+	"TaskUpdate":     {primary: "taskId", secondary: "status"},
+	"TaskOutput":     {primary: "taskId"},
+	"TaskStop":       {primary: "taskId"},
+	"BashOutput":     {primary: "bash_id"},
+	"Workflow":       {primary: "name"},
+	"ScheduleWakeup": {primary: "reason"},
+	"ToolSearch":     {primary: "query"},
 }
 
-// FormatConversation reads a JSONL session file and writes a human-readable
-// formatted conversation to the given writer. If n > 0, only the last n JSONL
-// entries are included; if n <= 0, all entries are included.
-func FormatConversation(jsonlFilepath string, n int, w io.Writer) error {
-	lines, err := collectJSONLLines(jsonlFilepath, n)
+// FormatOptions controls which record classes a transcript render includes and
+// whether subagent transcripts are inlined.
+//
+// The default (zero value) renders the conversation plus the structural events
+// that change how the conversation should be read: compaction boundaries, fork
+// lineage, subagent spawns and returns, queued human input, slash commands and
+// errors. Verbose adds the high-volume bookkeeping records — hooks, turn
+// timings, attachments, thinking blocks, successful tool results — which are
+// noise for reading but necessary for auditing.
+type FormatOptions struct {
+	// TailLines, when > 0, limits the render to the last N JSONL records of
+	// the transcript named by the caller. Inlined subagent transcripts are
+	// always rendered whole, because a tail of a subagent is meaningless
+	// without its prompt.
+	TailLines int
+
+	// Verbose renders every record class rather than the conversational ones.
+	Verbose bool
+
+	// ExpandAgents inlines each subagent's transcript, indented, at the point
+	// its spawner called it. Requires Root.
+	ExpandAgents bool
+
+	// Root is the session's transcript tree. When set, subagent spawns are
+	// annotated with the agent ID needed to print them, and ExpandAgents
+	// becomes available. When nil the formatter renders a single flat file.
+	Root *Transcript
+}
+
+// FormatTranscriptFile renders one JSONL transcript file under the given
+// options. Subagent awareness requires opts.Root; without it the file is
+// rendered on its own.
+func FormatTranscriptFile(jsonlFilepath string, opts FormatOptions, w io.Writer) error {
+	f := newConversationFormatter(opts)
+	f.target = opts.Root
+	return f.render(jsonlFilepath, opts.TailLines, w)
+}
+
+// FormatTranscript renders a node of a transcript tree — the session's main
+// transcript or one subagent's — under the given options.
+func FormatTranscript(t *Transcript, opts FormatOptions, w io.Writer) error {
+	if t == nil {
+		return fmt.Errorf("no transcript to format")
+	}
+	f := newConversationFormatter(opts)
+	f.target = t
+	return f.render(t.Filepath, opts.TailLines, w)
+}
+
+// conversationFormatter holds the per-render lookup tables and the set of
+// subagents already inlined, so that a subagent reachable both by its spawn
+// tool_use ID and by its return record is rendered exactly once.
+type conversationFormatter struct {
+	opts FormatOptions
+	// target is the transcript node being rendered, which is the session's
+	// main transcript unless the caller selected one subagent. It scopes the
+	// unlinked-agents trailer.
+	target      *Transcript
+	byToolUseID map[string]*Transcript
+	byAgentID   map[string]*Transcript
+	byAgentName map[string][]*Transcript
+	// claimed marks agents a spawn site or return line has already accounted
+	// for, so a reused agent name is not handed to two call sites and the
+	// unlinked-agents trailer only lists what genuinely has no anchor.
+	claimed map[string]bool
+	// inlined marks agents whose transcript has already been written out.
+	// Transcripts contain duplicate records (the same uuid written twice is
+	// present in real files), so a spawn can be rendered more than once;
+	// without this guard the duplicate would inline the whole subagent twice.
+	inlined map[string]bool
+	depth   int
+}
+
+func newConversationFormatter(opts FormatOptions) *conversationFormatter {
+	f := &conversationFormatter{
+		opts:        opts,
+		byToolUseID: map[string]*Transcript{},
+		byAgentID:   map[string]*Transcript{},
+		byAgentName: map[string][]*Transcript{},
+		claimed:     map[string]bool{},
+		inlined:     map[string]bool{},
+	}
+	if opts.Root != nil {
+		opts.Root.Walk(func(n *Transcript) {
+			if n.IsMain() {
+				return
+			}
+			f.byAgentID[n.AgentID] = n
+			if n.Meta.ToolUseID != "" {
+				f.byToolUseID[n.Meta.ToolUseID] = n
+			}
+			if n.Meta.Name != "" {
+				f.byAgentName[n.Meta.Name] = append(f.byAgentName[n.Meta.Name], n)
+			}
+		})
+		for name := range f.byAgentName {
+			candidates := f.byAgentName[name]
+			sort.SliceStable(candidates, func(i, j int) bool { return candidates[i].StartedAt < candidates[j].StartedAt })
+		}
+	}
+	return f
+}
+
+// render reads a transcript file and writes its formatted blocks, separated by
+// blank lines. A leading fork banner is emitted when the file carries fork
+// provenance.
+func (f *conversationFormatter) render(jsonlFilepath string, tailLines int, w io.Writer) error {
+	lines, fork, err := scanTranscriptFile(jsonlFilepath, tailLines)
 	if err != nil {
 		return err
 	}
 
 	var blocks []string
+	if fork != nil {
+		blocks = append(blocks, fmt.Sprintf("[FORK] this session was forked from session %s\n", fork.SessionID))
+	}
+	seenUUIDs := map[string]bool{}
 	for _, line := range lines {
-		formatted := formatJSONLLine(line)
-		if formatted != "" {
+		if isDuplicateRecord(line, seenUUIDs) {
+			continue
+		}
+		if formatted := f.formatLine(line); formatted != "" {
 			blocks = append(blocks, formatted)
 		}
+	}
+	if trailer := f.unexpandedAgentsTrailer(); trailer != "" {
+		blocks = append(blocks, trailer)
 	}
 
 	for i, block := range blocks {
@@ -89,78 +303,112 @@ func FormatConversation(jsonlFilepath string, n int, w io.Writer) error {
 	return nil
 }
 
-// collectJSONLLines reads all lines from a JSONL file, returning the last n
-// lines if n > 0, or all lines if n <= 0. Uses a ring buffer for efficient
-// tail collection. Delegates line reading to ScanJSONLLines so lines larger
-// than 1 MB (inline base64 screenshots) are handled without aborting.
-func collectJSONLLines(jsonlFilepath string, n int) ([]string, error) {
-	if n <= 0 {
-		var lines []string
-		err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
-			lines = append(lines, string(line))
-			return nil
-		})
-		if err != nil {
-			return nil, err
+// isDuplicateRecord reports whether a line repeats a record already rendered,
+// recording its identity when it does not.
+//
+// Real transcripts contain the same record written twice — on one 68 MB session
+// on disk, 44% of the records are repeats, and a forked file can hold its entire
+// pre-fork conversation verbatim a second time. Rendering both copies shows the
+// conversation happening twice, which is not what happened. Records with no uuid
+// (queue operations, titles, mode switches) are never deduplicated, because
+// nothing identifies them.
+func isDuplicateRecord(line string, seen map[string]bool) bool {
+	var record struct {
+		UUID string `json:"uuid"`
+	}
+	if err := json.Unmarshal([]byte(line), &record); err != nil || record.UUID == "" {
+		return false
+	}
+	if seen[record.UUID] {
+		return true
+	}
+	seen[record.UUID] = true
+	return false
+}
+
+// unexpandedAgentsTrailer lists subagent transcripts that expansion never
+// reached. An agent whose spawn tool_use is outside the printed tail, or whose
+// spawner was killed before writing a result, has no anchor in the rendered
+// text; without this trailer it would silently vanish from an --expand-agents
+// render that claims to be complete.
+//
+// The walk is over the transcript being rendered, not the whole session: when
+// the caller asked for one subagent, the other 297 in the session are not
+// "missing from the printed range", they were never in scope, and listing them
+// buries the transcript that was asked for.
+func (f *conversationFormatter) unexpandedAgentsTrailer() string {
+	if !f.opts.ExpandAgents || f.depth > 0 {
+		return ""
+	}
+	scope := f.target
+	if scope == nil {
+		scope = f.opts.Root
+	}
+	if scope == nil {
+		return ""
+	}
+
+	var missing []*Transcript
+	scope.Walk(func(n *Transcript) {
+		if n == scope || n.IsMain() {
+			return
 		}
-		return lines, nil
-	}
-
-	ring := make([]string, n)
-	total := 0
-	err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
-		ring[total%n] = string(line)
-		total++
-		return nil
+		if !f.claimed[n.AgentID] {
+			missing = append(missing, n)
+		}
 	})
-	if err != nil {
-		return nil, err
+	if len(missing) == 0 {
+		return ""
 	}
+	sort.SliceStable(missing, func(i, j int) bool { return missing[i].StartedAt < missing[j].StartedAt })
 
-	count := total
-	if count > n {
-		count = n
+	var b strings.Builder
+	fmt.Fprintf(&b, "[UNLINKED AGENTS] %d subagent transcript(s) with no spawn site in the printed range\n", len(missing))
+	for _, n := range missing {
+		fmt.Fprintf(&b, "  %s (%s) %s\n", n.AgentID, n.Meta.DisplayType(), truncate(n.Meta.DisplayLabel(), maxToolParamLen))
 	}
-	startIdx := total - count
-	result := make([]string, count)
-	for i := 0; i < count; i++ {
-		result[i] = ring[(startIdx+i)%n]
-	}
-	return result, nil
+	return b.String()
 }
 
-// formatJSONLLine parses a single JSONL line and returns its formatted
-// representation, or "" if the line should be skipped.
-func formatJSONLLine(line string) string {
-	var entry jsonlEntry
-	if err := json.Unmarshal([]byte(line), &entry); err != nil {
+// formatLine parses a single JSONL record and returns its formatted
+// representation, or "" if the record renders nothing under these options.
+func (f *conversationFormatter) formatLine(line string) string {
+	var record jsonlRecord
+	if err := json.Unmarshal([]byte(line), &record); err != nil {
 		return ""
 	}
 
-	switch entry.Type {
+	switch record.Type {
 	case "user":
-		return formatUserEntry(entry.Message, entry.Timestamp)
+		return f.formatUserEntry(record)
 	case "assistant":
-		return formatAssistantEntry(entry.Message, entry.Timestamp)
+		return f.formatAssistantEntry(record)
 	default:
-		// Skip system, progress, file-history-snapshot, queue-operation,
-		// summary, custom-title, and any other non-conversation types.
-		return ""
+		return f.formatEventEntry(record)
 	}
 }
 
-// formatUserEntry formats a user message entry. Plain text content is shown
-// under a [timestamp USER] header. Tool result blocks with errors are shown as
-// error lines; successful tool results are skipped entirely.
-func formatUserEntry(rawMessage json.RawMessage, timestamp string) string {
-	var msg apiMessage
-	if err := json.Unmarshal(rawMessage, &msg); err != nil {
+// formatUserEntry formats a user record. Plain text content is shown under a
+// [timestamp USER] header tagged with the message's origin. A record carrying a
+// subagent's toolUseResult renders as an agent-return line, and optionally the
+// whole subagent transcript. Tool result blocks render on error, and under
+// Verbose on success.
+func (f *conversationFormatter) formatUserEntry(record jsonlRecord) string {
+	if record.IsCompactSummary {
+		return f.formatCompactSummary(record)
+	}
+	if record.IsMeta && !f.opts.Verbose {
 		return ""
 	}
 
-	header := formatRoleHeader("USER", timestamp)
+	var msg apiMessage
+	if err := json.Unmarshal(record.Message, &msg); err != nil {
+		return ""
+	}
 
-	// Try string content first (plain user text).
+	header := formatRoleHeader(userRoleLabel(record.Origin), record.Timestamp)
+
+	// String content is a plain user turn.
 	var textContent string
 	if err := json.Unmarshal(msg.Content, &textContent); err == nil {
 		if textContent == "" {
@@ -169,43 +417,177 @@ func formatUserEntry(rawMessage json.RawMessage, timestamp string) string {
 		return header + "\n" + textContent + "\n"
 	}
 
-	// Array content — look for user text and tool_result blocks with errors.
 	var blocks []contentBlock
 	if err := json.Unmarshal(msg.Content, &blocks); err != nil {
 		return ""
 	}
 
-	var parts []string
-	hasUserText := false
-	for _, b := range blocks {
-		if b.Type == "text" && b.Text != "" {
-			hasUserText = true
-			parts = append(parts, b.Text)
-		}
-		if b.Type == "tool_result" && b.IsError {
-			errMsg := extractToolResultError(b)
-			if errMsg != "" {
-				parts = append(parts, "  > ERROR: "+truncate(errMsg, maxErrorLen))
-			}
-		}
-		// Successful tool results are skipped.
-	}
-
+	parts, hasUserText := f.formatUserBlocks(blocks, f.decodeAgentResult(record.ToolUseResult))
 	if len(parts) == 0 {
 		return ""
 	}
+	// Blocks that are purely tool results are not something the user said, so
+	// they render without a USER header. A record that mixes real user text
+	// with tool results keeps the header.
 	if hasUserText {
 		return header + "\n" + strings.Join(parts, "\n") + "\n"
 	}
 	return strings.Join(parts, "\n") + "\n"
 }
 
-// formatAssistantEntry formats an assistant message entry. Text blocks are
-// rendered as-is, tool_use blocks as one-line summaries, and thinking blocks
-// are skipped.
-func formatAssistantEntry(rawMessage json.RawMessage, timestamp string) string {
+// formatUserBlocks renders the content blocks of a user record, reporting
+// whether any of them was text the user actually wrote.
+func (f *conversationFormatter) formatUserBlocks(blocks []contentBlock, agentResult *agentToolUseResult) ([]string, bool) {
+	var parts []string
+	hasUserText := false
+	for _, b := range blocks {
+		if b.Type == "text" {
+			if b.Text != "" {
+				hasUserText = true
+				parts = append(parts, b.Text)
+			}
+			continue
+		}
+		if b.Type != "tool_result" {
+			continue
+		}
+		rendered := f.formatToolResultBlock(b, agentResult)
+		if rendered == "" {
+			continue
+		}
+		if agentResult != nil && !b.IsError {
+			// toolUseResult is a property of the record, not of any one block,
+			// so a record carrying several tool_result blocks would otherwise
+			// repeat the same subagent return line once per block.
+			agentResult = nil
+		}
+		parts = append(parts, rendered)
+	}
+	return parts, hasUserText
+}
+
+// formatToolResultBlock renders one tool_result block, or "" when it is not
+// visible under these options. A failure always renders; a subagent's return
+// renders as its own summary line; an ordinary success is noise by default and
+// context under Verbose.
+func (f *conversationFormatter) formatToolResultBlock(b contentBlock, agentResult *agentToolUseResult) string {
+	if b.IsError {
+		errMsg := extractToolResultText(b)
+		if errMsg == "" {
+			return ""
+		}
+		return "  > ERROR: " + truncate(errMsg, maxErrorLen)
+	}
+	if agentResult != nil {
+		return f.formatAgentReturn(agentResult)
+	}
+	if !f.opts.Verbose {
+		return ""
+	}
+	body := extractToolResultText(b)
+	if body == "" {
+		return ""
+	}
+	return "  < " + indentContinuation(truncate(body, maxToolResultLen))
+}
+
+// formatCompactSummary renders the synthetic user message Claude Code injects
+// after compacting a conversation. It is labelled distinctly because it is not
+// something the user said — mistaking it for a human turn misreads the whole
+// transcript — and it is never truncated, because after a compaction it is the
+// only surviving record of everything before the boundary.
+func (f *conversationFormatter) formatCompactSummary(record jsonlRecord) string {
 	var msg apiMessage
-	if err := json.Unmarshal(rawMessage, &msg); err != nil {
+	if err := json.Unmarshal(record.Message, &msg); err != nil {
+		return ""
+	}
+	body := ""
+	var textContent string
+	if err := json.Unmarshal(msg.Content, &textContent); err == nil {
+		body = textContent
+	} else {
+		var blocks []contentBlock
+		if err := json.Unmarshal(msg.Content, &blocks); err == nil {
+			var texts []string
+			for _, b := range blocks {
+				if b.Type == "text" && b.Text != "" {
+					texts = append(texts, b.Text)
+				}
+			}
+			body = strings.Join(texts, "\n")
+		}
+	}
+	if body == "" {
+		return ""
+	}
+	return formatRoleHeader("COMPACT SUMMARY", record.Timestamp) + "\n" + body + "\n"
+}
+
+// userRoleLabel tags the USER header with the message's origin when the record
+// carries one. Distinguishing a human order from a peer agent's message or a
+// background-task notification is not cosmetic: all three arrive as user
+// records and are otherwise indistinguishable in the rendered transcript.
+func userRoleLabel(origin *recordOrigin) string {
+	if origin == nil || origin.Kind == "" {
+		return "USER"
+	}
+	if origin.From != "" {
+		return fmt.Sprintf("USER %s:%s", origin.Kind, origin.From)
+	}
+	return "USER " + origin.Kind
+}
+
+// decodeAgentResult extracts a subagent completion payload from a record's
+// toolUseResult, returning nil when the field is absent or belongs to an
+// ordinary tool.
+func (f *conversationFormatter) decodeAgentResult(raw json.RawMessage) *agentToolUseResult {
+	if len(raw) == 0 {
+		return nil
+	}
+	var result agentToolUseResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil
+	}
+	if result.AgentID == "" {
+		return nil
+	}
+	return &result
+}
+
+// formatAgentReturn renders a subagent's completion as a one-line summary, and
+// inlines the subagent's transcript beneath it when expansion is on and the
+// spawn site did not already inline it.
+func (f *conversationFormatter) formatAgentReturn(result *agentToolUseResult) string {
+	line := fmt.Sprintf("  < Agent %s (%s) %s", result.AgentID, orUnknown(result.AgentType), orUnknown(result.Status))
+	var extras []string
+	if result.TotalToolUseCount > 0 {
+		extras = append(extras, fmt.Sprintf("%d tools", int(result.TotalToolUseCount)))
+	}
+	if result.TotalDurationMs > 0 {
+		extras = append(extras, formatDurationMs(result.TotalDurationMs))
+	}
+	if result.TotalTokens > 0 {
+		extras = append(extras, fmt.Sprintf("%d tok", int(result.TotalTokens)))
+	}
+	if len(extras) > 0 {
+		line += " - " + strings.Join(extras, ", ")
+	}
+
+	if agent := f.byAgentID[result.AgentID]; agent != nil {
+		f.claimed[agent.AgentID] = true
+		if nested := f.expandAgent(agent); nested != "" {
+			return line + "\n" + nested
+		}
+	}
+	return line
+}
+
+// formatAssistantEntry formats an assistant record. Text blocks render as-is,
+// tool_use blocks as one-line summaries, and thinking blocks only under
+// Verbose.
+func (f *conversationFormatter) formatAssistantEntry(record jsonlRecord) string {
+	var msg apiMessage
+	if err := json.Unmarshal(record.Message, &msg); err != nil {
 		return ""
 	}
 
@@ -222,16 +604,216 @@ func formatAssistantEntry(rawMessage json.RawMessage, timestamp string) string {
 				parts = append(parts, b.Text)
 			}
 		case "tool_use":
-			parts = append(parts, formatToolCall(b.Name, b.Input))
+			parts = append(parts, f.formatToolUseBlock(b, record.Timestamp))
 		case "thinking":
-			// Skip thinking blocks.
+			if !f.opts.Verbose {
+				continue
+			}
+			if thought := firstNonEmpty(b.Thinking, b.Text); thought != "" {
+				parts = append(parts, "  ~ THINKING: "+indentContinuation(thought))
+			}
 		}
 	}
 
 	if len(parts) == 0 {
 		return ""
 	}
-	return formatRoleHeader("ASSISTANT", timestamp) + "\n" + strings.Join(parts, "\n") + "\n"
+	return formatRoleHeader("ASSISTANT", record.Timestamp) + "\n" + strings.Join(parts, "\n") + "\n"
+}
+
+// formatToolUseBlock renders a tool call, annotating a subagent spawn with the
+// agent ID that names its transcript and, under expansion, inlining that
+// transcript directly beneath the call.
+func (f *conversationFormatter) formatToolUseBlock(b contentBlock, timestamp string) string {
+	line := formatToolCall(b.Name, b.Input)
+
+	agent := f.resolveSpawnedAgent(b, timestamp)
+	if agent == nil {
+		return line
+	}
+	f.claimed[agent.AgentID] = true
+	line += fmt.Sprintf("  [agent %s]", agent.AgentID)
+	if nested := f.expandAgent(agent); nested != "" {
+		return line + "\n" + nested
+	}
+	return line
+}
+
+// resolveSpawnedAgent finds the transcript a spawn tool_use produced.
+//
+// The direct link is the sidecar's toolUseId, but only about half the subagent
+// transcripts on disk carry one: a *named* agent (spawned with a name, the
+// pattern behind background teammates) gets a sidecar with a name and no
+// toolUseId, and its spawn's tool_result reports status "teammate_spawned"
+// with no agentId either. For those the name is the only link, and a name can
+// be reused across a session, so the candidate is disambiguated by start time:
+// a subagent's transcript begins at or after the call that spawned it, and an
+// already-claimed transcript is never handed to a second spawn site.
+//
+// A candidate that started BEFORE the call is never accepted: it belongs to an
+// earlier spawn of the same name. Measured over every named spawn on this
+// machine, a subagent's transcript begins between 0.0s and 948s after its call
+// and never before it, so this rejects no legitimate match. When nothing is
+// left, this returns nil rather than guessing, and the unlinked-agents trailer
+// reports the transcript — a smaller error than attributing one agent's work to
+// another agent's call.
+//
+// What it does NOT guarantee: if a spawn produced no transcript at all (the
+// agent died before writing one), the next same-named transcript is later than
+// that dead call and will be attributed to it. Distinguishing that case needs
+// information the spawn site does not carry.
+func (f *conversationFormatter) resolveSpawnedAgent(b contentBlock, timestamp string) *Transcript {
+	if agent := f.byToolUseID[b.ID]; agent != nil {
+		return agent
+	}
+	if b.Name != "Agent" && b.Name != "Task" {
+		return nil
+	}
+	name := extractStringField(b.Input, "name")
+	if name == "" {
+		return nil
+	}
+
+	// Candidates are ordered by start time, so the first unclaimed one that did
+	// not start before this call is the earliest match.
+	for _, c := range f.byAgentName[name] {
+		if f.claimed[c.AgentID] {
+			continue
+		}
+		if timestamp != "" && c.StartedAt != "" && c.StartedAt < timestamp {
+			continue
+		}
+		return c
+	}
+	return nil
+}
+
+// expandAgent renders a subagent's transcript indented for inlining, or ""
+// when expansion is off, the agent is unknown, it was already inlined, or the
+// nesting bound has been reached. Marking the agent expanded before recursing
+// makes a cyclic parent chain terminate.
+func (f *conversationFormatter) expandAgent(agent *Transcript) string {
+	if agent == nil || !f.opts.ExpandAgents || f.inlined[agent.AgentID] {
+		return ""
+	}
+	if f.depth >= maxExpansionDepth {
+		return nestedIndent + fmt.Sprintf("[agent %s not expanded: nesting limit %d reached]\n", agent.AgentID, maxExpansionDepth)
+	}
+	f.claimed[agent.AgentID] = true
+	f.inlined[agent.AgentID] = true
+
+	nested := &conversationFormatter{
+		opts:        FormatOptions{Verbose: f.opts.Verbose, ExpandAgents: true, Root: f.opts.Root},
+		target:      agent,
+		byToolUseID: f.byToolUseID,
+		byAgentID:   f.byAgentID,
+		byAgentName: f.byAgentName,
+		claimed:     f.claimed,
+		inlined:     f.inlined,
+		depth:       f.depth + 1,
+	}
+
+	var buf bytes.Buffer
+	// A subagent transcript is always rendered whole: a tail of a subagent
+	// omits the prompt that gives its output meaning.
+	if err := nested.render(agent.Filepath, 0, &buf); err != nil {
+		return indentBlock(fmt.Sprintf("[agent %s transcript unreadable: %v]\n", agent.AgentID, err), nestedIndent)
+	}
+
+	label := agent.Meta.DisplayLabel()
+	head := fmt.Sprintf("--- begin agent %s (%s)", agent.AgentID, agent.Meta.DisplayType())
+	if label != "" {
+		head += fmt.Sprintf(": %s", truncate(label, maxToolParamLen))
+	}
+	head += " ---\n"
+	tail := fmt.Sprintf("--- end agent %s ---\n", agent.AgentID)
+
+	body := buf.String()
+	if body == "" {
+		body = "(no conversation messages)\n"
+	}
+	return indentBlock(head+body+tail, nestedIndent)
+}
+
+// scanTranscriptFile makes one pass over a JSONL transcript, returning the last
+// n lines (or all of them when n <= 0) together with the file's fork reference.
+//
+// The fork reference is collected over the WHOLE file rather than over the
+// returned window. Fork provenance occupies a contiguous prefix of a forked
+// transcript — on one real file, records 1 through 2775 of 6049 — so scanning
+// only a tail loses it. `session print` tails by default, which is exactly the
+// invocation where a silent omission is least likely to be noticed.
+func scanTranscriptFile(jsonlFilepath string, n int) ([]string, *forkRef, error) {
+	var fork *forkRef
+	noteFork := func(line []byte) {
+		if fork != nil {
+			return
+		}
+		var record struct {
+			ForkedFrom *forkRef `json:"forkedFrom"`
+		}
+		if err := json.Unmarshal(line, &record); err != nil {
+			return
+		}
+		if record.ForkedFrom != nil && record.ForkedFrom.SessionID != "" {
+			fork = record.ForkedFrom
+		}
+	}
+
+	if n <= 0 {
+		var lines []string
+		err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
+			noteFork(line)
+			lines = append(lines, string(line))
+			return nil
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return lines, fork, nil
+	}
+
+	// The ring grows to the requested size rather than being allocated up
+	// front, so a mistyped --tail cannot allocate gigabytes for a small file.
+	ring := make([]string, 0, ringSeedCapacity(n))
+	total := 0
+	err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
+		noteFork(line)
+		if len(ring) < n {
+			ring = append(ring, string(line))
+		} else {
+			ring[total%n] = string(line)
+		}
+		total++
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	count := total
+	if count > n {
+		count = n
+	}
+	startIdx := total - count
+	result := make([]string, count)
+	for i := 0; i < count; i++ {
+		result[i] = ring[(startIdx+i)%n]
+	}
+	return result, fork, nil
+}
+
+// maxRingSeedCapacity bounds the up-front allocation of a tail buffer. The ring
+// still grows to whatever --tail asked for, but only as lines actually arrive,
+// so the memory a request can reserve is bounded by the file, not by the flag.
+const maxRingSeedCapacity = 1024
+
+// ringSeedCapacity returns the initial capacity for a tail ring of size n.
+func ringSeedCapacity(n int) int {
+	if n < maxRingSeedCapacity {
+		return n
+	}
+	return maxRingSeedCapacity
 }
 
 // formatRoleHeader builds the header line for a conversation entry, e.g.
@@ -244,17 +826,14 @@ func formatRoleHeader(role string, timestamp string) string {
 	return "[" + timestamp + " " + role + "]"
 }
 
-// extractToolResultError extracts the error message from a tool_result content
-// block. The content field can be either a plain string or an array of text
-// blocks.
-func extractToolResultError(b contentBlock) string {
-	// Try string content first.
+// extractToolResultText extracts the text body of a tool_result content block.
+// The content field is either a plain string or an array of content blocks.
+func extractToolResultText(b contentBlock) string {
 	var textContent string
 	if err := json.Unmarshal(b.Content, &textContent); err == nil {
 		return textContent
 	}
 
-	// Try array of content blocks.
 	var innerBlocks []contentBlock
 	if err := json.Unmarshal(b.Content, &innerBlocks); err != nil {
 		return ""
@@ -348,4 +927,58 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// indentBlock prefixes every non-empty line of a block with the given indent.
+func indentBlock(block string, indent string) string {
+	if block == "" {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSuffix(block, "\n"), "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = indent + line
+		}
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// indentContinuation aligns the second and later lines of a multi-line value
+// under the marker that introduces it, so a wrapped body cannot be mistaken for
+// a new transcript entry.
+func indentContinuation(s string) string {
+	return strings.ReplaceAll(s, "\n", "\n    ")
+}
+
+// formatDurationMs renders a millisecond duration compactly: "820ms", "12.4s",
+// "3m12s".
+func formatDurationMs(ms float64) string {
+	switch {
+	case ms < 1000:
+		return fmt.Sprintf("%dms", int(ms))
+	case ms < 60000:
+		return fmt.Sprintf("%.1fs", ms/1000)
+	default:
+		total := int(ms / 1000)
+		return fmt.Sprintf("%dm%02ds", total/60, total%60)
+	}
+}
+
+// orUnknown substitutes a placeholder for an empty field so a rendered line
+// never has a hole in it.
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// firstNonEmpty returns the first non-empty argument, or "".
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/internal/session/format_events.go
+++ b/internal/session/format_events.go
@@ -1,0 +1,315 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Everything in a transcript that is not a user or assistant message is an
+// event record, and Claude Code writes a lot of them: hook results, turn
+// timings, compaction boundaries, queue operations, attachments, slash-command
+// invocations, API errors. Rendering them all by default would bury the
+// conversation; rendering none of them — which is what the formatter used to do
+// — silently drops the records that explain why the conversation looks the way
+// it does.
+//
+// The split below is by that question. An event renders by default when a
+// reader who cannot see it would misread the conversation: a compaction that
+// deleted the preceding context, a slash command that produced the next turn, a
+// queued human instruction, an error that truncated a response. Everything else
+// is bookkeeping and renders only under Verbose.
+
+// defaultVisibleSystemSubtypes are the system-record subtypes that change how
+// the surrounding conversation should be read.
+var defaultVisibleSystemSubtypes = map[string]bool{
+	"compact_boundary":       true,
+	"local_command":          true,
+	"api_error":              true,
+	"agents_killed":          true,
+	"model_refusal_fallback": true,
+	"informational":          true,
+	"scheduled_task_fire":    true,
+}
+
+// formatEventEntry renders a non-conversation record, or "" when the record is
+// not visible under these options.
+func (f *conversationFormatter) formatEventEntry(record jsonlRecord) string {
+	switch record.Type {
+	case "system":
+		return f.formatSystemEntry(record)
+	case "queue-operation":
+		return f.formatQueueEntry(record)
+	case "attachment":
+		return f.formatAttachmentEntry(record)
+	case "summary":
+		if record.Summary == "" {
+			return ""
+		}
+		return formatRoleHeader("SUMMARY", record.Timestamp) + "\n" + record.Summary + "\n"
+	default:
+		if !f.opts.Verbose || record.Type == "" {
+			return ""
+		}
+		return formatEventLine(record.Timestamp, strings.ToUpper(record.Type), minorRecordDetail(record))
+	}
+}
+
+// minorRecordDetail returns the payload of the small single-purpose record
+// types, each of which carries its whole meaning in one field. Rendering the
+// bare type name instead reports that something happened while discarding what
+// it was — a mode switch, a rename, the prompt that started a turn.
+func minorRecordDetail(record jsonlRecord) string {
+	return firstNonEmpty(
+		record.CustomTitle,
+		record.AgencCustomTitle,
+		record.AITitle,
+		record.AgentName,
+		record.Mode,
+		record.PermissionMode,
+		record.LastPrompt,
+	)
+}
+
+// formatSystemEntry renders a system record. Compaction boundaries are special
+// cased because they are the single most consequential event in a transcript:
+// everything before one was discarded from the model's context, and a reader
+// who does not see the boundary will read the summary that follows as if it
+// were a human message.
+func (f *conversationFormatter) formatSystemEntry(record jsonlRecord) string {
+	switch record.Subtype {
+	case "compact_boundary":
+		return formatCompactBoundary(record)
+	case "stop_hook_summary":
+		return f.formatStopHookSummary(record)
+	case "turn_duration":
+		if !f.opts.Verbose {
+			return ""
+		}
+		return formatEventLine(record.Timestamp, "TURN",
+			fmt.Sprintf("%s over %d messages", formatDurationMs(record.DurationMs), record.MessageCount))
+	case "api_error":
+		detail := "API error"
+		if record.MaxRetries > 0 {
+			detail = fmt.Sprintf("API error, retry %d/%d", record.RetryAttempt, record.MaxRetries)
+		}
+		return formatEventLine(record.Timestamp, "ERROR", detail)
+	case "local_command":
+		return formatEventLine(record.Timestamp, "COMMAND", f.eventText(record.Content))
+	case "agents_killed":
+		return formatEventLine(record.Timestamp, "AGENTS KILLED", f.eventText(record.Content))
+	}
+
+	if !defaultVisibleSystemSubtypes[record.Subtype] && !f.opts.Verbose {
+		return ""
+	}
+	label := strings.ToUpper(strings.ReplaceAll(orUnknown(record.Subtype), "_", " "))
+	if record.Level == "warning" || record.Level == "error" {
+		label = strings.ToUpper(record.Level) + " " + label
+	}
+	return formatEventLine(record.Timestamp, label, f.eventText(record.Content))
+}
+
+// formatCompactBoundary renders a compaction with the numbers that say how much
+// context it destroyed, so the reader can judge what the summary below it is
+// standing in for.
+func formatCompactBoundary(record jsonlRecord) string {
+	detail := ""
+	if m := record.CompactMetadata; m != nil {
+		var parts []string
+		if m.Trigger != "" {
+			parts = append(parts, "trigger="+m.Trigger)
+		}
+		if m.PreTokens > 0 {
+			parts = append(parts, fmt.Sprintf("%d tok before", int(m.PreTokens)))
+		}
+		if m.PostTokens > 0 {
+			parts = append(parts, fmt.Sprintf("%d tok after", int(m.PostTokens)))
+		}
+		if m.CumulativeDroppedTokens > 0 {
+			parts = append(parts, fmt.Sprintf("%d tok dropped cumulatively", int(m.CumulativeDroppedTokens)))
+		}
+		detail = strings.Join(parts, ", ")
+	}
+	return formatEventLine(record.Timestamp, "COMPACTED", detail)
+}
+
+// formatStopHookSummary renders a Stop-hook result. A clean run is bookkeeping;
+// a hook that errored or blocked continuation changed what the agent did next
+// and is shown by default.
+func (f *conversationFormatter) formatStopHookSummary(record jsonlRecord) string {
+	errs := rawArrayLen(record.HookErrors)
+	if errs == 0 && !record.PreventedContinuation && !f.opts.Verbose {
+		return ""
+	}
+
+	var parts []string
+	if errs > 0 {
+		parts = append(parts, fmt.Sprintf("%d hook error(s)", errs))
+	}
+	if record.PreventedContinuation {
+		parts = append(parts, "blocked continuation")
+	}
+	if record.StopReason != "" {
+		parts = append(parts, "reason: "+record.StopReason)
+	}
+	if f.opts.Verbose {
+		if n := rawArrayLen(record.HookInfos); n > 0 {
+			parts = append(parts, fmt.Sprintf("%d hook(s) ran", n))
+		}
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "ran clean")
+	}
+	return formatEventLine(record.Timestamp, "STOP HOOK", strings.Join(parts, ", "))
+}
+
+// formatQueueEntry renders a queue operation. An enqueue or popAll carries the
+// text of an instruction that arrived mid-turn — the case where a message the
+// user actually sent never appears as a USER record at all, because the turn it
+// landed in was still running. The dequeue and remove churn around it is
+// bookkeeping.
+func (f *conversationFormatter) formatQueueEntry(record jsonlRecord) string {
+	text := f.eventText(record.Content)
+	switch record.Operation {
+	case "enqueue", "popAll":
+		if text == "" {
+			return ""
+		}
+		return formatEventLine(record.Timestamp, "QUEUED "+record.Operation, text)
+	case "dequeue", "remove":
+		if !f.opts.Verbose {
+			return ""
+		}
+		return formatEventLine(record.Timestamp, "QUEUE "+record.Operation, text)
+	default:
+		if !f.opts.Verbose || record.Operation == "" {
+			return ""
+		}
+		return formatEventLine(record.Timestamp, "QUEUE "+record.Operation, text)
+	}
+}
+
+// attachmentSummary is the subset of attachment payload fields used to build a
+// one-line label. Attachments carry a dozen different shapes; these are the
+// fields that identify which one it is and what it referred to.
+type attachmentSummary struct {
+	Type        string          `json:"type"`
+	Filename    string          `json:"filename"`
+	Path        string          `json:"path"`
+	DisplayPath string          `json:"displayPath"`
+	Prompt      string          `json:"prompt"`
+	Content     json.RawMessage `json:"content"`
+	HookName    string          `json:"hookName"`
+	Description string          `json:"description"`
+	Status      string          `json:"status"`
+	Banner      string          `json:"banner"`
+	Style       string          `json:"style"`
+	URL         string          `json:"url"`
+}
+
+// formatAttachmentEntry renders an attachment record. Only queued_command is
+// visible by default: it is the mid-turn instruction the user typed, and it is
+// otherwise invisible in the transcript.
+func (f *conversationFormatter) formatAttachmentEntry(record jsonlRecord) string {
+	var att attachmentSummary
+	if err := json.Unmarshal(record.Attachment, &att); err != nil {
+		return ""
+	}
+
+	if att.Type == "queued_command" {
+		if att.Prompt == "" {
+			return ""
+		}
+		return formatEventLine(record.Timestamp, "QUEUED COMMAND", att.Prompt)
+	}
+
+	if !f.opts.Verbose {
+		return ""
+	}
+
+	detail := firstNonEmpty(
+		att.DisplayPath,
+		att.Filename,
+		att.Path,
+		att.Banner,
+		att.HookName,
+		att.Description,
+		att.Style,
+		att.URL,
+		f.eventText(att.Content),
+	)
+	return formatEventLine(record.Timestamp, "ATTACHMENT "+orUnknown(att.Type), detail)
+}
+
+// formatEventLine renders one event as a bracketed header plus an optional
+// detail, truncated to a single readable line's worth of text.
+func formatEventLine(timestamp string, label string, detail string) string {
+	header := formatRoleHeader(label, timestamp)
+	detail = collapseWhitespace(detail)
+	if detail == "" {
+		return header + "\n"
+	}
+	return header + " " + truncate(detail, maxEventContentLen) + "\n"
+}
+
+// eventText coerces a record's content field into text. Content is written as a
+// bare string on system and queue records, and as an array of strings or of
+// {text}/{content} objects on hook attachments.
+func (f *conversationFormatter) eventText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return asString
+	}
+
+	var asStrings []string
+	if err := json.Unmarshal(raw, &asStrings); err == nil {
+		return strings.Join(asStrings, " ")
+	}
+
+	var asBlocks []struct {
+		Text    string `json:"text"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &asBlocks); err == nil {
+		var parts []string
+		for _, b := range asBlocks {
+			if t := firstNonEmpty(b.Text, b.Content); t != "" {
+				parts = append(parts, t)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+
+	var asObject struct {
+		Text    string `json:"text"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &asObject); err == nil {
+		return firstNonEmpty(asObject.Text, asObject.Content)
+	}
+	return ""
+}
+
+// rawArrayLen returns the element count of a raw JSON array, or 0 when the
+// value is absent, null, or not an array.
+func rawArrayLen(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return 0
+	}
+	return len(items)
+}
+
+// collapseWhitespace folds newlines and runs of spaces into single spaces so an
+// event detail occupies exactly one line.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/session/format_fidelity_test.go
+++ b/internal/session/format_fidelity_test.go
@@ -1,0 +1,209 @@
+package session
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The tests here pin behaviours that an adversarial review proved wrong against
+// the real transcripts on disk. Each one is the hermetic form of a defect that
+// was measured on a live file; the measured numbers are in the comments so a
+// future reader can tell what the fixture stands for.
+
+func TestFormatFindsForkProvenanceOutsideTheTailWindow(t *testing.T) {
+	// Fork provenance occupies a contiguous PREFIX of a forked transcript — on
+	// one real file, records 1 through 2775 of 6049. Scanning only the tailed
+	// window therefore lost the banner at `session print`'s default --tail 20,
+	// which is the invocation where a silent omission is least likely to be
+	// noticed. The scan now covers the whole file.
+	var lines []string
+	for i := 0; i < 5; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"user","timestamp":"2026-01-01T00:00:%02d.000Z","forkedFrom":{"sessionId":"src-session-id","messageUuid":"m%d"},"uuid":"f%d","message":{"role":"user","content":"forked prefix %d"}}`, i, i, i, i))
+	}
+	for i := 0; i < 20; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"user","timestamp":"2026-01-01T01:00:%02d.000Z","uuid":"n%d","message":{"role":"user","content":"after the fork %d"}}`, i, i, i))
+	}
+
+	tailed := renderLines(t, FormatOptions{TailLines: 3}, lines...)
+
+	// Positive control: the tail really did cut the prefix off.
+	mustNotContain(t, tailed, "forked prefix 0")
+	mustContain(t, tailed, "[FORK] this session was forked from session src-session-id")
+}
+
+func TestFormatSkipsRecordsRepeatedUnderTheSameUUID(t *testing.T) {
+	// Real transcripts write the same record twice — a forked file can carry
+	// its whole pre-fork conversation verbatim a second time. Rendering both
+	// copies shows a conversation that never happened.
+	duplicated := `{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","uuid":"same-uuid","message":{"role":"user","content":"SAID ONCE"}}`
+
+	got := renderLines(t, FormatOptions{}, duplicated, duplicated)
+
+	if n := strings.Count(got, "SAID ONCE"); n != 1 {
+		t.Errorf("record rendered %d times, want 1\n%s", n, got)
+	}
+}
+
+func TestFormatKeepsDistinctRecordsThatHaveNoUUID(t *testing.T) {
+	// Queue operations, titles and mode switches carry no uuid. Deduplicating
+	// on an empty key would collapse all of them into one.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2026-01-01T00:00:00.000Z","content":"first instruction"}`,
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2026-01-01T00:00:01.000Z","content":"second instruction"}`,
+	)
+
+	mustContain(t, got, "first instruction", "second instruction")
+}
+
+func TestSummarizeTranscriptCountsRepeatedRecordsOnce(t *testing.T) {
+	// On a 68 MB session on disk, counting lines reported 10011 messages and
+	// 3168 tool calls against a deduplicated truth of 4663 and 1482 — an
+	// overstatement of more than 100% in a column the new --agents table prints.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	user := `{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"user","content":"hi"}}`
+	assistant := `{"type":"assistant","uuid":"a1","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`
+	content := strings.Join([]string{user, assistant, user, assistant}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := SummarizeTranscript(path)
+	if err != nil {
+		t.Fatalf("SummarizeTranscript: %v", err)
+	}
+
+	if stats.UserMessages != 1 || stats.AssistantMessages != 1 || stats.ToolCalls != 1 {
+		t.Errorf("user=%d assistant=%d tools=%d, want 1/1/1 after deduplication",
+			stats.UserMessages, stats.AssistantMessages, stats.ToolCalls)
+	}
+}
+
+func TestSummarizeTranscriptCountsUUIDlessRecordsEveryTime(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	noUUID := `{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"user","content":"hi"}}`
+	if err := os.WriteFile(path, []byte(noUUID+"\n"+noUUID+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := SummarizeTranscript(path)
+	if err != nil {
+		t.Fatalf("SummarizeTranscript: %v", err)
+	}
+
+	if stats.UserMessages != 2 {
+		t.Errorf("user messages = %d, want 2: records with no uuid cannot be deduplicated", stats.UserMessages)
+	}
+}
+
+func TestFormatTrailerCoversOnlyTheRenderedTranscript(t *testing.T) {
+	// Printing one subagent of a 298-agent session used to append a trailer
+	// naming 297 others as "no spawn site in the printed range" — 80% of the
+	// output, and it listed the very transcript being printed.
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("atarget", &AgentMeta{AgentType: "Explore", Description: "the one asked for"},
+		assistantLine("2026-01-01T00:01:00.000Z", "TARGET BODY"))
+	fs.addAgent("aother1", &AgentMeta{AgentType: "Explore", Description: "unrelated one"},
+		assistantLine("2026-01-01T00:02:00.000Z", "other body"))
+	fs.addAgent("aother2", &AgentMeta{AgentType: "Explore", Description: "unrelated two"},
+		assistantLine("2026-01-01T00:03:00.000Z", "other body two"))
+	root := fs.discover()
+
+	target, err := ResolveAgent(root, "atarget")
+	if err != nil {
+		t.Fatalf("ResolveAgent: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := FormatTranscript(target, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	mustContain(t, got, "TARGET BODY")
+	mustNotContain(t, got, "UNLINKED AGENTS", "aother1", "aother2", "atarget (")
+}
+
+func TestFormatTrailerStillCoversTheSessionWhenTheSessionIsRendered(t *testing.T) {
+	// The scoping fix must not silence the trailer on the case it exists for.
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("astray", &AgentMeta{AgentType: "Explore", Description: "never returned"},
+		assistantLine("2026-01-01T00:01:00.000Z", "stray body"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	mustContain(t, buf.String(), "[UNLINKED AGENTS] 1 subagent transcript(s)", "astray")
+}
+
+func TestFormatDeclinesASubagentThatStartedBeforeItsSupposedSpawn(t *testing.T) {
+	// A transcript that began before the call cannot be that call's output. It
+	// belongs to an earlier spawn of the same name, and attributing it here
+	// would put one agent's work under another agent's call.
+	fs := newFakeSession(t,
+		`{"type":"assistant","timestamp":"2026-01-01T12:00:00.000Z","uuid":"s1","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_late","name":"Agent","input":{"description":"the later call","name":"worker"}}]}}`,
+	)
+	fs.addAgent("aworker-early", &AgentMeta{Name: "worker"},
+		assistantLine("2026-01-01T10:00:00.000Z", "WORK FROM AN EARLIER SPAWN"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	if strings.Contains(got, "[agent aworker-early]") {
+		t.Errorf("a transcript that started 2h before the call must not be attributed to it\n%s", got)
+	}
+	// It must not vanish either: the trailer is what keeps it visible.
+	mustContain(t, got, "[UNLINKED AGENTS]", "aworker-early")
+}
+
+func TestDecodeAgentResultIgnoresOrdinaryToolResults(t *testing.T) {
+	// Ordinary tools also write a toolUseResult. Without the agent-ID guard,
+	// every Bash and Read result would render as "< Agent unknown (unknown)".
+	got := renderLines(t, FormatOptions{},
+		`{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","uuid":"u1","toolUseResult":{"stdout":"file1.txt","stderr":"","interrupted":false},"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file1.txt"}]}}`,
+	)
+
+	if strings.Contains(got, "Agent") {
+		t.Errorf("an ordinary tool result must not render as a subagent return\n%s", got)
+	}
+}
+
+func TestTailDoesNotAllocateForTheRequestedSizeUpFront(t *testing.T) {
+	// `--tail 20000000` on a one-line file grew the heap by 305 MB, because the
+	// ring was allocated for the requested count before anything was read. A
+	// mistyped digit count could exhaust memory on a tiny file.
+	path := filepath.Join(t.TempDir(), "one.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"user","uuid":"u1","message":{"role":"user","content":"only line"}}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	var buf bytes.Buffer
+	if err := FormatTranscriptFile(path, FormatOptions{TailLines: 20_000_000}, &buf); err != nil {
+		t.Fatalf("FormatTranscriptFile: %v", err)
+	}
+	runtime.ReadMemStats(&after)
+
+	// Positive control: a render that produced nothing would also allocate
+	// nothing, and would pass the size assertion for the wrong reason.
+	mustContain(t, buf.String(), "only line")
+	if grew := after.TotalAlloc - before.TotalAlloc; grew > 32*1024*1024 {
+		t.Errorf("allocated %d bytes for a one-line file, want far under 32 MB", grew)
+	}
+}

--- a/internal/session/format_observability_test.go
+++ b/internal/session/format_observability_test.go
@@ -1,0 +1,711 @@
+package session
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// renderLines writes JSONL records to a temp file and formats them, returning
+// the rendered text. It covers the single-file case where no transcript tree is
+// involved.
+func renderLines(t *testing.T, opts FormatOptions, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := FormatTranscriptFile(path, opts, &buf); err != nil {
+		t.Fatalf("FormatTranscriptFile: %v", err)
+	}
+	return buf.String()
+}
+
+func mustContain(t *testing.T, got string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+func mustNotContain(t *testing.T, got string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if strings.Contains(got, want) {
+			t.Errorf("output should not contain %q\n--- output ---\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatRendersCompactionBoundary(t *testing.T) {
+	// Without this line the transcript silently jumps: everything above the
+	// boundary was dropped from the model's context, and the summary below it
+	// reads like a human message.
+	got := renderLines(t, FormatOptions{},
+		assistantLine("2026-01-01T00:00:00.000Z", "before"),
+		`{"type":"system","subtype":"compact_boundary","timestamp":"2026-01-01T00:01:00.000Z","content":"Conversation compacted","compactMetadata":{"trigger":"auto","preTokens":354559,"postTokens":26757,"cumulativeDroppedTokens":327802}}`,
+	)
+
+	mustContain(t, got, "COMPACTED", "trigger=auto", "354559 tok before", "26757 tok after", "327802 tok dropped")
+}
+
+func TestFormatLabelsCompactSummaryDistinctlyFromAUserTurn(t *testing.T) {
+	got := renderLines(t, FormatOptions{},
+		`{"type":"user","isCompactSummary":true,"timestamp":"2026-01-01T00:01:00.000Z","message":{"role":"user","content":"This session is being continued from a previous conversation."}}`,
+	)
+
+	mustContain(t, got, "COMPACT SUMMARY", "This session is being continued")
+	mustNotContain(t, got, "[2026-01-01T00:01:00.000Z USER]")
+}
+
+func TestFormatRendersForkProvenance(t *testing.T) {
+	got := renderLines(t, FormatOptions{},
+		`{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","forkedFrom":{"sessionId":"3666d990-4ef0-4af4-9cab-0e0089c80759","messageUuid":"a83bf03d"},"message":{"role":"user","content":"hi"}}`,
+	)
+
+	mustContain(t, got, "[FORK]", "3666d990-4ef0-4af4-9cab-0e0089c80759")
+}
+
+func TestFormatTagsMessageOrigin(t *testing.T) {
+	// A human order, a peer agent's message and a background-task notification
+	// are all written as user records. Rendering them identically is how an
+	// agent replaying a transcript mistakes a peer's message for the user's.
+	tests := []struct {
+		name   string
+		origin string
+		want   string
+	}{
+		{"human", `,"origin":{"kind":"human"}`, "USER human"},
+		{"peer", `,"origin":{"kind":"peer","from":"build-lead-2"}`, "USER peer:build-lead-2"},
+		{"task notification", `,"origin":{"kind":"task-notification"}`, "USER task-notification"},
+		{"absent", ``, "[2026-01-01T00:00:00.000Z USER]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderLines(t, FormatOptions{},
+				`{"type":"user","timestamp":"2026-01-01T00:00:00.000Z"`+tt.origin+`,"message":{"role":"user","content":"do the thing"}}`)
+			mustContain(t, got, tt.want)
+		})
+	}
+}
+
+func TestFormatRendersAgentSpawnAndReturn(t *testing.T) {
+	// The Agent tool used to render as a bare "Agent()" because the parameter
+	// map only knew the older "Task" name, and its successful result was
+	// dropped as an ordinary tool result — so a subagent left no trace at all.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"Extract KB reqs","subagent_type":"Explore"}}]}}`,
+		`{"type":"user","timestamp":"2026-01-01T00:05:00.000Z","toolUseResult":{"status":"completed","agentId":"aa8d6202c85e084d7","agentType":"Explore","totalDurationMs":91000,"totalTokens":52248,"totalToolUseCount":7},"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"}]}}`,
+	)
+
+	mustContain(t, got,
+		`> Agent("Extract KB reqs", subagent_type="Explore")`,
+		"< Agent aa8d6202c85e084d7 (Explore) completed",
+		"7 tools", "1m31s", "52248 tok")
+}
+
+func TestFormatRendersOneAgentReturnPerRecord(t *testing.T) {
+	// toolUseResult is a property of the record, not of a block. A record
+	// carrying more than one tool_result block must not repeat the subagent
+	// return line once per block.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"user","timestamp":"2026-01-01T00:05:00.000Z","toolUseResult":{"status":"completed","agentId":"aa8d6202c85e084d7","agentType":"Explore"},"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"},{"type":"tool_result","tool_use_id":"toolu_2","content":"also done"}]}}`,
+	)
+
+	if n := strings.Count(got, "< Agent aa8d6202c85e084d7"); n != 1 {
+		t.Errorf("agent return rendered %d times, want 1\n%s", n, got)
+	}
+}
+
+func TestFormatAnnotatesSpawnWithAgentIDWhenTreeIsKnown(t *testing.T) {
+	fs := newFakeSession(t,
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"look","subagent_type":"Explore"}}]}}`,
+	)
+	fs.addAgent("aabc123", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1", Description: "look"},
+		userLine("2026-01-01T00:00:10.000Z", "agent prompt"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	// Without expansion the spawn still names the transcript, so the reader
+	// knows what to pass to --agent.
+	mustContain(t, buf.String(), "[agent aabc123]")
+	mustNotContain(t, buf.String(), "begin agent")
+}
+
+func TestFormatExpandsAgentTranscriptInline(t *testing.T) {
+	fs := newFakeSession(t,
+		userLine("2026-01-01T00:00:00.000Z", "go"),
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"look","subagent_type":"Explore"}}]}}`,
+	)
+	fs.addAgent("aabc123", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1", Description: "look at the KB"},
+		userLine("2026-01-01T00:00:10.000Z", "agent prompt here"),
+		assistantLine("2026-01-01T00:00:11.000Z", "agent answer here"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	mustContain(t, got,
+		"--- begin agent aabc123 (Explore): look at the KB ---",
+		"agent prompt here",
+		"agent answer here",
+		"--- end agent aabc123 ---")
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "agent answer here") && !strings.HasPrefix(line, nestedIndent) {
+			t.Errorf("nested transcript line should be indented, got %q", line)
+		}
+	}
+}
+
+func TestFormatExpandsNamedBackgroundAgentByName(t *testing.T) {
+	// A named agent's sidecar carries a name and no toolUseId, and its spawn's
+	// tool_result reports status "teammate_spawned" with no agentId. The name
+	// is the only link between the call and the transcript.
+	fs := newFakeSession(t,
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"probe","name":"v1d-probe"}}]}}`,
+	)
+	fs.addAgent("av1d-probe-0edd", &AgentMeta{AgentType: "v1d-probe", Name: "v1d-probe"},
+		assistantLine("2026-01-01T00:00:30.000Z", "probe output"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	mustContain(t, buf.String(), "[agent av1d-probe-0edd]", "probe output")
+}
+
+func TestFormatDisambiguatesReusedAgentNamesByStartTime(t *testing.T) {
+	fs := newFakeSession(t,
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"first","name":"worker"}}]}}`,
+		`{"type":"assistant","timestamp":"2026-01-01T02:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_2","name":"Agent","input":{"description":"second","name":"worker"}}]}}`,
+	)
+	fs.addAgent("aworker-early", &AgentMeta{Name: "worker"}, assistantLine("2026-01-01T00:00:05.000Z", "EARLY RUN"))
+	fs.addAgent("aworker-late", &AgentMeta{Name: "worker"}, assistantLine("2026-01-01T02:00:05.000Z", "LATE RUN"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	earlyIdx := strings.Index(got, "EARLY RUN")
+	lateIdx := strings.Index(got, "LATE RUN")
+	if earlyIdx < 0 || lateIdx < 0 {
+		t.Fatalf("both runs should be inlined\n%s", got)
+	}
+	if earlyIdx > lateIdx {
+		t.Errorf("the earlier agent should be attributed to the earlier spawn")
+	}
+	if strings.Count(got, "EARLY RUN") != 1 || strings.Count(got, "LATE RUN") != 1 {
+		t.Errorf("each transcript should be inlined exactly once")
+	}
+}
+
+func TestFormatListsAgentsWithNoSpawnSite(t *testing.T) {
+	// A subagent whose spawner was killed, or whose spawn falls outside a
+	// tailed range, has nothing in the rendered text to hang off. Silently
+	// omitting it would make an --expand-agents render look complete when it
+	// is not.
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aorphan1", &AgentMeta{AgentType: "Explore", Description: "never returned"},
+		assistantLine("2026-01-01T00:00:10.000Z", "partial work"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	mustContain(t, buf.String(), "[UNLINKED AGENTS] 1 subagent transcript(s)", "aorphan1", "never returned")
+}
+
+func TestFormatRendersQueuedInstructions(t *testing.T) {
+	// A message the user types while a turn is running is written as a queue
+	// operation, not as a user record. It used to be invisible, which made
+	// "agenc mission print" unable to show that an order had been given.
+	lines := []string{
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2026-01-01T00:00:00.000Z","content":"stop and check the diff"}`,
+		`{"type":"queue-operation","operation":"remove","timestamp":"2026-01-01T00:00:05.000Z","content":"stop and check the diff"}`,
+		`{"type":"attachment","timestamp":"2026-01-01T00:00:06.000Z","attachment":{"type":"queued_command","prompt":"also push it"}}`,
+	}
+
+	got := renderLines(t, FormatOptions{}, lines...)
+	mustContain(t, got, "QUEUED enqueue", "stop and check the diff", "QUEUED COMMAND", "also push it")
+	mustNotContain(t, got, "QUEUE remove")
+
+	verbose := renderLines(t, FormatOptions{Verbose: true}, lines...)
+	mustContain(t, verbose, "QUEUE remove")
+}
+
+func TestFormatRendersSlashCommandsAndErrors(t *testing.T) {
+	got := renderLines(t, FormatOptions{},
+		`{"type":"system","subtype":"local_command","timestamp":"2026-01-01T00:00:00.000Z","content":"<command-name>/teleport</command-name>"}`,
+		`{"type":"system","subtype":"api_error","timestamp":"2026-01-01T00:00:01.000Z","level":"error","retryAttempt":1,"maxRetries":10}`,
+		`{"type":"system","subtype":"agents_killed","timestamp":"2026-01-01T00:00:02.000Z"}`,
+		`{"type":"system","subtype":"model_refusal_fallback","timestamp":"2026-01-01T00:00:03.000Z","content":"Switched to Opus 4.8."}`,
+	)
+
+	mustContain(t, got, "COMMAND", "/teleport", "ERROR", "retry 1/10", "AGENTS KILLED", "MODEL REFUSAL FALLBACK")
+}
+
+func TestFormatShowsFailingHooksAndHidesCleanOnes(t *testing.T) {
+	clean := `{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-01-01T00:00:00.000Z","hookErrors":[],"preventedContinuation":false}`
+	failing := `{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-01-01T00:00:01.000Z","hookErrors":["boom"],"preventedContinuation":true,"stopReason":"blocked by guard"}`
+
+	got := renderLines(t, FormatOptions{}, clean, failing)
+	mustContain(t, got, "STOP HOOK", "1 hook error(s)", "blocked continuation", "blocked by guard")
+	if strings.Count(got, "STOP HOOK") != 1 {
+		t.Errorf("a clean stop hook should not render by default\n%s", got)
+	}
+
+	verbose := renderLines(t, FormatOptions{Verbose: true}, clean, failing)
+	if strings.Count(verbose, "STOP HOOK") != 2 {
+		t.Errorf("verbose should render both stop hooks\n%s", verbose)
+	}
+}
+
+func TestFormatVerboseAddsThinkingAttachmentsAndSuccessfulResults(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"weighing the options"},{"type":"text","text":"answer"}]}}`,
+		`{"type":"user","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"file1.txt"}]}}`,
+		`{"type":"attachment","timestamp":"2026-01-01T00:00:02.000Z","attachment":{"type":"file","filename":"/tmp/x.md","displayPath":"x.md"}}`,
+		`{"type":"system","subtype":"turn_duration","timestamp":"2026-01-01T00:00:03.000Z","durationMs":95150,"messageCount":50}`,
+	}
+
+	got := renderLines(t, FormatOptions{}, lines...)
+	mustContain(t, got, "answer")
+	mustNotContain(t, got, "weighing the options", "file1.txt", "ATTACHMENT", "TURN")
+
+	verbose := renderLines(t, FormatOptions{Verbose: true}, lines...)
+	mustContain(t, verbose, "THINKING", "weighing the options", "file1.txt", "ATTACHMENT file", "x.md", "TURN", "1m35s", "50 messages")
+}
+
+func TestFormatVerboseCarriesMinorRecordPayloads(t *testing.T) {
+	// These record types carry their whole meaning in one field. Rendering the
+	// bare type name reports that something happened and discards what it was.
+	lines := []string{
+		`{"type":"mode","timestamp":"2026-01-01T00:00:00.000Z","mode":"plan"}`,
+		`{"type":"permission-mode","timestamp":"2026-01-01T00:00:01.000Z","permissionMode":"acceptEdits"}`,
+		`{"type":"custom-title","timestamp":"2026-01-01T00:00:02.000Z","customTitle":"renamed by the user"}`,
+		`{"type":"agent-name","timestamp":"2026-01-01T00:00:03.000Z","agentName":"build-lead-2"}`,
+		`{"type":"last-prompt","timestamp":"2026-01-01T00:00:04.000Z","lastPrompt":"land the plane"}`,
+	}
+
+	mustNotContain(t, renderLines(t, FormatOptions{}, lines...), "MODE", "CUSTOM-TITLE")
+
+	verbose := renderLines(t, FormatOptions{Verbose: true}, lines...)
+	mustContain(t, verbose,
+		"[2026-01-01T00:00:00.000Z MODE] plan",
+		"[2026-01-01T00:00:01.000Z PERMISSION-MODE] acceptEdits",
+		"[2026-01-01T00:00:02.000Z CUSTOM-TITLE] renamed by the user",
+		"[2026-01-01T00:00:03.000Z AGENT-NAME] build-lead-2",
+		"[2026-01-01T00:00:04.000Z LAST-PROMPT] land the plane")
+}
+
+func TestFormatTailAppliesToTheMainFileButNotToInlinedAgents(t *testing.T) {
+	fs := newFakeSession(t,
+		userLine("2026-01-01T00:00:00.000Z", "OLD TURN THAT THE TAIL DROPS"),
+		assistantLine("2026-01-01T00:00:01.000Z", "old reply"),
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"look","subagent_type":"Explore"}}]}}`,
+	)
+	fs.addAgent("aabc123", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1"},
+		userLine("2026-01-01T00:00:10.000Z", "AGENT FIRST LINE"),
+		assistantLine("2026-01-01T00:00:11.000Z", "AGENT LAST LINE"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true, TailLines: 1}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	mustNotContain(t, got, "OLD TURN THAT THE TAIL DROPS")
+	// A tail of a subagent would cut off the prompt that gives its output
+	// meaning, so inlined subagents are always rendered whole.
+	mustContain(t, got, "AGENT FIRST LINE", "AGENT LAST LINE")
+}
+
+func TestFormatDoesNotInlineAnAgentTwiceForDuplicateRecords(t *testing.T) {
+	// Real transcripts contain records written twice with the same uuid. Both
+	// copies render, so a spawn can be seen twice; the subagent's transcript
+	// must still appear once.
+	spawn := `{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"look","subagent_type":"Explore"}}]}}`
+	fs := newFakeSession(t, spawn, spawn)
+	fs.addAgent("aabc123", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1"},
+		assistantLine("2026-01-01T00:00:10.000Z", "AGENT BODY"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	if got := strings.Count(buf.String(), "AGENT BODY"); got != 1 {
+		t.Errorf("subagent transcript inlined %d times, want 1\n%s", got, buf.String())
+	}
+}
+
+func TestFormatDefaultShapeIsUnchangedForPlainConversation(t *testing.T) {
+	// The default render must stay byte-identical to what the formatter
+	// produced before the tree work: header, body, blank line between blocks,
+	// no trailing blank line.
+	got := renderLines(t, FormatOptions{},
+		userLine("2026-01-01T00:00:00.000Z", "Hello"),
+		assistantLine("2026-01-01T00:00:01.000Z", "Hi"),
+	)
+
+	want := "[2026-01-01T00:00:00.000Z USER]\nHello\n\n[2026-01-01T00:00:01.000Z ASSISTANT]\nHi\n"
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+// --- Long-tail record classes -----------------------------------------------
+//
+// Everything below pins a rendering branch that the tests above leave
+// unexercised. Each one was chosen because mutating the branch it covers left
+// the rest of the suite green.
+
+// spawnLine builds an assistant record whose single tool_use is a subagent
+// spawn with the given tool-use ID, which is what a sidecar's toolUseId links
+// against.
+func spawnLine(timestamp string, toolUseID string, description string) string {
+	return `{"type":"assistant","timestamp":"` + timestamp + `","message":{"role":"assistant","content":[{"type":"tool_use","id":` + quote(toolUseID) + `,"name":"Agent","input":{"description":` + quote(description) + `}}]}}`
+}
+
+func TestFormatRendersSummaryRecords(t *testing.T) {
+	// A summary record is the auto-generated title of a resumed conversation;
+	// dropping it removes the only line saying what the session was about.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"summary","timestamp":"2026-01-01T00:00:00.000Z","summary":"Refactored the pool linker"}`,
+		`{"type":"summary","timestamp":"2026-01-01T00:00:01.000Z","summary":""}`,
+	)
+
+	mustContain(t, got, "[2026-01-01T00:00:00.000Z SUMMARY]\nRefactored the pool linker")
+	// An empty summary carries nothing, so it renders no header at all.
+	mustNotContain(t, got, "[2026-01-01T00:00:01.000Z SUMMARY]")
+}
+
+func TestFormatPrefixesSystemNoticesWithTheirLevel(t *testing.T) {
+	// api_error has its own earlier case and never reaches the level prefix; an
+	// "informational" record does. A warning-level notice rendered as an
+	// ordinary one is how a degraded run reads as a healthy one in a replay.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"system","subtype":"informational","timestamp":"2026-01-01T00:00:00.000Z","level":"warning","content":"context is running low"}`,
+		`{"type":"system","subtype":"informational","timestamp":"2026-01-01T00:00:01.000Z","level":"error","content":"tool call rejected"}`,
+		`{"type":"system","subtype":"informational","timestamp":"2026-01-01T00:00:02.000Z","content":"nothing special"}`,
+	)
+
+	mustContain(t, got,
+		"[2026-01-01T00:00:00.000Z WARNING INFORMATIONAL] context is running low",
+		"[2026-01-01T00:00:01.000Z ERROR INFORMATIONAL] tool call rejected",
+		"[2026-01-01T00:00:02.000Z INFORMATIONAL] nothing special")
+}
+
+func TestFormatRendersAPIErrorsWithoutRetryCounts(t *testing.T) {
+	// Not every api_error record carries maxRetries. Without the bare-detail
+	// branch the line would render as a header with nothing after it.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"system","subtype":"api_error","timestamp":"2026-01-01T00:00:00.000Z","level":"error"}`,
+	)
+
+	mustContain(t, got, "[2026-01-01T00:00:00.000Z ERROR] API error")
+	mustNotContain(t, got, "retry")
+}
+
+func TestFormatRendersPopAllQueueOperations(t *testing.T) {
+	// popAll drains a whole queue of typed-ahead instructions into a turn.
+	// Treating it as bookkeeping loses every message in it.
+	got := renderLines(t, FormatOptions{},
+		`{"type":"queue-operation","operation":"popAll","timestamp":"2026-01-01T00:00:00.000Z","content":"actually stop and rebase first"}`,
+	)
+
+	mustContain(t, got, "[2026-01-01T00:00:00.000Z QUEUED popAll] actually stop and rebase first")
+}
+
+func TestFormatVerboseStopHookDetail(t *testing.T) {
+	// The default-mode test only counts STOP HOOK occurrences, so neither the
+	// verbose hook count nor the clean-run wording is pinned by it.
+	clean := `{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-01-01T00:00:00.000Z","hookErrors":[]}`
+	ranHooks := `{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-01-01T00:00:01.000Z","hookErrors":[],"hookInfos":[{"name":"a"},{"name":"b"},{"name":"c"}]}`
+
+	got := renderLines(t, FormatOptions{Verbose: true}, clean, ranHooks)
+
+	mustContain(t, got,
+		"[2026-01-01T00:00:00.000Z STOP HOOK] ran clean",
+		"[2026-01-01T00:00:01.000Z STOP HOOK] 3 hook(s) ran")
+}
+
+func TestFormatDecodesEveryEventContentShape(t *testing.T) {
+	// A record's content is written as a bare string, an array of strings, an
+	// array of {text}/{content} blocks, or a single object. A shape the decoder
+	// cannot read renders the event with its payload silently missing.
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"bare string", `"plain content"`, "plain content"},
+		{"array of strings", `["alpha","bravo"]`, "alpha bravo"},
+		{"array of blocks", `[{"text":"gamma"},{"content":"delta"}]`, "gamma delta"},
+		{"single object", `{"text":"epsilon"}`, "epsilon"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderLines(t, FormatOptions{},
+				`{"type":"system","subtype":"local_command","timestamp":"2026-01-01T00:00:00.000Z","content":`+tt.content+`}`)
+			mustContain(t, got, "[2026-01-01T00:00:00.000Z COMMAND] "+tt.want)
+		})
+	}
+}
+
+func TestFormatAttachmentFallsBackThroughEveryLabelField(t *testing.T) {
+	// displayPath short-circuits the fallback chain, so a displayPath fixture
+	// exercises none of the fields below it — and an attachment whose only
+	// identifying field is one of those renders as a bare header.
+	tests := []struct {
+		name       string
+		attachment string
+		want       string
+	}{
+		{"displayPath", `{"type":"file","displayPath":"docs/x.md"}`, "ATTACHMENT file] docs/x.md"},
+		{"filename", `{"type":"file","filename":"/tmp/only-filename.md"}`, "ATTACHMENT file] /tmp/only-filename.md"},
+		{"path", `{"type":"file","path":"/tmp/only-path.md"}`, "ATTACHMENT file] /tmp/only-path.md"},
+		{"banner", `{"type":"notice","banner":"BANNER ONLY"}`, "ATTACHMENT notice] BANNER ONLY"},
+		{"hookName", `{"type":"hook","hookName":"PreToolUse-guard"}`, "ATTACHMENT hook] PreToolUse-guard"},
+		{"description", `{"type":"diagnostic","description":"lint reported 3 problems"}`, "ATTACHMENT diagnostic] lint reported 3 problems"},
+		{"style", `{"type":"output_style","style":"explanatory"}`, "ATTACHMENT output_style] explanatory"},
+		{"url", `{"type":"link","url":"https://example.com/spec"}`, "ATTACHMENT link] https://example.com/spec"},
+		{"content", `{"type":"hook_result","content":"hook stdout body"}`, "ATTACHMENT hook_result] hook stdout body"},
+		{"untyped with no identifying field", `{}`, "ATTACHMENT unknown]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderLines(t, FormatOptions{Verbose: true},
+				`{"type":"attachment","timestamp":"2026-01-01T00:00:00.000Z","attachment":`+tt.attachment+`}`)
+			mustContain(t, got, "[2026-01-01T00:00:00.000Z "+tt.want)
+		})
+	}
+}
+
+func TestFormatSkipsMalformedAttachments(t *testing.T) {
+	// An attachment payload that is not an object must render nothing, rather
+	// than an "ATTACHMENT unknown" header that looks like a real record.
+	got := renderLines(t, FormatOptions{Verbose: true},
+		`{"type":"attachment","timestamp":"2026-01-01T00:00:00.000Z","attachment":"not an object"}`,
+		`{"type":"attachment","timestamp":"2026-01-01T00:00:01.000Z","attachment":{"type":"file","displayPath":"real.md"}}`,
+	)
+
+	// The well-formed neighbour proves the attachment path ran at all, so the
+	// absence below is a real skip rather than a render that never happened.
+	mustContain(t, got, "[2026-01-01T00:00:01.000Z ATTACHMENT file] real.md")
+	mustNotContain(t, got, "2026-01-01T00:00:00.000Z ATTACHMENT")
+}
+
+func TestFormatEventDetailOccupiesExactlyOneLine(t *testing.T) {
+	// The documented contract for an event is one line. Both halves of it are
+	// load-bearing: an untruncated hook payload floods the render, and an
+	// uncollapsed one puts transcript text where a header is expected.
+	longTail := strings.Repeat("A", maxEventContentLen+20) + "TAIL_MARKER"
+
+	got := renderLines(t, FormatOptions{},
+		`{"type":"system","subtype":"local_command","timestamp":"2026-01-01T00:00:00.000Z","content":`+quote(longTail)+`}`,
+		`{"type":"system","subtype":"local_command","timestamp":"2026-01-01T00:00:01.000Z","content":"first fragment\nsecond fragment\n\n  third fragment"}`,
+	)
+
+	mustContain(t, got, "...")
+	mustNotContain(t, got, "TAIL_MARKER")
+	mustContain(t, got, "[2026-01-01T00:00:01.000Z COMMAND] first fragment second fragment third fragment")
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "second fragment") && !strings.Contains(line, "first fragment") {
+			t.Errorf("event detail wrapped onto a second line: %q", line)
+		}
+	}
+}
+
+func TestFormatHidesMetaUserRecordsByDefault(t *testing.T) {
+	// isMeta records are Claude Code's own injected scaffolding, not something
+	// the user said. Rendering them by default puts words in the user's mouth.
+	meta := `{"type":"user","isMeta":true,"timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"user","content":"Caveat: the messages below were generated by a hook."}}`
+
+	got := renderLines(t, FormatOptions{}, meta, userLine("2026-01-01T00:00:01.000Z", "a real turn"))
+	mustContain(t, got, "a real turn")
+	mustNotContain(t, got, "Caveat: the messages below")
+
+	mustContain(t, renderLines(t, FormatOptions{Verbose: true}, meta), "Caveat: the messages below")
+}
+
+func TestFormatExpandsDeepAgentChainsUpToTheNestingLimit(t *testing.T) {
+	// A chain one longer than maxExpansionDepth: expansion must recurse the
+	// whole chain and then say so when it stops, because an agent silently
+	// dropped at the bound is indistinguishable from one that never ran.
+	ids := []string{"a01", "a02", "a03", "a04", "a05", "a06", "a07", "a08", "a09", "a10", "a11", "a12", "a13"}
+
+	fs := newFakeSession(t, spawnLine("2026-01-01T00:00:00.000Z", "toolu_a01", "start the chain"))
+	// Carry the neighbours in variables rather than indexing off i: the guarded
+	// ids[i-1] is safe, but gosec cannot prove it (G602), and a lint suppression
+	// would be a worse trade than simply not indexing.
+	previousID := ""
+	for i, id := range ids {
+		// An empty ParentAgentID attaches the first agent to the session root.
+		meta := &AgentMeta{AgentType: "general-purpose", ToolUseID: "toolu_" + id, ParentAgentID: previousID}
+		lines := []string{assistantLine("2026-01-01T00:01:00.000Z", "BODY-"+id)}
+		for _, nextID := range ids[i+1:] {
+			lines = append(lines, spawnLine("2026-01-01T00:01:01.000Z", "toolu_"+nextID, "go deeper"))
+			break
+		}
+		fs.addAgent(id, meta, lines...)
+		previousID = id
+	}
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	// Nesting works well past one level, all the way to the bound.
+	mustContain(t, got, "--- begin agent a03 (general-purpose) ---", "--- begin agent a12 (general-purpose) ---")
+	for _, id := range ids[:len(ids)-1] {
+		mustContain(t, got, "BODY-"+id)
+	}
+	// The 13th is refused, and says why.
+	mustContain(t, got, "[agent a13 not expanded: nesting limit 12 reached]")
+	mustNotContain(t, got, "BODY-a13", "--- begin agent a13")
+	// The refusal is the anchor, so a13 is not also reported as unlinked.
+	mustNotContain(t, got, "[UNLINKED AGENTS]")
+}
+
+func TestFormatReportsAnUnreadableAgentTranscript(t *testing.T) {
+	fs := newFakeSession(t, spawnLine("2026-01-01T00:00:00.000Z", "toolu_1", "look"))
+	fs.addAgent("aunreadable", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1"},
+		assistantLine("2026-01-01T00:00:10.000Z", "unreachable body"))
+
+	path := filepath.Join(fs.projectDir, fs.sessionID, "subagents", "agent-aunreadable.jsonl")
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+	// Running as root defeats the permission bit, which would leave this test
+	// asserting on a transcript that read back perfectly fine.
+	if f, err := os.Open(path); err == nil {
+		f.Close()
+		t.Skip("cannot make a file unreadable in this environment")
+	}
+
+	root := fs.discover()
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	// A subagent that cannot be read must say so where its transcript belongs,
+	// not vanish from a render that claims to be complete.
+	mustContain(t, buf.String(), "[agent aunreadable transcript unreadable:")
+	mustNotContain(t, buf.String(), "unreachable body")
+}
+
+func TestFormatReportsAnAgentWithNoConversationMessages(t *testing.T) {
+	// A subagent that wrote only bookkeeping records renders an empty body.
+	// Without the placeholder the spawn's begin/end markers wrap nothing, which
+	// reads as a formatting bug rather than as the fact it is.
+	fs := newFakeSession(t, spawnLine("2026-01-01T00:00:00.000Z", "toolu_1", "look"))
+	fs.addAgent("aempty", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1"},
+		`{"type":"file-history-snapshot","timestamp":"2026-01-01T00:00:10.000Z"}`,
+		`{"type":"file-history-snapshot","timestamp":"2026-01-01T00:00:11.000Z"}`)
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+
+	mustContain(t, buf.String(),
+		"--- begin agent aempty (Explore) ---",
+		"(no conversation messages)",
+		"--- end agent aempty ---")
+}
+
+func TestFormatIndentsContinuationLinesOfMultiLineValues(t *testing.T) {
+	// A wrapped body whose later lines start at column zero is indistinguishable
+	// from a new transcript entry.
+	got := renderLines(t, FormatOptions{Verbose: true},
+		`{"type":"user","timestamp":"2026-01-01T00:00:00.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"result line one\nresult line two"}]}}`,
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"thought line one\nthought line two"}]}}`,
+	)
+
+	mustContain(t, got,
+		"  < result line one\n    result line two",
+		"  ~ THINKING: thought line one\n    thought line two")
+}
+
+func TestFormatRendersSubSecondAndSubMinuteAgentDurations(t *testing.T) {
+	// Only the minutes branch is exercised elsewhere, and most subagent runs
+	// are shorter than that.
+	tests := []struct {
+		name       string
+		durationMs string
+		want       string
+	}{
+		{"milliseconds", "820", "820ms"},
+		{"seconds", "12400", "12.4s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := renderLines(t, FormatOptions{},
+				`{"type":"user","timestamp":"2026-01-01T00:05:00.000Z","toolUseResult":{"status":"completed","agentId":"adur1","agentType":"Explore","totalDurationMs":`+tt.durationMs+`},"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"}]}}`)
+			mustContain(t, got, "< Agent adur1 (Explore) completed - "+tt.want)
+		})
+	}
+}
+
+func TestFormatOrdersUnlinkedAgentsByStartTime(t *testing.T) {
+	// The trailer's own sort is what puts these in start order: the tree walk
+	// reaches them parent-before-child, which here is not chronological.
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aparent", &AgentMeta{AgentType: "Explore"},
+		assistantLine("2026-01-01T00:05:00.000Z", "parent work"))
+	fs.addAgent("asibling", &AgentMeta{AgentType: "Explore"},
+		assistantLine("2026-01-01T00:03:00.000Z", "sibling work"))
+	fs.addAgent("achild", &AgentMeta{AgentType: "Explore", ParentAgentID: "aparent"},
+		assistantLine("2026-01-01T00:01:00.000Z", "child work"))
+	root := fs.discover()
+
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, FormatOptions{Root: root, ExpandAgents: true}, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	got := buf.String()
+
+	trailerIdx := strings.Index(got, "[UNLINKED AGENTS] 3 subagent transcript(s)")
+	if trailerIdx < 0 {
+		t.Fatalf("expected all three agents in an unlinked-agents trailer\n%s", got)
+	}
+	trailer := got[trailerIdx:]
+	child := strings.Index(trailer, "achild")
+	sibling := strings.Index(trailer, "asibling")
+	parent := strings.Index(trailer, "aparent")
+	if child < 0 || sibling < 0 || parent < 0 {
+		t.Fatalf("trailer should name all three agents, got\n%s", trailer)
+	}
+	if child > sibling || sibling > parent {
+		t.Errorf("trailer order = achild@%d asibling@%d aparent@%d, want chronological 00:01 < 00:03 < 00:05\n%s",
+			child, sibling, parent, trailer)
+	}
+}

--- a/internal/session/format_test.go
+++ b/internal/session/format_test.go
@@ -117,7 +117,7 @@ func TestFormatToolCall(t *testing.T) {
 	}
 }
 
-func TestFormatConversation(t *testing.T) {
+func TestFormatTranscriptFile(t *testing.T) {
 	claudeTmpDir := "/tmp/claude"
 	if err := os.MkdirAll(claudeTmpDir, 0755); err != nil {
 		t.Fatalf("failed to create /tmp/claude: %v", err)
@@ -306,13 +306,13 @@ func TestFormatConversation(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			if err := FormatConversation(jsonlFilepath, tt.n, &buf); err != nil {
-				t.Fatalf("FormatConversation() error: %v", err)
+			if err := FormatTranscriptFile(jsonlFilepath, FormatOptions{TailLines: tt.n}, &buf); err != nil {
+				t.Fatalf("FormatTranscriptFile() error: %v", err)
 			}
 
 			got := buf.String()
 			if got != tt.want {
-				t.Errorf("FormatConversation() =\n%q\nwant:\n%q", got, tt.want)
+				t.Errorf("FormatTranscriptFile() =\n%q\nwant:\n%q", got, tt.want)
 			}
 		})
 	}
@@ -320,8 +320,8 @@ func TestFormatConversation(t *testing.T) {
 
 func TestFormatConversationFileError(t *testing.T) {
 	var buf bytes.Buffer
-	err := FormatConversation("/nonexistent/path/session.jsonl", 0, &buf)
+	err := FormatTranscriptFile("/nonexistent/path/session.jsonl", FormatOptions{}, &buf)
 	if err == nil {
-		t.Error("FormatConversation() should return error for nonexistent file")
+		t.Error("FormatTranscriptFile() should return error for nonexistent file")
 	}
 }

--- a/internal/session/format_workflow_test.go
+++ b/internal/session/format_workflow_test.go
@@ -181,3 +181,53 @@ func TestFormatTimeWindowKeepsOnlyRecordsInsideIt(t *testing.T) {
 	all := renderRoot(t, root, FormatOptions{})
 	mustContain(t, all, "BEFORE", "AFTER", "NO TIMESTAMP")
 }
+
+func TestFormatBudgetSkipAccountsForWhatTheSkippedAgentSpawned(t *testing.T) {
+	// A loose agent whose transcript spawns a workflow run and a nested agent.
+	// Skipped for budget, the run and the nested agent must be attributed to
+	// the skip — not reported as "no spawn site in the printed range", which
+	// would be false: the site exists, it was not rendered.
+	fs := newFakeSession(t,
+		userLine("2026-01-01T00:00:00.000Z", "go"),
+		spawnLine("2026-01-01T00:01:00.000Z", "toolu_outer", "outer"),
+	)
+	outerLines := append([]string{userLine("2026-01-01T00:01:01.000Z", strings.Repeat("o", 3000))},
+		workflowSpawn("2026-01-01T00:01:02.000Z", "toolu_inner_wf", "wnested1")...)
+	outerLines = append(outerLines, spawnLine("2026-01-01T00:01:03.000Z", "toolu_inner_agent", "inner"))
+	fs.addAgent("aouter", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_outer"}, outerLines...)
+	fs.addAgent("ainner", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_inner_agent", ParentAgentID: "aouter"}, assistantLine("2026-01-01T00:01:04.000Z", "inner body"))
+	fs.addWorkflowAgent("wf_nest0001-aaa", "awn", assistantLine("2026-01-01T00:01:05.000Z", "wf body"))
+	fs.addWorkflowManifest("wf_nest0001-aaa", `{"taskId":"wnested1","workflowName":"nested","status":"completed","startTime":1767225665000}`)
+	root := fs.discover()
+
+	got := renderRoot(t, root, FormatOptions{ExpandAgents: true, MaxExpandBytes: 1024})
+
+	mustContain(t, got, "[agent aouter not expanded: ", "; 1 nested agent(s) and 1 workflow run(s) spawned inside it are not shown either]")
+	mustNotContain(t, got, "[UNLINKED WORKFLOWS]", "[UNLINKED AGENTS]", "inner body")
+
+	// Positive control: with the budget off, the run is anchored inside the
+	// inlined block and nothing is reported unlinked either.
+	all := renderRoot(t, root, FormatOptions{ExpandAgents: true})
+	mustContain(t, all, "[workflow wf_nest0001-aaa (nested): 1 agents, completed]", "--- begin agent ainner")
+	mustNotContain(t, all, "[UNLINKED WORKFLOWS]", "[UNLINKED AGENTS]")
+}
+
+func TestFormatBudgetNoteRendersOncePerAgent(t *testing.T) {
+	// Real files carry the same tool_use block in several records with
+	// distinct uuids; the note must not repeat with them.
+	fs := newFakeSession(t,
+		userLine("2026-01-01T00:00:00.000Z", "go"),
+		spawnLine("2026-01-01T00:01:00.000Z", "toolu_big", "big"),
+		strings.Replace(spawnLine("2026-01-01T00:01:00.000Z", "toolu_big", "big"), `"uuid":"`, `"uuid":"dup-`, 1),
+	)
+	fs.addAgent("abig", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_big"}, assistantLine("2026-01-01T00:01:01.000Z", strings.Repeat("b", 3000)))
+	root := fs.discover()
+
+	got := renderRoot(t, root, FormatOptions{ExpandAgents: true, MaxExpandBytes: 1024})
+	if n := strings.Count(got, "[agent abig not expanded"); n != 1 {
+		t.Errorf("budget note rendered %d times for one agent, want 1\n%s", n, got)
+	}
+	if n := strings.Count(renderRoot(t, root, FormatOptions{ExpandAgents: true}), "--- begin agent abig"); n != 1 {
+		t.Errorf("control: agent inlined %d times, want 1", n)
+	}
+}

--- a/internal/session/format_workflow_test.go
+++ b/internal/session/format_workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 )
 
 // workflowSpawn writes the two records a Workflow call leaves in a transcript:
@@ -155,4 +156,28 @@ func TestFormatExpansionBudgetIsChargedPerAgentAsItIsInlined(t *testing.T) {
 
 	unlimited := renderRoot(t, root, FormatOptions{ExpandAgents: true})
 	mustContain(t, unlimited, "--- begin agent afirst", "--- begin agent asecond")
+}
+
+func TestFormatTimeWindowKeepsOnlyRecordsInsideIt(t *testing.T) {
+	fs := newFakeSession(t,
+		`{"type":"user","uuid":"f1","timestamp":"2026-01-01T00:00:00.000Z","forkedFrom":{"sessionId":"src-session","messageUuid":"x"},"message":{"role":"user","content":"BEFORE"}}`,
+		userLine("2026-01-01T10:00:00.000Z", "INSIDE ONE"),
+		`{"type":"queue-operation","operation":"enqueue","content":"NO TIMESTAMP"}`,
+		userLine("2026-01-01T11:00:00.000Z", "INSIDE TWO"),
+		userLine("2026-01-01T12:00:00.000Z", "AFTER"),
+	)
+	fs.addAgent("aloose", &AgentMeta{AgentType: "Explore"}, assistantLine("2026-01-01T10:30:00.000Z", "agent body"))
+	root := fs.discover()
+
+	got := renderRoot(t, root, FormatOptions{
+		Since: time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC),
+	})
+
+	mustContain(t, got, "INSIDE ONE", "INSIDE TWO", "[FORK] this session was forked from session src-session", "[SUBAGENTS] 1 transcript(s) not shown")
+	mustNotContain(t, got, "BEFORE", "AFTER", "NO TIMESTAMP")
+
+	// Positive control: with no window, everything renders.
+	all := renderRoot(t, root, FormatOptions{})
+	mustContain(t, all, "BEFORE", "AFTER", "NO TIMESTAMP")
 }

--- a/internal/session/format_workflow_test.go
+++ b/internal/session/format_workflow_test.go
@@ -1,0 +1,158 @@
+package session
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// workflowSpawn writes the two records a Workflow call leaves in a transcript:
+// the assistant's tool_use and the user-side tool_result naming the task ID.
+func workflowSpawn(timestamp string, toolUseID string, taskID string) []string {
+	return []string{
+		`{"type":"assistant","timestamp":"` + timestamp + `","uuid":"wu-` + toolUseID + `","message":{"role":"assistant","content":[{"type":"tool_use","id":"` + toolUseID + `","name":"Workflow","input":{"scriptPath":"/x/analyze.js"}}]}}`,
+		`{"type":"user","timestamp":"` + timestamp + `","uuid":"wr-` + toolUseID + `","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"` + toolUseID + `","content":"Workflow launched in background. Task ID: ` + taskID + `\nSummary: one agent per thread"}]}}`,
+	}
+}
+
+func sessionWithOneWorkflowRun(t *testing.T, extraMain ...string) *fakeSession {
+	t.Helper()
+	lines := append([]string{userLine("2026-01-01T00:00:00.000Z", "go")}, workflowSpawn("2026-01-01T00:01:00.000Z", "toolu_wf1", "w9gxz79on")...)
+	lines = append(lines, extraMain...)
+	fs := newFakeSession(t, lines...)
+	fs.addWorkflowAgent("wf_3a23189e-9d5", "aw1", assistantLine("2026-01-01T00:02:00.000Z", "WORKFLOW AGENT ONE BODY"))
+	fs.addWorkflowAgent("wf_3a23189e-9d5", "aw2", assistantLine("2026-01-01T00:03:00.000Z", "WORKFLOW AGENT TWO BODY"))
+	fs.addWorkflowJournal("wf_3a23189e-9d5", []string{"aw1", "aw2"}, 1)
+	fs.addWorkflowManifest("wf_3a23189e-9d5", `{"runId":"wf_3a23189e-9d5","timestamp":"2026-01-01T00:01:00.500Z","taskId":"w9gxz79on","workflowName":"analyze","summary":"one agent per thread","status":"completed","durationMs":"1487202"}`)
+	return fs
+}
+
+func renderRoot(t *testing.T, root *Transcript, opts FormatOptions) string {
+	t.Helper()
+	opts.Root = root
+	var buf bytes.Buffer
+	if err := FormatTranscript(root, opts, &buf); err != nil {
+		t.Fatalf("FormatTranscript: %v", err)
+	}
+	return buf.String()
+}
+
+func TestFormatAnchorsAWorkflowSpawnToItsRun(t *testing.T) {
+	// A Workflow call used to render as a bare "> Workflow()" — 62 times in one
+	// real session — with no run ID, no count and no way to open it.
+	root := sessionWithOneWorkflowRun(t).discover()
+	got := renderRoot(t, root, FormatOptions{})
+
+	mustContain(t, got, `> Workflow()  [workflow wf_3a23189e-9d5 (analyze): 2 agents, completed, `)
+	mustNotContain(t, got, "WORKFLOW AGENT ONE BODY")
+}
+
+func TestFormatFooterCountsEverythingNotShown(t *testing.T) {
+	fs := sessionWithOneWorkflowRun(t)
+	fs.addAgent("aloose", &AgentMeta{AgentType: "Explore"}, assistantLine("2026-01-01T00:05:00.000Z", "loose body"))
+	root := fs.discover()
+
+	got := renderRoot(t, root, FormatOptions{ListCommand: "agenc session print 11111111 --agents"})
+
+	footer := "[SUBAGENTS] 3 transcript(s) not shown: 1 spawned directly, 2 in 1 workflow run(s) - --agents to list them, --agent <id> or --workflow <id> to open one - agenc session print 11111111 --agents"
+	mustContain(t, got, footer)
+	if !strings.HasSuffix(strings.TrimRight(got, "\n"), footer) {
+		t.Errorf("the footer must be the last line of the render")
+	}
+}
+
+func TestFormatFooterIsSilentWhenNothingIsHidden(t *testing.T) {
+	root := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go")).discover()
+	mustNotContain(t, renderRoot(t, root, FormatOptions{}), "[SUBAGENTS]", "[WORKFLOWS]")
+}
+
+func TestFormatFooterIsScopedToTheMainTranscript(t *testing.T) {
+	fs := sessionWithOneWorkflowRun(t)
+	fs.addAgent("aloose", &AgentMeta{AgentType: "Explore"}, assistantLine("2026-01-01T00:05:00.000Z", "loose body"))
+	root := fs.discover()
+	agent, err := ResolveAgent(root, "aloose")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := FormatTranscript(agent, FormatOptions{Root: root}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	mustNotContain(t, buf.String(), "[SUBAGENTS]")
+}
+
+func TestFormatExpansionNeverInlinesWorkflowRuns(t *testing.T) {
+	root := sessionWithOneWorkflowRun(t).discover()
+	got := renderRoot(t, root, FormatOptions{ExpandAgents: true})
+
+	mustNotContain(t, got, "WORKFLOW AGENT ONE BODY", "begin agent aw1", "[UNLINKED WORKFLOWS]", "[UNLINKED AGENTS]")
+	mustContain(t, got, "[WORKFLOWS] 2 agent transcript(s) in 1 workflow run(s) are not inlined - --workflow <id> to list a run")
+}
+
+func TestFormatListsWorkflowRunsWhoseSpawnIsOutsideTheTail(t *testing.T) {
+	// Twenty records after the spawn push it out of a --tail 5 window. Under
+	// expansion the run must still be accounted for, by name, once — not once
+	// per agent.
+	var filler []string
+	for i := 0; i < 20; i++ {
+		filler = append(filler, userLine("2026-01-01T00:10:00.000Z", "later"))
+	}
+	root := sessionWithOneWorkflowRun(t, filler...).discover()
+	got := renderRoot(t, root, FormatOptions{ExpandAgents: true, TailLines: 5})
+
+	mustNotContain(t, got, "[workflow wf_3a23189e-9d5")
+	mustContain(t, got, "[UNLINKED WORKFLOWS] 1 workflow run(s) with no spawn site in the printed range", "  wf_3a23189e-9d5 (analyze): 2 agent(s), completed")
+	if n := strings.Count(got, "wf_3a23189e-9d5"); n != 1 {
+		t.Errorf("run named %d times, want exactly once (the trailer line), not once per agent; got:\n%s", n, got)
+	}
+}
+
+func TestScanFindsTaskIDsOutsideTheTailWindow(t *testing.T) {
+	// The link between a spawn and its run lives in the tool_result record, so
+	// it must be collected over the whole file like fork provenance is.
+	var filler []string
+	for i := 0; i < 20; i++ {
+		filler = append(filler, userLine("2026-01-01T00:10:00.000Z", "later"))
+	}
+	root := sessionWithOneWorkflowRun(t, filler...).discover()
+	_, _, taskIDs, err := scanTranscriptFile(root.Filepath, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if taskIDs["toolu_wf1"] != "w9gxz79on" {
+		t.Errorf("taskIDs = %v", taskIDs)
+	}
+}
+
+func TestFormatWorkflowSpawnWithNoRunOnDiskStaysBare(t *testing.T) {
+	// A spawn whose run directory and manifest were both deleted has nothing to
+	// anchor to; rendering must not invent one.
+	fs := newFakeSession(t, append([]string{userLine("2026-01-01T00:00:00.000Z", "go")}, workflowSpawn("2026-01-01T00:01:00.000Z", "toolu_gone", "wgone")...)...)
+	got := renderRoot(t, fs.discover(), FormatOptions{})
+	mustContain(t, got, "> Workflow()")
+	mustNotContain(t, got, "[workflow", "[SUBAGENTS]")
+}
+
+func TestFormatExpansionBudgetIsChargedPerAgentAsItIsInlined(t *testing.T) {
+	// Two agents of ~2 KB each under a 3 KB budget: the first is inlined, the
+	// second is replaced by a note naming its size, the budget and the flags.
+	// Charging at the inline site, not up front, is what lets a tailed render
+	// expand the agents in its window without being refused for the rest.
+	body := strings.Repeat("y", 2000)
+	fs := newFakeSession(t,
+		userLine("2026-01-01T00:00:00.000Z", "go"),
+		spawnLine("2026-01-01T00:01:00.000Z", "toolu_1", "first"),
+		spawnLine("2026-01-01T00:02:00.000Z", "toolu_2", "second"),
+	)
+	fs.addAgent("afirst", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1"}, assistantLine("2026-01-01T00:01:01.000Z", "FIRST "+body))
+	fs.addAgent("asecond", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_2"}, assistantLine("2026-01-01T00:02:01.000Z", "SECOND "+body))
+	root := fs.discover()
+
+	got := renderRoot(t, root, FormatOptions{ExpandAgents: true, MaxExpandBytes: 3 * 1024})
+
+	mustContain(t, got, "--- begin agent afirst", "[agent asecond not expanded: ", " would exceed the 3.0 KB expansion budget; raise --max-expand-mb, or print it alone with --agent asecond]")
+	mustNotContain(t, got, "SECOND yyy", "[UNLINKED AGENTS]")
+
+	unlimited := renderRoot(t, root, FormatOptions{ExpandAgents: true})
+	mustContain(t, unlimited, "--- begin agent afirst", "--- begin agent asecond")
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // errStopScanningForConversation is a sentinel returned from hasConversationData's
@@ -196,4 +197,26 @@ func findMostRecentJSONL(projectDirpath string) string {
 	}
 
 	return latestFilepath
+}
+
+// WriteJSONLWindow copies the records of a JSONL file whose timestamp falls in
+// [since, until] to w, one per line, and returns how many it wrote. A zero
+// bound is open on that side; a record with no timestamp is skipped when any
+// bound is set. It is the raw-format counterpart of the text renderer's window.
+func WriteJSONLWindow(jsonlFilepath string, since time.Time, until time.Time, w io.Writer) (int, error) {
+	written := 0
+	err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
+		if !inTimeWindow(string(line), since, until) {
+			return nil
+		}
+		if _, err := w.Write(line); err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte("\n")); err != nil {
+			return err
+		}
+		written++
+		return nil
+	})
+	return written, err
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -135,10 +135,16 @@ func TailJSONLFile(jsonlFilepath string, n int, w io.Writer) (int, error) {
 		return count, err
 	}
 
-	ring := make([]string, n)
+	// The ring grows to the requested size rather than being allocated up
+	// front, so a mistyped line count cannot reserve gigabytes for a small file.
+	ring := make([]string, 0, ringSeedCapacity(n))
 	total := 0
 	err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
-		ring[total%n] = string(line)
+		if len(ring) < n {
+			ring = append(ring, string(line))
+		} else {
+			ring[total%n] = string(line)
+		}
 		total++
 		return nil
 	})

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -219,4 +220,50 @@ func WriteJSONLWindow(jsonlFilepath string, since time.Time, until time.Time, w 
 		return nil
 	})
 	return written, err
+}
+
+// LatestTranscriptActivity returns the most recent modification time among
+// everything a project's sessions write: each session's main JSONL and every
+// subagent transcript and workflow journal beneath it, in both layouts. It is
+// the liveness signal for idle detection.
+//
+// The main JSONL alone is not that signal. While the main agent waits on a
+// subagent or a workflow run it writes nothing, and on this machine one run
+// lasted 47 minutes against a 30-minute idle timeout — the mission would have
+// been stopped mid-run with 699 agents working under it. The subagent files
+// are where the activity is during exactly the stretches the main file is
+// silent.
+func LatestTranscriptActivity(projectDirpath string) (time.Time, bool) {
+	var latest time.Time
+	found := false
+	note := func(info os.FileInfo) {
+		if info.ModTime().After(latest) {
+			latest = info.ModTime()
+		}
+		found = true
+	}
+	entries, err := os.ReadDir(projectDirpath)
+	if err != nil {
+		return time.Time{}, false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			if strings.HasSuffix(entry.Name(), ".jsonl") {
+				if info, err := entry.Info(); err == nil {
+					note(info)
+				}
+			}
+			continue
+		}
+		_ = filepath.WalkDir(filepath.Join(projectDirpath, entry.Name(), subagentsDirname), func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
+				return nil
+			}
+			if info, err := d.Info(); err == nil {
+				note(info)
+			}
+			return nil
+		})
+	}
+	return latest, found
 }

--- a/internal/session/transcript.go
+++ b/internal/session/transcript.go
@@ -17,10 +17,11 @@ import (
 //	agent-<agent-id>.jsonl       the subagent's conversation
 //	agent-<agent-id>.meta.json   who spawned it, what type, how deep
 //
-// Subagents nest — a subagent can spawn subagents — but the directory stays
-// flat: every descendant of the session, at any depth, is a sibling file in
-// that one directory. The tree is reconstructed from each meta file's
-// parentAgentId, not from the filesystem layout.
+// Subagents nest — a subagent can spawn subagents — but that directory stays
+// flat: every descendant spawned with the Agent tool, at any depth, is a
+// sibling file in it, and the tree is reconstructed from each meta file's
+// parentAgentId, not from the filesystem layout. Agents spawned by the Workflow
+// tool live one level down, in subagents/workflows/<run-id>/; see workflow.go.
 
 const (
 	// subagentsDirname is the directory under <project>/<session-id>/ holding
@@ -53,11 +54,13 @@ const (
 var errStopScanning = errors.New("stop scanning")
 
 // AgentMeta mirrors the fields of a subagent's agent-<id>.meta.json sidecar.
-// Every field is optional, and on a long-lived machine most of them are absent:
-// of 7053 subagent transcripts, 3.6% have no sidecar at all, only 31% of the
-// sidecars name a parentAgentId, and only 8.4% of named agents carry a
-// toolUseId. Discovery therefore never requires a sidecar — a subagent with no
-// metadata still appears in the tree, attached to the session root.
+// Every field is optional, and on a long-lived machine most of them are absent.
+// Measured over the flat subagents/ directories of every session on one
+// machine (7158 transcripts): 3.6% have no sidecar at all, 30% of the sidecars
+// name a parentAgentId, and 8.3% of named agents carry a toolUseId. Workflow
+// agents' sidecars (8918 more) carry only agentType and spawnDepth. Discovery
+// therefore never requires a sidecar — a subagent with no metadata still
+// appears in the tree, attached to the session root.
 type AgentMeta struct {
 	AgentType       string `json:"agentType"`
 	CustomAgentType string `json:"customAgentType"`
@@ -139,6 +142,19 @@ type Transcript struct {
 
 	// Children are the subagents this transcript spawned, ordered by StartedAt.
 	Children []*Transcript
+
+	// Bytes is the transcript's size on disk.
+	Bytes int64
+
+	// Workflow is the run this agent belongs to, or nil for the main transcript
+	// and for agents spawned directly with the Agent tool.
+	Workflow *WorkflowRun
+
+	// Workflows lists the session's workflow runs, ordered by start time. Only
+	// the session root carries them; a run's agents are reached through the
+	// run, not through Children, so Walk and Flatten stay bounded by the number
+	// of directly spawned agents.
+	Workflows []*WorkflowRun
 }
 
 // IsMain reports whether this is the session's own transcript rather than a
@@ -170,6 +186,22 @@ func (t *Transcript) Flatten() []*Transcript {
 	return out
 }
 
+// AllAgents returns every subagent transcript of the session in listing order:
+// the directly spawned ones depth-first, then each workflow run's agents by
+// run. It is the set a completeness claim must be checked against.
+func (t *Transcript) AllAgents() []*Transcript {
+	var out []*Transcript
+	t.Walk(func(n *Transcript) {
+		if !n.IsMain() {
+			out = append(out, n)
+		}
+	})
+	for _, run := range t.Workflows {
+		out = append(out, run.Agents...)
+	}
+	return out
+}
+
 // SessionSubagentsDirpath returns the directory holding a session's subagent
 // transcripts. The directory does not necessarily exist — a session that never
 // spawned a subagent has none.
@@ -196,10 +228,12 @@ func DiscoverSessionTranscripts(projectDirpath string, sessionID string) (*Trans
 	root := &Transcript{
 		Filepath:  mainFilepath,
 		StartedAt: readStartTimestamp(mainFilepath),
+		Bytes:     fileSize(mainFilepath),
 	}
 
-	nodes := discoverSubagentTranscripts(SessionSubagentsDirpath(projectDirpath, sessionID))
-	linkTranscriptTree(root, nodes)
+	subagentsDirpath := SessionSubagentsDirpath(projectDirpath, sessionID)
+	linkTranscriptTree(root, discoverSubagentTranscripts(subagentsDirpath, true))
+	root.Workflows = discoverWorkflowRuns(subagentsDirpath, SessionWorkflowsDirpath(projectDirpath, sessionID))
 	return root, nil
 }
 
@@ -216,7 +250,10 @@ func DiscoverTranscriptsForFile(jsonlFilepath string) (*Transcript, error) {
 // discoverSubagentTranscripts reads every agent-<id>.jsonl in a subagents
 // directory, pairing each with its sidecar metadata when present. Returns nil
 // when the directory does not exist or cannot be read.
-func discoverSubagentTranscripts(subagentsDirpath string) []*Transcript {
+//
+// readStarts controls whether each transcript's first timestamp is read now;
+// a workflow run's agents defer it (see WorkflowRun.LoadAgentDetails).
+func discoverSubagentTranscripts(subagentsDirpath string, readStarts bool) []*Transcript {
 	entries, err := os.ReadDir(subagentsDirpath)
 	if err != nil {
 		return nil
@@ -236,13 +273,17 @@ func discoverSubagentTranscripts(subagentsDirpath string) []*Transcript {
 		transcriptFilepath := filepath.Join(subagentsDirpath, name)
 		meta, metaFound := readAgentMeta(filepath.Join(subagentsDirpath, agentFilePrefix+agentID+agentMetaSuffix))
 
-		nodes = append(nodes, &Transcript{
+		node := &Transcript{
 			AgentID:   agentID,
 			Filepath:  transcriptFilepath,
 			Meta:      meta,
 			MetaFound: metaFound,
-			StartedAt: readStartTimestamp(transcriptFilepath),
-		})
+			Bytes:     fileSize(transcriptFilepath),
+		}
+		if readStarts {
+			node.StartedAt = readStartTimestamp(transcriptFilepath)
+		}
+		nodes = append(nodes, node)
 	}
 	return nodes
 }
@@ -315,22 +356,34 @@ func createsParentCycle(byID map[string]*Transcript, agentID string, parentID st
 	return true
 }
 
+// lessByStart orders transcripts chronologically, breaking ties by agent ID so
+// two agents that started in the same instant list deterministically.
+func lessByStart(a, b *Transcript) bool {
+	if a.StartedAt != b.StartedAt {
+		return a.StartedAt < b.StartedAt
+	}
+	return a.AgentID < b.AgentID
+}
+
 // assignDepthsAndSort walks the linked tree setting Depth from the tree shape
 // and ordering each node's children chronologically. Sibling order falls back
 // to agent ID so the output is deterministic when timestamps are missing or
 // identical.
 func assignDepthsAndSort(node *Transcript, depth int) {
 	node.Depth = depth
-	sort.SliceStable(node.Children, func(i, j int) bool {
-		a, b := node.Children[i], node.Children[j]
-		if a.StartedAt != b.StartedAt {
-			return a.StartedAt < b.StartedAt
-		}
-		return a.AgentID < b.AgentID
-	})
+	sort.SliceStable(node.Children, func(i, j int) bool { return lessByStart(node.Children[i], node.Children[j]) })
 	for _, child := range node.Children {
 		assignDepthsAndSort(child, depth+1)
 	}
+}
+
+// fileSize returns a file's size in bytes, or 0 when it cannot be stat'ed.
+func fileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }
 
 // readStartTimestamp returns the timestamp of the first timestamped record in a
@@ -457,41 +510,56 @@ func decodeContentBlocks(rawMessage json.RawMessage) []contentBlock {
 // matches the requested ID prefix.
 var ErrAgentNotFound = errors.New("no matching subagent transcript")
 
-// ResolveAgent finds the single subagent in a transcript tree whose agent ID
-// starts with the given prefix. An exact match always wins over prefix matches.
-// An ambiguous prefix is an error naming every candidate, so the caller can
-// print something actionable rather than picking arbitrarily.
-func ResolveAgent(root *Transcript, prefix string) (*Transcript, error) {
-	if prefix == "" {
+// ResolveAgent finds the single subagent an agent would mean by a key: its
+// agent ID, a unique prefix of it, its spawn-time name, or a unique prefix of
+// its name or a substring of its description. Workflow agents are searched
+// too. An exact ID match always wins, then an exact name; an ambiguous key is
+// an error naming every candidate, so the caller can print something
+// actionable rather than picking arbitrarily.
+func ResolveAgent(root *Transcript, key string) (*Transcript, error) {
+	if key == "" {
 		return nil, fmt.Errorf("%w: empty agent ID", ErrAgentNotFound)
 	}
 
-	var exact *Transcript
-	var matches []*Transcript
-	root.Walk(func(n *Transcript) {
-		if n.IsMain() || !strings.HasPrefix(n.AgentID, prefix) {
-			return
+	var idPrefix, nameMatch, textMatch []*Transcript
+	lower := strings.ToLower(key)
+	for _, n := range root.AllAgents() {
+		switch {
+		case n.AgentID == key:
+			return n, nil
+		case strings.HasPrefix(n.AgentID, key):
+			idPrefix = append(idPrefix, n)
 		}
-		if n.AgentID == prefix && exact == nil {
-			exact = n
+		if n.Meta.Name == key {
+			nameMatch = append(nameMatch, n)
+		} else if strings.HasPrefix(strings.ToLower(n.Meta.Name), lower) || strings.Contains(strings.ToLower(n.Meta.Description), lower) {
+			textMatch = append(textMatch, n)
 		}
-		matches = append(matches, n)
-	})
+	}
 
-	if exact != nil {
-		return exact, nil
-	}
-	switch len(matches) {
-	case 0:
-		return nil, fmt.Errorf("%w for ID prefix '%s'", ErrAgentNotFound, prefix)
-	case 1:
-		return matches[0], nil
-	default:
-		ids := make([]string, 0, len(matches))
-		for _, m := range matches {
-			ids = append(ids, m.AgentID)
+	for _, candidates := range [][]*Transcript{idPrefix, nameMatch, textMatch} {
+		switch len(candidates) {
+		case 0:
+			continue
+		case 1:
+			return candidates[0], nil
+		default:
+			return nil, fmt.Errorf("agent '%s' is ambiguous, matches: %s", key, describeAgents(candidates))
 		}
-		sort.Strings(ids)
-		return nil, fmt.Errorf("agent ID prefix '%s' is ambiguous, matches: %s", prefix, strings.Join(ids, ", "))
 	}
+	return nil, fmt.Errorf("%w for '%s'", ErrAgentNotFound, key)
+}
+
+// describeAgents renders candidates as "id (label)" pairs, sorted by ID.
+func describeAgents(agents []*Transcript) string {
+	parts := make([]string, 0, len(agents))
+	for _, a := range agents {
+		if label := a.Meta.DisplayLabel(); label != "" {
+			parts = append(parts, fmt.Sprintf("%s (%s)", a.AgentID, label))
+		} else {
+			parts = append(parts, a.AgentID)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
 }

--- a/internal/session/transcript.go
+++ b/internal/session/transcript.go
@@ -422,6 +422,9 @@ type TranscriptStats struct {
 	CompactBoundaries int
 	FirstTimestamp    string
 	LastTimestamp     string
+
+	// ForkedFromSessionID is the session this one was forked from, or "".
+	ForkedFromSessionID string
 }
 
 // SummarizeTranscript scans a JSONL transcript and counts its conversation
@@ -442,9 +445,13 @@ func SummarizeTranscript(jsonlFilepath string) (TranscriptStats, error) {
 			Timestamp string          `json:"timestamp"`
 			UUID      string          `json:"uuid"`
 			Message   json.RawMessage `json:"message"`
+			Fork      *forkRef        `json:"forkedFrom"`
 		}
 		if err := json.Unmarshal(line, &record); err != nil {
 			return nil
+		}
+		if record.Fork != nil && record.Fork.SessionID != "" && stats.ForkedFromSessionID == "" {
+			stats.ForkedFromSessionID = record.Fork.SessionID
 		}
 		// A record with no uuid (queue operations, titles, mode switches) has
 		// nothing to identify it, so it is always counted.

--- a/internal/session/transcript.go
+++ b/internal/session/transcript.go
@@ -1,0 +1,497 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// A Claude session is not a single file. The main conversation lives at
+// <project>/<session-id>.jsonl, but every subagent the session spawns gets its
+// own transcript under <project>/<session-id>/subagents/, written as a pair:
+//
+//	agent-<agent-id>.jsonl       the subagent's conversation
+//	agent-<agent-id>.meta.json   who spawned it, what type, how deep
+//
+// Subagents nest — a subagent can spawn subagents — but the directory stays
+// flat: every descendant of the session, at any depth, is a sibling file in
+// that one directory. The tree is reconstructed from each meta file's
+// parentAgentId, not from the filesystem layout.
+
+const (
+	// subagentsDirname is the directory under <project>/<session-id>/ holding
+	// subagent transcripts.
+	subagentsDirname = "subagents"
+
+	// agentFilePrefix and agentFileSuffix bracket the agent ID in a subagent
+	// transcript filename: agent-<agent-id>.jsonl
+	agentFilePrefix = "agent-"
+	agentFileSuffix = ".jsonl"
+
+	// agentMetaSuffix replaces agentFileSuffix to locate a subagent's sidecar
+	// metadata file: agent-<agent-id>.meta.json
+	agentMetaSuffix = ".meta.json"
+
+	// startTimestampScanLimit caps how many leading JSONL records are examined
+	// when looking for a transcript's first timestamp. Discovery orders
+	// subagents chronologically, and the first record almost always carries a
+	// timestamp; the limit keeps discovery from reading whole files.
+	startTimestampScanLimit = 8
+
+	// maxExpansionDepth bounds recursive subagent expansion. Real spawn depths
+	// observed on disk top out around 5; the bound exists so that a corrupted
+	// or cyclic parentAgentId chain cannot produce unbounded output.
+	maxExpansionDepth = 12
+)
+
+// errStopScanning halts ScanJSONLLines once a callback has what it needs.
+// Callers identify it with errors.Is and treat it as success.
+var errStopScanning = errors.New("stop scanning")
+
+// AgentMeta mirrors the fields of a subagent's agent-<id>.meta.json sidecar.
+// Every field is optional, and on a long-lived machine most of them are absent:
+// of 7053 subagent transcripts, 3.6% have no sidecar at all, only 31% of the
+// sidecars name a parentAgentId, and only 8.4% of named agents carry a
+// toolUseId. Discovery therefore never requires a sidecar — a subagent with no
+// metadata still appears in the tree, attached to the session root.
+type AgentMeta struct {
+	AgentType       string `json:"agentType"`
+	CustomAgentType string `json:"customAgentType"`
+	Description     string `json:"description"`
+	Name            string `json:"name"`
+	ToolUseID       string `json:"toolUseId"`
+	ParentAgentID   string `json:"parentAgentId"`
+	SpawnDepth      *int   `json:"spawnDepth"`
+	Model           string `json:"model"`
+	TaskKind        string `json:"taskKind"`
+	TeamName        string `json:"teamName"`
+	PermissionMode  string `json:"permissionMode"`
+	IsFork          bool   `json:"isFork"`
+	StoppedByUser   bool   `json:"stoppedByUser"`
+}
+
+// DisplayType returns the most specific agent-type label available, preferring
+// a custom agent type over the built-in one and falling back to "unknown" when
+// no sidecar was found.
+//
+// A forked agent is marked, because it did not start from a fresh context: it
+// inherited its spawner's entire conversation, so its transcript begins mid
+// thought and reads as though records are missing when nothing is.
+func (m AgentMeta) DisplayType() string {
+	base := "unknown"
+	switch {
+	case m.CustomAgentType != "":
+		base = m.CustomAgentType
+	case m.AgentType != "":
+		base = m.AgentType
+	}
+	if m.IsFork {
+		return base + " (fork)"
+	}
+	return base
+}
+
+// DisplayLabel returns the human-facing one-line label for an agent: its
+// spawn-time name if it was given one, otherwise the description the spawner
+// wrote, otherwise an empty string.
+func (m AgentMeta) DisplayLabel() string {
+	if m.Name != "" {
+		return m.Name
+	}
+	return m.Description
+}
+
+// Transcript is a single JSONL conversation log belonging to a session: either
+// the session's own main transcript (AgentID == "") or one subagent's.
+type Transcript struct {
+	// AgentID is the subagent identifier parsed from the filename, or "" for
+	// the session's main transcript.
+	AgentID string
+
+	// Filepath is the absolute path to the JSONL file.
+	Filepath string
+
+	// Meta is the sidecar metadata; the zero value when MetaFound is false.
+	Meta AgentMeta
+
+	// MetaFound reports whether an agent-<id>.meta.json sidecar was read.
+	MetaFound bool
+
+	// Depth is the distance from the session's main transcript in the
+	// reconstructed tree — 0 for the main transcript, 1 for a subagent it
+	// spawned directly, and so on. It is derived from the tree, not copied
+	// from the sidecar's spawnDepth, so it stays correct when a sidecar is
+	// missing or its parent's transcript was never written.
+	Depth int
+
+	// StartedAt is the timestamp of the transcript's first timestamped record,
+	// or "" if none of the leading records carried one. Used to order siblings.
+	StartedAt string
+
+	// Orphaned reports that the sidecar named a parentAgentId with no matching
+	// transcript on disk, so this node was attached to the session root
+	// instead of to its real parent.
+	Orphaned bool
+
+	// Children are the subagents this transcript spawned, ordered by StartedAt.
+	Children []*Transcript
+}
+
+// IsMain reports whether this is the session's own transcript rather than a
+// subagent's.
+func (t *Transcript) IsMain() bool { return t.AgentID == "" }
+
+// Walk invokes fn on this transcript and every descendant, depth-first in
+// child order. It is cycle-safe: a node is visited at most once.
+func (t *Transcript) Walk(fn func(*Transcript)) {
+	visited := map[*Transcript]bool{}
+	var walk func(*Transcript)
+	walk = func(n *Transcript) {
+		if n == nil || visited[n] {
+			return
+		}
+		visited[n] = true
+		fn(n)
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(t)
+}
+
+// Flatten returns this transcript and every descendant in depth-first order.
+func (t *Transcript) Flatten() []*Transcript {
+	var out []*Transcript
+	t.Walk(func(n *Transcript) { out = append(out, n) })
+	return out
+}
+
+// SessionSubagentsDirpath returns the directory holding a session's subagent
+// transcripts. The directory does not necessarily exist — a session that never
+// spawned a subagent has none.
+func SessionSubagentsDirpath(projectDirpath string, sessionID string) string {
+	return filepath.Join(projectDirpath, sessionID, subagentsDirname)
+}
+
+// DiscoverSessionTranscripts builds the full transcript tree for a session: the
+// main JSONL plus every subagent transcript, linked into a tree by each
+// subagent's parentAgentId.
+//
+// The main transcript must exist; a missing one is an error. Everything below
+// it is best-effort by design — a missing subagents directory, an unreadable
+// sidecar, a parentAgentId naming an agent whose transcript was never written,
+// or a cycle in the parent chain each degrade to "attach to the session root"
+// rather than dropping the transcript. A transcript that exists on disk is
+// always reachable in the returned tree.
+func DiscoverSessionTranscripts(projectDirpath string, sessionID string) (*Transcript, error) {
+	mainFilepath := filepath.Join(projectDirpath, sessionID+agentFileSuffix)
+	if _, err := os.Stat(mainFilepath); err != nil {
+		return nil, fmt.Errorf("no transcript for session '%s' at '%s': %w", sessionID, mainFilepath, err)
+	}
+
+	root := &Transcript{
+		Filepath:  mainFilepath,
+		StartedAt: readStartTimestamp(mainFilepath),
+	}
+
+	nodes := discoverSubagentTranscripts(SessionSubagentsDirpath(projectDirpath, sessionID))
+	linkTranscriptTree(root, nodes)
+	return root, nil
+}
+
+// DiscoverTranscriptsForFile builds the transcript tree for an arbitrary main
+// JSONL path, deriving the session's sidecar directory from the filename. It is
+// the entry point for callers that already hold a path (mission print resolves
+// the active JSONL by modification time rather than by session ID).
+func DiscoverTranscriptsForFile(jsonlFilepath string) (*Transcript, error) {
+	dir := filepath.Dir(jsonlFilepath)
+	sessionID := strings.TrimSuffix(filepath.Base(jsonlFilepath), agentFileSuffix)
+	return DiscoverSessionTranscripts(dir, sessionID)
+}
+
+// discoverSubagentTranscripts reads every agent-<id>.jsonl in a subagents
+// directory, pairing each with its sidecar metadata when present. Returns nil
+// when the directory does not exist or cannot be read.
+func discoverSubagentTranscripts(subagentsDirpath string) []*Transcript {
+	entries, err := os.ReadDir(subagentsDirpath)
+	if err != nil {
+		return nil
+	}
+
+	var nodes []*Transcript
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, agentFilePrefix) || !strings.HasSuffix(name, agentFileSuffix) {
+			continue
+		}
+		agentID := strings.TrimSuffix(strings.TrimPrefix(name, agentFilePrefix), agentFileSuffix)
+		if agentID == "" {
+			continue
+		}
+
+		transcriptFilepath := filepath.Join(subagentsDirpath, name)
+		meta, metaFound := readAgentMeta(filepath.Join(subagentsDirpath, agentFilePrefix+agentID+agentMetaSuffix))
+
+		nodes = append(nodes, &Transcript{
+			AgentID:   agentID,
+			Filepath:  transcriptFilepath,
+			Meta:      meta,
+			MetaFound: metaFound,
+			StartedAt: readStartTimestamp(transcriptFilepath),
+		})
+	}
+	return nodes
+}
+
+// readAgentMeta parses a subagent's sidecar metadata file. A missing or
+// malformed sidecar yields the zero AgentMeta and false — never an error,
+// because a subagent with no readable metadata must still appear in the tree.
+func readAgentMeta(metaFilepath string) (AgentMeta, bool) {
+	data, err := os.ReadFile(metaFilepath)
+	if err != nil {
+		return AgentMeta{}, false
+	}
+	var meta AgentMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return AgentMeta{}, false
+	}
+	return meta, true
+}
+
+// linkTranscriptTree attaches each discovered subagent to its parent, filling
+// in Depth and Orphaned. Any node whose parent is unknown, self-referential, or
+// part of a cycle is attached to the root so that it is still reachable.
+func linkTranscriptTree(root *Transcript, nodes []*Transcript) {
+	byID := make(map[string]*Transcript, len(nodes))
+	for _, n := range nodes {
+		byID[n.AgentID] = n
+	}
+
+	for _, n := range nodes {
+		parentID := n.Meta.ParentAgentID
+		if parentID == "" || parentID == n.AgentID {
+			root.Children = append(root.Children, n)
+			continue
+		}
+		parent, ok := byID[parentID]
+		if !ok {
+			// The sidecar names a spawner whose transcript is not on disk
+			// (deleted, or spawned from a different session). Keep the
+			// transcript reachable and record why it moved.
+			n.Orphaned = true
+			root.Children = append(root.Children, n)
+			continue
+		}
+		if createsParentCycle(byID, n.AgentID, parentID) {
+			n.Orphaned = true
+			root.Children = append(root.Children, n)
+			continue
+		}
+		parent.Children = append(parent.Children, n)
+	}
+
+	assignDepthsAndSort(root, 0)
+}
+
+// createsParentCycle reports whether making parentID the parent of agentID
+// would close a cycle, by walking the existing parent chain upward from
+// parentID looking for agentID. The walk is bounded by the node count so a
+// pre-existing cycle among other nodes cannot hang it.
+func createsParentCycle(byID map[string]*Transcript, agentID string, parentID string) bool {
+	for i := 0; i <= len(byID); i++ {
+		if parentID == "" || parentID == agentID {
+			return parentID == agentID
+		}
+		next, ok := byID[parentID]
+		if !ok {
+			return false
+		}
+		parentID = next.Meta.ParentAgentID
+	}
+	return true
+}
+
+// assignDepthsAndSort walks the linked tree setting Depth from the tree shape
+// and ordering each node's children chronologically. Sibling order falls back
+// to agent ID so the output is deterministic when timestamps are missing or
+// identical.
+func assignDepthsAndSort(node *Transcript, depth int) {
+	node.Depth = depth
+	sort.SliceStable(node.Children, func(i, j int) bool {
+		a, b := node.Children[i], node.Children[j]
+		if a.StartedAt != b.StartedAt {
+			return a.StartedAt < b.StartedAt
+		}
+		return a.AgentID < b.AgentID
+	})
+	for _, child := range node.Children {
+		assignDepthsAndSort(child, depth+1)
+	}
+}
+
+// readStartTimestamp returns the timestamp of the first timestamped record in a
+// JSONL file, or "" if none of the leading records carry one.
+func readStartTimestamp(jsonlFilepath string) string {
+	found := ""
+	seen := 0
+	err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
+		seen++
+		var record struct {
+			Timestamp string `json:"timestamp"`
+		}
+		if err := json.Unmarshal(line, &record); err == nil && record.Timestamp != "" {
+			found = record.Timestamp
+			return errStopScanning
+		}
+		if seen >= startTimestampScanLimit {
+			return errStopScanning
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errStopScanning) {
+		return ""
+	}
+	return found
+}
+
+// TranscriptStats summarizes one transcript's contents. Producing it requires a
+// full pass over the file, so it is computed on demand rather than during
+// discovery.
+type TranscriptStats struct {
+	UserMessages      int
+	AssistantMessages int
+	ToolCalls         int
+	ToolErrors        int
+	CompactBoundaries int
+	FirstTimestamp    string
+	LastTimestamp     string
+}
+
+// SummarizeTranscript scans a JSONL transcript and counts its conversation
+// records. A file that cannot be read yields zeroed stats and an error; callers
+// rendering a table should show the row anyway.
+//
+// Records repeated under the same uuid are counted once. Real transcripts hold
+// a great many of them — on one 68 MB session on disk, counting every line
+// reports 10011 messages against a true 4663 — so counting lines rather than
+// records overstates a session's size by more than 100%.
+func SummarizeTranscript(jsonlFilepath string) (TranscriptStats, error) {
+	var stats TranscriptStats
+	seenUUIDs := map[string]bool{}
+	err := ScanJSONLLines(jsonlFilepath, func(line []byte) error {
+		var record struct {
+			Type      string          `json:"type"`
+			Subtype   string          `json:"subtype"`
+			Timestamp string          `json:"timestamp"`
+			UUID      string          `json:"uuid"`
+			Message   json.RawMessage `json:"message"`
+		}
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil
+		}
+		// A record with no uuid (queue operations, titles, mode switches) has
+		// nothing to identify it, so it is always counted.
+		if record.UUID != "" {
+			if seenUUIDs[record.UUID] {
+				return nil
+			}
+			seenUUIDs[record.UUID] = true
+		}
+		if record.Timestamp != "" {
+			if stats.FirstTimestamp == "" {
+				stats.FirstTimestamp = record.Timestamp
+			}
+			stats.LastTimestamp = record.Timestamp
+		}
+
+		switch record.Type {
+		case "user":
+			stats.UserMessages++
+			for _, b := range decodeContentBlocks(record.Message) {
+				if b.Type == "tool_result" && b.IsError {
+					stats.ToolErrors++
+				}
+			}
+		case "assistant":
+			stats.AssistantMessages++
+			for _, b := range decodeContentBlocks(record.Message) {
+				if b.Type == "tool_use" {
+					stats.ToolCalls++
+				}
+			}
+		case "system":
+			if record.Subtype == "compact_boundary" {
+				stats.CompactBoundaries++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return TranscriptStats{}, err
+	}
+	return stats, nil
+}
+
+// decodeContentBlocks extracts the content blocks from a raw message, returning
+// nil for string-valued or malformed content.
+func decodeContentBlocks(rawMessage json.RawMessage) []contentBlock {
+	if len(rawMessage) == 0 {
+		return nil
+	}
+	var msg apiMessage
+	if err := json.Unmarshal(rawMessage, &msg); err != nil {
+		return nil
+	}
+	var blocks []contentBlock
+	if err := json.Unmarshal(msg.Content, &blocks); err != nil {
+		return nil
+	}
+	return blocks
+}
+
+// ErrAgentNotFound is returned by ResolveAgent when no subagent in the tree
+// matches the requested ID prefix.
+var ErrAgentNotFound = errors.New("no matching subagent transcript")
+
+// ResolveAgent finds the single subagent in a transcript tree whose agent ID
+// starts with the given prefix. An exact match always wins over prefix matches.
+// An ambiguous prefix is an error naming every candidate, so the caller can
+// print something actionable rather than picking arbitrarily.
+func ResolveAgent(root *Transcript, prefix string) (*Transcript, error) {
+	if prefix == "" {
+		return nil, fmt.Errorf("%w: empty agent ID", ErrAgentNotFound)
+	}
+
+	var exact *Transcript
+	var matches []*Transcript
+	root.Walk(func(n *Transcript) {
+		if n.IsMain() || !strings.HasPrefix(n.AgentID, prefix) {
+			return
+		}
+		if n.AgentID == prefix && exact == nil {
+			exact = n
+		}
+		matches = append(matches, n)
+	})
+
+	if exact != nil {
+		return exact, nil
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("%w for ID prefix '%s'", ErrAgentNotFound, prefix)
+	case 1:
+		return matches[0], nil
+	default:
+		ids := make([]string, 0, len(matches))
+		for _, m := range matches {
+			ids = append(ids, m.AgentID)
+		}
+		sort.Strings(ids)
+		return nil, fmt.Errorf("agent ID prefix '%s' is ambiguous, matches: %s", prefix, strings.Join(ids, ", "))
+	}
+}

--- a/internal/session/transcript.go
+++ b/internal/session/transcript.go
@@ -377,6 +377,24 @@ func assignDepthsAndSort(node *Transcript, depth int) {
 	}
 }
 
+// FormatBytes renders a byte count for a table cell or a notice: whole bytes
+// below 1 KB, one decimal above, and never "1024.0 KB" — a value that would
+// round up to 1024 moves to the next unit.
+func FormatBytes(n int64) string {
+	units := []string{"KB", "MB", "GB", "TB"}
+	f := float64(n)
+	if f < 1024 {
+		return fmt.Sprintf("%d B", n)
+	}
+	unit := 0
+	f /= 1024
+	for f >= 1023.95 && unit < len(units)-1 {
+		f /= 1024
+		unit++
+	}
+	return fmt.Sprintf("%.1f %s", f, units[unit])
+}
+
 // fileSize returns a file's size in bytes, or 0 when it cannot be stat'ed.
 func fileSize(path string) int64 {
 	info, err := os.Stat(path)
@@ -537,7 +555,7 @@ func ResolveAgent(root *Transcript, key string) (*Transcript, error) {
 		case strings.HasPrefix(n.AgentID, key):
 			idPrefix = append(idPrefix, n)
 		}
-		if n.Meta.Name == key {
+		if strings.EqualFold(n.Meta.Name, key) {
 			nameMatch = append(nameMatch, n)
 		} else if strings.HasPrefix(strings.ToLower(n.Meta.Name), lower) || strings.Contains(strings.ToLower(n.Meta.Description), lower) {
 			textMatch = append(textMatch, n)
@@ -557,6 +575,11 @@ func ResolveAgent(root *Transcript, key string) (*Transcript, error) {
 	return nil, fmt.Errorf("%w for '%s'", ErrAgentNotFound, key)
 }
 
+// maxNamedCandidates bounds how many candidates an ambiguity error names.
+// Every agent ID starts with "a", so `--agent a` on a 7214-agent session
+// once produced a 138 KB error message.
+const maxNamedCandidates = 20
+
 // describeAgents renders candidates as "id (label)" pairs, sorted by ID.
 func describeAgents(agents []*Transcript) string {
 	parts := make([]string, 0, len(agents))
@@ -568,5 +591,14 @@ func describeAgents(agents []*Transcript) string {
 		}
 	}
 	sort.Strings(parts)
-	return strings.Join(parts, ", ")
+	return joinCandidates(parts, ", ")
+}
+
+// joinCandidates joins at most maxNamedCandidates entries and says how many
+// were left out, so an ambiguity error stays readable at any scale.
+func joinCandidates(parts []string, sep string) string {
+	if len(parts) <= maxNamedCandidates {
+		return strings.Join(parts, sep)
+	}
+	return strings.Join(parts[:maxNamedCandidates], sep) + fmt.Sprintf("%s... and %d more", sep, len(parts)-maxNamedCandidates)
 }

--- a/internal/session/transcript_test.go
+++ b/internal/session/transcript_test.go
@@ -1,0 +1,413 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSession builds a Claude project directory on disk: a main transcript at
+// <dir>/<sessionID>.jsonl plus subagent transcripts under
+// <dir>/<sessionID>/subagents/. It mirrors the real layout so the discovery
+// tests exercise the same path resolution the CLI uses.
+type fakeSession struct {
+	t          *testing.T
+	projectDir string
+	sessionID  string
+}
+
+func newFakeSession(t *testing.T, mainLines ...string) *fakeSession {
+	t.Helper()
+	fs := &fakeSession{t: t, projectDir: t.TempDir(), sessionID: "11111111-2222-3333-4444-555555555555"}
+	fs.writeFile(filepath.Join(fs.projectDir, fs.sessionID+".jsonl"), strings.Join(mainLines, "\n"))
+	return fs
+}
+
+// addAgent writes a subagent transcript and, when meta is non-nil, its sidecar.
+func (fs *fakeSession) addAgent(agentID string, meta *AgentMeta, lines ...string) {
+	fs.t.Helper()
+	dir := filepath.Join(fs.projectDir, fs.sessionID, "subagents")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		fs.t.Fatalf("mkdir subagents: %v", err)
+	}
+	fs.writeFile(filepath.Join(dir, "agent-"+agentID+".jsonl"), strings.Join(lines, "\n"))
+	if meta == nil {
+		return
+	}
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		fs.t.Fatalf("marshal meta: %v", err)
+	}
+	fs.writeFile(filepath.Join(dir, "agent-"+agentID+".meta.json"), string(encoded))
+}
+
+func (fs *fakeSession) writeFile(path string, content string) {
+	fs.t.Helper()
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		fs.t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func (fs *fakeSession) discover() *Transcript {
+	fs.t.Helper()
+	root, err := DiscoverSessionTranscripts(fs.projectDir, fs.sessionID)
+	if err != nil {
+		fs.t.Fatalf("DiscoverSessionTranscripts: %v", err)
+	}
+	return root
+}
+
+// userLine and assistantLine build minimal conversation records.
+func userLine(timestamp string, text string) string {
+	return `{"type":"user","timestamp":"` + timestamp + `","message":{"role":"user","content":` + quote(text) + `}}`
+}
+
+func assistantLine(timestamp string, text string) string {
+	return `{"type":"assistant","timestamp":"` + timestamp + `","message":{"role":"assistant","content":[{"type":"text","text":` + quote(text) + `}]}}`
+}
+
+func quote(s string) string {
+	encoded, _ := json.Marshal(s)
+	return string(encoded)
+}
+
+func agentIDsOf(nodes []*Transcript) []string {
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, n.AgentID)
+	}
+	return out
+}
+
+func TestDiscoverSessionTranscriptsMainOnly(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "hi"))
+
+	root := fs.discover()
+
+	if !root.IsMain() {
+		t.Errorf("root should be the main transcript, got agent ID %q", root.AgentID)
+	}
+	if got := len(root.Flatten()); got != 1 {
+		t.Errorf("expected 1 transcript, got %d", got)
+	}
+	if root.StartedAt != "2026-01-01T00:00:00.000Z" {
+		t.Errorf("StartedAt = %q, want the first record's timestamp", root.StartedAt)
+	}
+}
+
+func TestDiscoverSessionTranscriptsMissingMainIsAnError(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := DiscoverSessionTranscripts(dir, "nope")
+
+	if err == nil {
+		t.Fatal("expected an error for a session with no main transcript")
+	}
+}
+
+func TestDiscoverSessionTranscriptsBuildsNestedTree(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aparent", &AgentMeta{AgentType: "Explore", ToolUseID: "toolu_1"},
+		userLine("2026-01-01T00:01:00.000Z", "parent agent prompt"))
+	fs.addAgent("achild", &AgentMeta{AgentType: "general-purpose", ParentAgentID: "aparent"},
+		userLine("2026-01-01T00:02:00.000Z", "child agent prompt"))
+	fs.addAgent("agrandchild", &AgentMeta{AgentType: "general-purpose", ParentAgentID: "achild"},
+		userLine("2026-01-01T00:03:00.000Z", "grandchild prompt"))
+
+	root := fs.discover()
+
+	if got := agentIDsOf(root.Flatten()); len(got) != 4 {
+		t.Fatalf("expected 4 transcripts, got %v", got)
+	}
+	if got := len(root.Children); got != 1 {
+		t.Fatalf("expected 1 direct child of the session, got %d", got)
+	}
+	parent := root.Children[0]
+	if parent.AgentID != "aparent" || parent.Depth != 1 {
+		t.Errorf("parent = %s at depth %d, want aparent at depth 1", parent.AgentID, parent.Depth)
+	}
+	if len(parent.Children) != 1 || parent.Children[0].AgentID != "achild" {
+		t.Fatalf("expected achild under aparent, got %v", agentIDsOf(parent.Children))
+	}
+	grandchild := parent.Children[0].Children
+	if len(grandchild) != 1 || grandchild[0].Depth != 3 {
+		t.Fatalf("expected agrandchild at depth 3, got %v", agentIDsOf(grandchild))
+	}
+}
+
+func TestDiscoverSessionTranscriptsKeepsAgentsWithNoMetadata(t *testing.T) {
+	// 3.6% of the subagent transcripts on a long-lived machine have no sidecar.
+	// Dropping them would make the tool silently under-report what a session did.
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("abare", nil, userLine("2026-01-01T00:01:00.000Z", "no sidecar"))
+
+	root := fs.discover()
+
+	if len(root.Children) != 1 {
+		t.Fatalf("expected the sidecar-less agent to be attached to the root, got %v", agentIDsOf(root.Children))
+	}
+	node := root.Children[0]
+	if node.MetaFound {
+		t.Error("MetaFound should be false when no sidecar exists")
+	}
+	if got := node.Meta.DisplayType(); got != "unknown" {
+		t.Errorf("DisplayType() = %q, want %q", got, "unknown")
+	}
+}
+
+func TestDiscoverSessionTranscriptsKeepsAgentsWithUnreadableMetadata(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("abroken", nil, userLine("2026-01-01T00:01:00.000Z", "x"))
+	fs.writeFile(filepath.Join(fs.projectDir, fs.sessionID, "subagents", "agent-abroken.meta.json"), "{not json")
+
+	root := fs.discover()
+
+	if len(root.Children) != 1 || root.Children[0].MetaFound {
+		t.Fatalf("a malformed sidecar should degrade to no-metadata, got %v", agentIDsOf(root.Children))
+	}
+}
+
+func TestDiscoverSessionTranscriptsMarksOrphans(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("alonely", &AgentMeta{AgentType: "Explore", ParentAgentID: "agone"},
+		userLine("2026-01-01T00:01:00.000Z", "x"))
+
+	root := fs.discover()
+
+	if len(root.Children) != 1 {
+		t.Fatalf("an orphan must stay reachable from the root, got %v", agentIDsOf(root.Children))
+	}
+	if !root.Children[0].Orphaned {
+		t.Error("expected Orphaned to be set when the named parent has no transcript")
+	}
+}
+
+func TestDiscoverSessionTranscriptsBreaksParentCycles(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aone", &AgentMeta{ParentAgentID: "atwo"}, userLine("2026-01-01T00:01:00.000Z", "one"))
+	fs.addAgent("atwo", &AgentMeta{ParentAgentID: "aone"}, userLine("2026-01-01T00:02:00.000Z", "two"))
+	fs.addAgent("aself", &AgentMeta{ParentAgentID: "aself"}, userLine("2026-01-01T00:03:00.000Z", "self"))
+
+	root := fs.discover()
+
+	// The assertion that matters is termination plus reachability: every
+	// transcript on disk appears exactly once, and Flatten() returns.
+	got := agentIDsOf(root.Flatten())
+	if len(got) != 4 {
+		t.Fatalf("expected the session plus 3 agents exactly once each, got %v", got)
+	}
+}
+
+func TestDiscoverSessionTranscriptsOrdersSiblingsByStartTime(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("azzz", &AgentMeta{}, userLine("2026-01-01T00:01:00.000Z", "first"))
+	fs.addAgent("aaaa", &AgentMeta{}, userLine("2026-01-01T00:09:00.000Z", "last"))
+
+	root := fs.discover()
+
+	if got := agentIDsOf(root.Children); got[0] != "azzz" || got[1] != "aaaa" {
+		t.Errorf("children = %v, want chronological order [azzz aaaa]", got)
+	}
+}
+
+func TestResolveAgent(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aa11bb", &AgentMeta{}, userLine("2026-01-01T00:01:00.000Z", "x"))
+	fs.addAgent("aa22cc", &AgentMeta{}, userLine("2026-01-01T00:02:00.000Z", "y"))
+	fs.addAgent("aa", &AgentMeta{}, userLine("2026-01-01T00:03:00.000Z", "z"))
+	root := fs.discover()
+
+	t.Run("exact match wins over prefix matches", func(t *testing.T) {
+		// "aa" is also a prefix of aa11bb and aa22cc; the exact ID must win
+		// rather than being reported as ambiguous.
+		got, err := ResolveAgent(root, "aa")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.AgentID != "aa" {
+			t.Errorf("got %q, want the exact match %q", got.AgentID, "aa")
+		}
+	})
+
+	t.Run("unique prefix", func(t *testing.T) {
+		got, err := ResolveAgent(root, "aa11")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.AgentID != "aa11bb" {
+			t.Errorf("got %q, want aa11bb", got.AgentID)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		_, err := ResolveAgent(root, "zzzz")
+		if !errors.Is(err, ErrAgentNotFound) {
+			t.Errorf("error = %v, want ErrAgentNotFound", err)
+		}
+	})
+
+	t.Run("empty prefix", func(t *testing.T) {
+		if _, err := ResolveAgent(root, ""); !errors.Is(err, ErrAgentNotFound) {
+			t.Errorf("error = %v, want ErrAgentNotFound", err)
+		}
+	})
+}
+
+func TestResolveAgentAmbiguousPrefixListsCandidates(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("abc111", &AgentMeta{}, userLine("2026-01-01T00:01:00.000Z", "x"))
+	fs.addAgent("abc222", &AgentMeta{}, userLine("2026-01-01T00:02:00.000Z", "y"))
+	root := fs.discover()
+
+	_, err := ResolveAgent(root, "abc")
+
+	if err == nil {
+		t.Fatal("expected an ambiguity error")
+	}
+	for _, want := range []string{"abc111", "abc222"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name candidate %s", err.Error(), want)
+		}
+	}
+}
+
+func TestSummarizeTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	content := strings.Join([]string{
+		userLine("2026-01-01T00:00:00.000Z", "hello"),
+		`{"type":"assistant","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+		`{"type":"user","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"user","content":[{"type":"tool_result","is_error":true,"content":"boom"}]}}`,
+		`{"type":"system","subtype":"compact_boundary","timestamp":"2026-01-01T00:00:03.000Z"}`,
+		`{"type":"file-history-snapshot","timestamp":"2026-01-01T00:00:04.000Z"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := SummarizeTranscript(path)
+	if err != nil {
+		t.Fatalf("SummarizeTranscript: %v", err)
+	}
+
+	if stats.UserMessages != 2 || stats.AssistantMessages != 1 {
+		t.Errorf("messages: user=%d assistant=%d, want 2 and 1", stats.UserMessages, stats.AssistantMessages)
+	}
+	if stats.ToolCalls != 1 || stats.ToolErrors != 1 || stats.CompactBoundaries != 1 {
+		t.Errorf("tools=%d errors=%d compactions=%d, want 1/1/1", stats.ToolCalls, stats.ToolErrors, stats.CompactBoundaries)
+	}
+	if stats.FirstTimestamp != "2026-01-01T00:00:00.000Z" || stats.LastTimestamp != "2026-01-01T00:00:04.000Z" {
+		t.Errorf("timestamps = %s..%s, want the file's first and last", stats.FirstTimestamp, stats.LastTimestamp)
+	}
+}
+
+func TestDiscoverTranscriptsForFile(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aone", &AgentMeta{}, userLine("2026-01-01T00:01:00.000Z", "x"))
+
+	root, err := DiscoverTranscriptsForFile(filepath.Join(fs.projectDir, fs.sessionID+".jsonl"))
+	if err != nil {
+		t.Fatalf("DiscoverTranscriptsForFile: %v", err)
+	}
+
+	if len(root.Flatten()) != 2 {
+		t.Errorf("expected the sidecar directory to be found from the file path, got %v", agentIDsOf(root.Flatten()))
+	}
+}
+
+// --- Long-tail discovery invariants -----------------------------------------
+
+func TestReadStartTimestampScansPastLeadingUntimestampedRecords(t *testing.T) {
+	// The leading records of a real transcript are frequently untimestamped
+	// bookkeeping. A scan that gives up on the first one leaves the transcript
+	// with no start time, and every ordering built on StartedAt collapses.
+	fs := newFakeSession(t,
+		`{"type":"file-history-snapshot"}`,
+		`{"type":"mode","mode":"plan"}`,
+		`{"type":"permission-mode","permissionMode":"acceptEdits"}`,
+		`{"type":"summary","summary":"resumed"}`,
+		`{"type":"file-history-snapshot"}`,
+		`{"type":"agent-name","agentName":"lead"}`,
+		`{"type":"last-prompt","lastPrompt":"go"}`,
+		userLine("2026-01-01T00:00:07.000Z", "the first timestamped record"),
+	)
+
+	root := fs.discover()
+
+	if root.StartedAt != "2026-01-01T00:00:07.000Z" {
+		t.Errorf("StartedAt = %q, want the 8th record's timestamp — the scan must run to the limit, not stop at the first untimestamped record", root.StartedAt)
+	}
+}
+
+func TestAgentMetaDisplayLabelPrefersNameOverDescription(t *testing.T) {
+	// A named agent and the description its spawner wrote are different facts.
+	// Showing the description for a named agent breaks the only handle a reader
+	// has for matching a transcript to the SendMessage target it answers to.
+	tests := []struct {
+		name string
+		meta AgentMeta
+		want string
+	}{
+		{"name wins over description", AgentMeta{Name: "reviewer-tests", Description: "close long-tail test gaps"}, "reviewer-tests"},
+		{"description when unnamed", AgentMeta{Description: "close long-tail test gaps"}, "close long-tail test gaps"},
+		{"empty when neither is set", AgentMeta{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.meta.DisplayLabel(); got != tt.want {
+				t.Errorf("DisplayLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverSessionTranscriptsBreaksStartTimeTiesByAgentID(t *testing.T) {
+	// Both agents start at the same instant, and the directory hands them over
+	// in the opposite order — '-' sorts before '.', so agent-aa-1.jsonl is read
+	// before agent-aa.jsonl. Only the agent-ID tiebreak makes the tree
+	// deterministic rather than an artefact of the filesystem.
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aa", &AgentMeta{}, userLine("2026-01-01T00:01:00.000Z", "first"))
+	fs.addAgent("aa-1", &AgentMeta{}, userLine("2026-01-01T00:01:00.000Z", "second"))
+
+	root := fs.discover()
+
+	got := agentIDsOf(root.Children)
+	if len(got) != 2 {
+		t.Fatalf("expected both agents attached to the root, got %v", got)
+	}
+	if got[0] != "aa" || got[1] != "aa-1" {
+		t.Errorf("children = %v, want [aa aa-1] — identical start times must fall back to agent ID order", got)
+	}
+}
+
+func TestWalkVisitsEachNodeOnceOnACyclicGraph(t *testing.T) {
+	// linkTranscriptTree guarantees an acyclic tree, so discovery never reaches
+	// Walk's visited guard. The guard is a documented property of Walk itself —
+	// every caller that hand-builds or mutates a tree relies on it — so it is
+	// pinned here on a graph built directly rather than discovered.
+	root := &Transcript{}
+	a := &Transcript{AgentID: "acycle-a"}
+	b := &Transcript{AgentID: "acycle-b"}
+	root.Children = []*Transcript{a}
+	a.Children = []*Transcript{b}
+	b.Children = []*Transcript{a, root}
+
+	visits := map[string]int{}
+	root.Walk(func(n *Transcript) { visits[n.AgentID]++ })
+
+	if len(visits) != 3 {
+		t.Fatalf("expected the root plus both agents visited, got %v", visits)
+	}
+	for id, n := range visits {
+		if n != 1 {
+			t.Errorf("node %q visited %d times, want exactly 1", id, n)
+		}
+	}
+}

--- a/internal/session/workflow.go
+++ b/internal/session/workflow.go
@@ -9,7 +9,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// transcriptTimestampLayout is the form transcript records use for timestamps
+// ("2026-08-21T17:59:07.553Z"); run start times are rendered in it so they
+// sort and compare with agent timestamps as plain strings.
+const transcriptTimestampLayout = "2006-01-02T15:04:05.000Z"
 
 // A session's subagents live in two places, and the second is the bigger one.
 //
@@ -73,9 +79,14 @@ type WorkflowRun struct {
 	Summary string
 	Status  string
 
-	// StartedAt is the manifest's RFC3339 timestamp, or the earliest agent's
-	// start when there is no manifest.
-	StartedAt string
+	// StartedAt is the run's start as an RFC3339 UTC timestamp, from the
+	// manifest's startTime (epoch milliseconds), or the earliest agent's start
+	// when the manifest lacks one. The manifest's "timestamp" field is the
+	// run's COMPLETION time — on one machine it trailed the earliest agent's
+	// start by the run's whole duration in 55 of 60 runs — and is kept as
+	// CompletedAt.
+	StartedAt   string
+	CompletedAt string
 
 	DurationMs     int64
 	TotalTokens    int64
@@ -153,6 +164,7 @@ func (v *flexInt64) UnmarshalJSON(b []byte) error {
 type workflowManifest struct {
 	RunID          string    `json:"runId"`
 	Timestamp      string    `json:"timestamp"`
+	StartTime      flexInt64 `json:"startTime"`
 	TaskID         string    `json:"taskId"`
 	WorkflowName   string    `json:"workflowName"`
 	Summary        string    `json:"summary"`
@@ -251,7 +263,10 @@ func applyWorkflowManifest(run *WorkflowRun) {
 	if m.Status != "" {
 		run.Status = m.Status
 	}
-	run.StartedAt = m.Timestamp
+	run.CompletedAt = m.Timestamp
+	if m.StartTime > 0 {
+		run.StartedAt = time.UnixMilli(int64(m.StartTime)).UTC().Format(transcriptTimestampLayout)
+	}
 	run.DurationMs = int64(m.DurationMs)
 	run.TotalTokens = int64(m.TotalTokens)
 	run.TotalToolCalls = int64(m.TotalToolCalls)
@@ -326,6 +341,6 @@ func ResolveWorkflow(root *Transcript, key string) (*WorkflowRun, error) {
 		for _, m := range matches {
 			ids = append(ids, fmt.Sprintf("%s (%s, %d agents)", m.RunID, m.DisplayName(), len(m.Agents)))
 		}
-		return nil, fmt.Errorf("workflow '%s' is ambiguous, matches: %s", key, strings.Join(ids, "; "))
+		return nil, fmt.Errorf("workflow '%s' is ambiguous, matches: %s", key, joinCandidates(ids, "; "))
 	}
 }

--- a/internal/session/workflow.go
+++ b/internal/session/workflow.go
@@ -1,0 +1,338 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// A session's subagents live in two places, and the second is the bigger one.
+//
+// Agents spawned with the Agent tool write to <session-id>/subagents/ directly.
+// Agents spawned by the Workflow tool write to a per-run directory,
+// <session-id>/subagents/workflows/<run-id>/, next to a journal.jsonl that
+// records each agent's start and structured result. The run's own manifest —
+// name, summary, status, duration, token totals and the task ID its spawn
+// reported — is written separately to <session-id>/workflows/<run-id>.json.
+//
+// Measured over every session on one machine: 8918 of 16076 subagent
+// transcripts (55%) were in workflow run directories, so a reader of the flat
+// directory alone sees less than half of what a session did. The nested
+// sidecars carry only an agentType and spawnDepth — no parent, no name, no
+// toolUseId — so a workflow agent is linked to its spawn site through its run:
+// the manifest's taskId matches the "Task ID" the Workflow tool's result
+// reported, 106 of 106 runs on that machine.
+//
+// The manifest's agentCount disagrees with the number of transcripts on disk
+// in 40 of those 106 runs, so agent counts are always taken from the directory.
+
+const (
+	// workflowsDirname names both the per-run agent directories under
+	// subagents/ and the manifest directory under <session-id>/.
+	workflowsDirname = "workflows"
+
+	// workflowRunPrefix starts every run ID and run directory name.
+	workflowRunPrefix = "wf_"
+
+	// workflowJournalFilename is the per-run journal of agent starts and results.
+	workflowJournalFilename = "journal.jsonl"
+
+	// workflowManifestSuffix completes <run-id> into its manifest filename.
+	workflowManifestSuffix = ".json"
+
+	// unknownWorkflowStatus is reported when a run has agents on disk but no
+	// readable manifest.
+	unknownWorkflowStatus = "unknown"
+)
+
+// WorkflowRun is one Workflow tool invocation: its manifest and the agents it
+// spawned. It is not a Transcript — a run has no conversation of its own — so
+// it is not a node in the agent tree; it hangs off the session root.
+type WorkflowRun struct {
+	// RunID is the wf_-prefixed identifier naming the run directory and manifest.
+	RunID string
+
+	// Dirpath is the run's agent directory; "" when only a manifest exists.
+	Dirpath string
+
+	// ManifestFilepath is the run's manifest; ManifestFound reports whether it
+	// was read successfully. A run without a manifest still lists its agents.
+	ManifestFilepath string
+	ManifestFound    bool
+
+	// TaskID is the background task ID the Workflow tool's result reported,
+	// which is how the run is linked back to its spawn site.
+	TaskID string
+
+	Name    string
+	Summary string
+	Status  string
+
+	// StartedAt is the manifest's RFC3339 timestamp, or the earliest agent's
+	// start when there is no manifest.
+	StartedAt string
+
+	DurationMs     int64
+	TotalTokens    int64
+	TotalToolCalls int64
+
+	// FinishedAgents counts the journal's result records, or -1 when the
+	// journal could not be read. Compared with len(Agents) it exposes agents
+	// that started and never reported.
+	FinishedAgents int
+
+	// Bytes is the total size of the run's agent transcripts on disk.
+	Bytes int64
+
+	// Agents are the run's transcripts. Their StartedAt is filled lazily by
+	// LoadAgentDetails, because reading the first record of every agent in a
+	// 7000-agent session costs seconds that a listing of runs does not need.
+	Agents []*Transcript
+
+	detailsLoaded bool
+}
+
+// LoadAgentDetails reads each agent's start timestamp and orders the run's
+// agents chronologically. It is idempotent and is called by every code path
+// that shows a run's agents individually.
+func (r *WorkflowRun) LoadAgentDetails() {
+	if r.detailsLoaded {
+		return
+	}
+	r.detailsLoaded = true
+	for _, a := range r.Agents {
+		if a.StartedAt == "" {
+			a.StartedAt = readStartTimestamp(a.Filepath)
+		}
+	}
+	sort.SliceStable(r.Agents, func(i, j int) bool { return lessByStart(r.Agents[i], r.Agents[j]) })
+}
+
+// DisplayName returns the workflow's name from its manifest, or a placeholder.
+func (r *WorkflowRun) DisplayName() string {
+	if r.Name != "" {
+		return r.Name
+	}
+	return "workflow"
+}
+
+// UnfinishedAgents reports how many agents started without reporting a result,
+// or 0 when the journal is unavailable.
+func (r *WorkflowRun) UnfinishedAgents() int {
+	if r.FinishedAgents < 0 {
+		return 0
+	}
+	if n := len(r.Agents) - r.FinishedAgents; n > 0 {
+		return n
+	}
+	return 0
+}
+
+// flexInt64 decodes a JSON number that the manifest writer sometimes quotes
+// ("agentCount": "20") and sometimes does not. Anything unparseable reads as 0
+// rather than failing the whole manifest, because every field here is
+// descriptive and a partial manifest beats none.
+type flexInt64 int64
+
+func (v *flexInt64) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(strings.TrimSpace(string(b)), `"`)
+	if s == "" || s == "null" {
+		*v = 0
+		return nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		*v = 0
+		return nil
+	}
+	*v = flexInt64(f)
+	return nil
+}
+
+// workflowManifest mirrors the fields of <session-id>/workflows/<run-id>.json
+// that the listing uses. The file also carries the script, args, phases,
+// progress log and the run's structured result; those are read on demand by
+// ReadWorkflowManifestJSON.
+type workflowManifest struct {
+	RunID          string    `json:"runId"`
+	Timestamp      string    `json:"timestamp"`
+	TaskID         string    `json:"taskId"`
+	WorkflowName   string    `json:"workflowName"`
+	Summary        string    `json:"summary"`
+	Status         string    `json:"status"`
+	DurationMs     flexInt64 `json:"durationMs"`
+	TotalTokens    flexInt64 `json:"totalTokens"`
+	TotalToolCalls flexInt64 `json:"totalToolCalls"`
+}
+
+// SessionWorkflowsDirpath returns the directory holding a session's workflow
+// run manifests. It need not exist.
+func SessionWorkflowsDirpath(projectDirpath string, sessionID string) string {
+	return filepath.Join(projectDirpath, sessionID, workflowsDirname)
+}
+
+// discoverWorkflowRuns finds every workflow run of a session: the union of run
+// directories under subagents/workflows/ and manifests under workflows/, keyed
+// by run ID. A run with agents but no manifest is listed with status unknown; a
+// run with a manifest but no agents is listed with none.
+func discoverWorkflowRuns(subagentsDirpath string, manifestsDirpath string) []*WorkflowRun {
+	byID := map[string]*WorkflowRun{}
+	get := func(runID string) *WorkflowRun {
+		if r := byID[runID]; r != nil {
+			return r
+		}
+		r := &WorkflowRun{RunID: runID, Status: unknownWorkflowStatus, FinishedAgents: -1}
+		byID[runID] = r
+		return r
+	}
+
+	runsDirpath := filepath.Join(subagentsDirpath, workflowsDirname)
+	if entries, err := os.ReadDir(runsDirpath); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), workflowRunPrefix) {
+				continue
+			}
+			run := get(entry.Name())
+			run.Dirpath = filepath.Join(runsDirpath, entry.Name())
+			run.Agents = discoverSubagentTranscripts(run.Dirpath, false)
+			for _, a := range run.Agents {
+				a.Workflow = run
+				a.Depth = 1
+				run.Bytes += a.Bytes
+			}
+			sort.SliceStable(run.Agents, func(i, j int) bool { return run.Agents[i].AgentID < run.Agents[j].AgentID })
+			run.FinishedAgents = countJournalResults(filepath.Join(run.Dirpath, workflowJournalFilename))
+		}
+	}
+
+	if entries, err := os.ReadDir(manifestsDirpath); err == nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasPrefix(name, workflowRunPrefix) || !strings.HasSuffix(name, workflowManifestSuffix) {
+				continue
+			}
+			run := get(strings.TrimSuffix(name, workflowManifestSuffix))
+			run.ManifestFilepath = filepath.Join(manifestsDirpath, name)
+			applyWorkflowManifest(run)
+		}
+	}
+
+	runs := make([]*WorkflowRun, 0, len(byID))
+	for _, run := range byID {
+		if run.StartedAt == "" && len(run.Agents) > 0 {
+			// No manifest: the run's start is its earliest agent's, which costs
+			// one read per agent — paid only for runs that lack a manifest.
+			run.LoadAgentDetails()
+			run.StartedAt = run.Agents[0].StartedAt
+		}
+		runs = append(runs, run)
+	}
+	sort.SliceStable(runs, func(i, j int) bool {
+		if runs[i].StartedAt != runs[j].StartedAt {
+			return runs[i].StartedAt < runs[j].StartedAt
+		}
+		return runs[i].RunID < runs[j].RunID
+	})
+	return runs
+}
+
+// applyWorkflowManifest reads a run's manifest into it. A missing or malformed
+// manifest leaves the run listed with whatever the directory established.
+func applyWorkflowManifest(run *WorkflowRun) {
+	data, err := os.ReadFile(run.ManifestFilepath)
+	if err != nil {
+		return
+	}
+	var m workflowManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return
+	}
+	run.ManifestFound = true
+	run.TaskID = m.TaskID
+	run.Name = m.WorkflowName
+	run.Summary = m.Summary
+	if m.Status != "" {
+		run.Status = m.Status
+	}
+	run.StartedAt = m.Timestamp
+	run.DurationMs = int64(m.DurationMs)
+	run.TotalTokens = int64(m.TotalTokens)
+	run.TotalToolCalls = int64(m.TotalToolCalls)
+}
+
+// countJournalResults counts the result records in a run's journal, or -1 when
+// the journal cannot be read. Each agent that finishes writes exactly one.
+func countJournalResults(journalFilepath string) int {
+	n := 0
+	err := ScanJSONLLines(journalFilepath, func(line []byte) error {
+		var record struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(line, &record) == nil && record.Type == "result" {
+			n++
+		}
+		return nil
+	})
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+// ReadWorkflowManifestJSON returns a run's whole manifest decoded as generic
+// JSON, for callers that want the fields the listing does not keep — the
+// phases, the progress log, the script and the run's structured result.
+func ReadWorkflowManifestJSON(run *WorkflowRun) (map[string]interface{}, error) {
+	if run == nil || run.ManifestFilepath == "" {
+		return nil, fmt.Errorf("workflow run has no manifest on disk")
+	}
+	data, err := os.ReadFile(run.ManifestFilepath)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("manifest '%s' is not valid JSON: %w", run.ManifestFilepath, err)
+	}
+	return out, nil
+}
+
+// ErrWorkflowNotFound is returned by ResolveWorkflow when nothing matches.
+var ErrWorkflowNotFound = errors.New("no matching workflow run")
+
+// ResolveWorkflow finds one workflow run by run ID, run ID prefix (with or
+// without the wf_ prefix), task ID, or workflow name. An exact ID match always
+// wins; an ambiguous key is an error naming every candidate.
+func ResolveWorkflow(root *Transcript, key string) (*WorkflowRun, error) {
+	if key == "" {
+		return nil, fmt.Errorf("%w: empty workflow ID", ErrWorkflowNotFound)
+	}
+	var matches []*WorkflowRun
+	for _, run := range root.Workflows {
+		if run.RunID == key || run.TaskID == key {
+			return run, nil
+		}
+	}
+	for _, run := range root.Workflows {
+		if strings.HasPrefix(run.RunID, key) || strings.HasPrefix(strings.TrimPrefix(run.RunID, workflowRunPrefix), key) || run.Name == key {
+			matches = append(matches, run)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("%w for '%s'", ErrWorkflowNotFound, key)
+	case 1:
+		return matches[0], nil
+	default:
+		ids := make([]string, 0, len(matches))
+		for _, m := range matches {
+			ids = append(ids, fmt.Sprintf("%s (%s, %d agents)", m.RunID, m.DisplayName(), len(m.Agents)))
+		}
+		return nil, fmt.Errorf("workflow '%s' is ambiguous, matches: %s", key, strings.Join(ids, "; "))
+	}
+}

--- a/internal/session/workflow.go
+++ b/internal/session/workflow.go
@@ -81,10 +81,14 @@ type WorkflowRun struct {
 	TotalTokens    int64
 	TotalToolCalls int64
 
-	// FinishedAgents counts the journal's result records, or -1 when the
-	// journal could not be read. Compared with len(Agents) it exposes agents
-	// that started and never reported.
-	FinishedAgents int
+	// JournaledResults counts the journal's result records, or -1 when the
+	// journal could not be read. The journal is the Workflow tool's resume
+	// cache, not a completion log: on one machine every agent file had a
+	// "started" record, while runs marked completed had hundreds of agents
+	// with no "result" (699 started, 253 results). It therefore says how
+	// many results were cached for resume, and nothing about which agents
+	// finished; it is kept for the JSON view and never rendered as a claim.
+	JournaledResults int
 
 	// Bytes is the total size of the run's agent transcripts on disk.
 	Bytes int64
@@ -119,18 +123,6 @@ func (r *WorkflowRun) DisplayName() string {
 		return r.Name
 	}
 	return "workflow"
-}
-
-// UnfinishedAgents reports how many agents started without reporting a result,
-// or 0 when the journal is unavailable.
-func (r *WorkflowRun) UnfinishedAgents() int {
-	if r.FinishedAgents < 0 {
-		return 0
-	}
-	if n := len(r.Agents) - r.FinishedAgents; n > 0 {
-		return n
-	}
-	return 0
 }
 
 // flexInt64 decodes a JSON number that the manifest writer sometimes quotes
@@ -186,7 +178,7 @@ func discoverWorkflowRuns(subagentsDirpath string, manifestsDirpath string) []*W
 		if r := byID[runID]; r != nil {
 			return r
 		}
-		r := &WorkflowRun{RunID: runID, Status: unknownWorkflowStatus, FinishedAgents: -1}
+		r := &WorkflowRun{RunID: runID, Status: unknownWorkflowStatus, JournaledResults: -1}
 		byID[runID] = r
 		return r
 	}
@@ -206,7 +198,7 @@ func discoverWorkflowRuns(subagentsDirpath string, manifestsDirpath string) []*W
 				run.Bytes += a.Bytes
 			}
 			sort.SliceStable(run.Agents, func(i, j int) bool { return run.Agents[i].AgentID < run.Agents[j].AgentID })
-			run.FinishedAgents = countJournalResults(filepath.Join(run.Dirpath, workflowJournalFilename))
+			run.JournaledResults = countJournalResults(filepath.Join(run.Dirpath, workflowJournalFilename))
 		}
 	}
 
@@ -266,7 +258,8 @@ func applyWorkflowManifest(run *WorkflowRun) {
 }
 
 // countJournalResults counts the result records in a run's journal, or -1 when
-// the journal cannot be read. Each agent that finishes writes exactly one.
+// the journal cannot be read. See WorkflowRun.JournaledResults for what that
+// number does and does not mean.
 func countJournalResults(journalFilepath string) int {
 	n := 0
 	err := ScanJSONLLines(journalFilepath, func(line []byte) error {

--- a/internal/session/workflow_test.go
+++ b/internal/session/workflow_test.go
@@ -148,10 +148,10 @@ func TestDiscoveryReadsWorkflowManifestAndJournal(t *testing.T) {
 	if len(run.Agents) != 3 {
 		t.Errorf("agent count must come from disk (3), not the manifest (20): got %d", len(run.Agents))
 	}
-	if run.FinishedAgents != 2 || run.UnfinishedAgents() != 1 {
-		t.Errorf("journal: finished=%d unfinished=%d, want 2/1", run.FinishedAgents, run.UnfinishedAgents())
+	if run.JournaledResults != 2 {
+		t.Errorf("journal: results=%d, want 2", run.JournaledResults)
 	}
-	if empty := root.Workflows[0]; len(empty.Agents) != 0 || empty.Status != "failed" || empty.FinishedAgents != -1 || empty.UnfinishedAgents() != 0 {
+	if empty := root.Workflows[0]; len(empty.Agents) != 0 || empty.Status != "failed" || empty.JournaledResults != -1 {
 		t.Errorf("manifest-only run: %+v", *empty)
 	}
 }
@@ -166,7 +166,7 @@ func TestDiscoveryToleratesMalformedManifestAndJournal(t *testing.T) {
 	if len(root.Workflows) != 1 || len(root.Workflows[0].Agents) != 1 {
 		t.Fatalf("a run with a broken manifest must still list its agents: %+v", root.Workflows)
 	}
-	if run := root.Workflows[0]; run.ManifestFound || run.Status != "unknown" || run.FinishedAgents != -1 {
+	if run := root.Workflows[0]; run.ManifestFound || run.Status != "unknown" || run.JournaledResults != -1 {
 		t.Errorf("broken manifest/absent journal: %+v", *run)
 	}
 }

--- a/internal/session/workflow_test.go
+++ b/internal/session/workflow_test.go
@@ -1,0 +1,268 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// addWorkflowAgent writes an agent transcript inside a workflow run directory,
+// with the minimal sidecar the Workflow tool actually writes.
+func (fs *fakeSession) addWorkflowAgent(runID string, agentID string, lines ...string) {
+	fs.t.Helper()
+	dir := filepath.Join(fs.projectDir, fs.sessionID, "subagents", "workflows", runID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		fs.t.Fatalf("mkdir run dir: %v", err)
+	}
+	fs.writeFile(filepath.Join(dir, "agent-"+agentID+".jsonl"), strings.Join(lines, "\n"))
+	fs.writeFile(filepath.Join(dir, "agent-"+agentID+".meta.json"), `{"agentType":"workflow-subagent","spawnDepth":1}`)
+}
+
+// addWorkflowManifest writes <session>/workflows/<runID>.json verbatim.
+func (fs *fakeSession) addWorkflowManifest(runID string, manifestJSON string) {
+	fs.t.Helper()
+	dir := filepath.Join(fs.projectDir, fs.sessionID, "workflows")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		fs.t.Fatalf("mkdir workflows: %v", err)
+	}
+	fs.writeFile(filepath.Join(dir, runID+".json"), manifestJSON)
+}
+
+// addWorkflowJournal writes a run's journal with the given agent IDs started and
+// the first `finished` of them reporting a result.
+func (fs *fakeSession) addWorkflowJournal(runID string, started []string, finished int) {
+	fs.t.Helper()
+	var lines []string
+	for _, id := range started {
+		lines = append(lines, `{"type":"started","key":"v2:k","agentId":"`+id+`"}`)
+	}
+	for _, id := range started[:finished] {
+		lines = append(lines, `{"type":"result","key":"v2:k","agentId":"`+id+`","result":{"ok":true}}`)
+	}
+	fs.writeFile(filepath.Join(fs.projectDir, fs.sessionID, "subagents", "workflows", runID, "journal.jsonl"), strings.Join(lines, "\n"))
+}
+
+// countAgentFilesIndependently counts agent-*.jsonl under a session directory
+// with filepath.WalkDir, which shares no code with discovery. Discovery was once
+// verified by a sweep that read directories the same non-recursive way the code
+// did, so the sweep confirmed a bug that hid 55% of the transcripts on disk.
+func countAgentFilesIndependently(t *testing.T, sessionDir string) int {
+	t.Helper()
+	n := 0
+	err := filepath.WalkDir(sessionDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := d.Name()
+		if !d.IsDir() && strings.HasPrefix(name, "agent-") && strings.HasSuffix(name, ".jsonl") {
+			n++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	return n
+}
+
+func TestDiscoveryReadsWorkflowRunDirectories(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aloose", &AgentMeta{AgentType: "Explore"}, assistantLine("2026-01-01T00:01:00.000Z", "loose body"))
+	fs.addWorkflowAgent("wf_aaaa1111-111", "aw1", assistantLine("2026-01-01T00:02:00.000Z", "wf body one"))
+	fs.addWorkflowAgent("wf_aaaa1111-111", "aw2", assistantLine("2026-01-01T00:03:00.000Z", "wf body two"))
+	fs.addWorkflowAgent("wf_bbbb2222-222", "aw3", assistantLine("2026-01-01T00:04:00.000Z", "wf body three"))
+
+	root := fs.discover()
+
+	if got, want := len(root.AllAgents()), countAgentFilesIndependently(t, filepath.Join(fs.projectDir, fs.sessionID)); got != want {
+		t.Fatalf("AllAgents() = %d, independent count on disk = %d", got, want)
+	}
+	// Positive control on the control: the independent count must include the
+	// nested files, or agreement proves nothing.
+	if countAgentFilesIndependently(t, filepath.Join(fs.projectDir, fs.sessionID)) != 4 {
+		t.Fatal("the independent counter did not see the nested layout")
+	}
+	if len(root.Workflows) != 2 {
+		t.Fatalf("workflow runs = %d, want 2", len(root.Workflows))
+	}
+	// Runs stay out of the tree walk, so Flatten is bounded by loose agents.
+	if got := len(root.Flatten()); got != 2 {
+		t.Errorf("Flatten() = %d nodes, want 2 (main + loose agent); runs must not be tree nodes", got)
+	}
+	run := root.Workflows[0]
+	run.LoadAgentDetails()
+	if run.RunID != "wf_aaaa1111-111" || len(run.Agents) != 2 || run.Agents[0].AgentID != "aw1" {
+		t.Errorf("first run = %s with %d agents, want wf_aaaa1111-111 with 2", run.RunID, len(run.Agents))
+	}
+	if run.Agents[0].Workflow != run || run.Agents[0].Depth != 1 {
+		t.Errorf("workflow agent must point at its run and sit at depth 1")
+	}
+	if run.Status != "unknown" || run.ManifestFound {
+		t.Errorf("run with no manifest: status=%q manifestFound=%v, want unknown/false", run.Status, run.ManifestFound)
+	}
+	if run.StartedAt != "2026-01-01T00:02:00.000Z" {
+		t.Errorf("run without manifest should start at its earliest agent, got %q", run.StartedAt)
+	}
+	if second := root.Workflows[1]; second.Agents[0].StartedAt != "" && !second.detailsLoaded {
+		t.Errorf("a run with agents must not read every agent's start eagerly")
+	}
+	if run.Bytes <= 0 || run.Agents[0].Bytes <= 0 {
+		t.Errorf("sizes must be recorded: run=%d agent=%d", run.Bytes, run.Agents[0].Bytes)
+	}
+}
+
+func TestDiscoveryReadsWorkflowManifestAndJournal(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addWorkflowAgent("wf_cccc3333-333", "ac1", assistantLine("2026-01-01T00:02:00.000Z", "one"))
+	fs.addWorkflowAgent("wf_cccc3333-333", "ac2", assistantLine("2026-01-01T00:03:00.000Z", "two"))
+	fs.addWorkflowAgent("wf_cccc3333-333", "ac3", assistantLine("2026-01-01T00:04:00.000Z", "three"))
+	fs.addWorkflowJournal("wf_cccc3333-333", []string{"ac1", "ac2", "ac3"}, 2)
+	// Numbers quoted, as the real writer quotes them; agentCount deliberately
+	// wrong, as it is in 40 of 106 real runs.
+	fs.addWorkflowManifest("wf_cccc3333-333", `{"runId":"wf_cccc3333-333","timestamp":"2026-01-01T00:01:30.000Z","taskId":"wtask1234","workflowName":"analyze","summary":"one agent per thread","status":"completed","agentCount":"20","durationMs":"1487202","totalTokens":1741419,"totalToolCalls":"194"}`)
+	// A manifest with no agent directory is still a run.
+	fs.addWorkflowManifest("wf_dddd4444-444", `{"runId":"wf_dddd4444-444","timestamp":"2026-01-01T00:00:30.000Z","taskId":"wtask9999","workflowName":"empty","status":"failed"}`)
+
+	root := fs.discover()
+
+	if len(root.Workflows) != 2 {
+		t.Fatalf("runs = %d, want 2", len(root.Workflows))
+	}
+	if root.Workflows[0].RunID != "wf_dddd4444-444" {
+		t.Errorf("runs must order by manifest timestamp; first = %s", root.Workflows[0].RunID)
+	}
+	run := root.Workflows[1]
+	if !run.ManifestFound || run.TaskID != "wtask1234" || run.Name != "analyze" || run.Status != "completed" || run.Summary != "one agent per thread" {
+		t.Errorf("manifest not applied: %+v", *run)
+	}
+	if run.StartedAt != "2026-01-01T00:01:30.000Z" {
+		t.Errorf("StartedAt must come from the manifest, got %q", run.StartedAt)
+	}
+	if run.DurationMs != 1487202 || run.TotalTokens != 1741419 || run.TotalToolCalls != 194 {
+		t.Errorf("quoted and unquoted numbers must both decode: %d %d %d", run.DurationMs, run.TotalTokens, run.TotalToolCalls)
+	}
+	if len(run.Agents) != 3 {
+		t.Errorf("agent count must come from disk (3), not the manifest (20): got %d", len(run.Agents))
+	}
+	if run.FinishedAgents != 2 || run.UnfinishedAgents() != 1 {
+		t.Errorf("journal: finished=%d unfinished=%d, want 2/1", run.FinishedAgents, run.UnfinishedAgents())
+	}
+	if empty := root.Workflows[0]; len(empty.Agents) != 0 || empty.Status != "failed" || empty.FinishedAgents != -1 || empty.UnfinishedAgents() != 0 {
+		t.Errorf("manifest-only run: %+v", *empty)
+	}
+}
+
+func TestDiscoveryToleratesMalformedManifestAndJournal(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addWorkflowAgent("wf_eeee5555-555", "ae1", assistantLine("2026-01-01T00:02:00.000Z", "one"))
+	fs.addWorkflowManifest("wf_eeee5555-555", `{not json`)
+
+	root := fs.discover()
+
+	if len(root.Workflows) != 1 || len(root.Workflows[0].Agents) != 1 {
+		t.Fatalf("a run with a broken manifest must still list its agents: %+v", root.Workflows)
+	}
+	if run := root.Workflows[0]; run.ManifestFound || run.Status != "unknown" || run.FinishedAgents != -1 {
+		t.Errorf("broken manifest/absent journal: %+v", *run)
+	}
+}
+
+func TestResolveAgentReachesWorkflowAgentsAndNames(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("areviewer-tests-97ef", &AgentMeta{Name: "reviewer-tests", Description: "Adversarial test-quality review"}, assistantLine("2026-01-01T00:01:00.000Z", "r"))
+	fs.addAgent("areviewer-code-1234", &AgentMeta{Name: "reviewer-code", Description: "Adversarial correctness review"}, assistantLine("2026-01-01T00:01:00.000Z", "r"))
+	fs.addWorkflowAgent("wf_ffff6666-666", "af0123456789", assistantLine("2026-01-01T00:02:00.000Z", "w"))
+
+	for key, want := range map[string]string{
+		"af0123456789":   "af0123456789",         // workflow agent by exact ID
+		"af01":           "af0123456789",         // and by prefix
+		"reviewer-tests": "areviewer-tests-97ef", // exact name beats the shared ID prefix "areviewer"
+		"test-quality":   "areviewer-tests-97ef", // description substring
+	} {
+		got, err := ResolveAgent(fs.discover(), key)
+		if err != nil {
+			t.Errorf("ResolveAgent(%q): %v", key, err)
+			continue
+		}
+		if got.AgentID != want {
+			t.Errorf("ResolveAgent(%q) = %s, want %s", key, got.AgentID, want)
+		}
+	}
+
+	_, err := ResolveAgent(fs.discover(), "areviewer")
+	if err == nil || !strings.Contains(err.Error(), "areviewer-code-1234 (reviewer-code)") || !strings.Contains(err.Error(), "areviewer-tests-97ef (reviewer-tests)") {
+		t.Errorf("ambiguous prefix must name every candidate with its label, got %v", err)
+	}
+	_, err = ResolveAgent(fs.discover(), "Adversarial")
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("a description substring shared by two agents is ambiguous, got %v", err)
+	}
+	if _, err := ResolveAgent(fs.discover(), "nosuch"); !errors.Is(err, ErrAgentNotFound) {
+		t.Errorf("want ErrAgentNotFound, got %v", err)
+	}
+}
+
+func TestResolveWorkflowByEveryHandle(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addWorkflowAgent("wf_3a23189e-9d5", "a1", assistantLine("2026-01-01T00:02:00.000Z", "w"))
+	fs.addWorkflowAgent("wf_3a9999ee-000", "a2", assistantLine("2026-01-01T00:03:00.000Z", "w"))
+	fs.addWorkflowManifest("wf_3a23189e-9d5", `{"taskId":"w9gxz79on","workflowName":"analyze","timestamp":"2026-01-01T00:01:00.000Z"}`)
+	fs.addWorkflowManifest("wf_3a9999ee-000", `{"taskId":"wother","workflowName":"classify","timestamp":"2026-01-01T00:02:30.000Z"}`)
+	root := fs.discover()
+
+	for _, key := range []string{"wf_3a23189e-9d5", "wf_3a23", "3a23", "w9gxz79on", "analyze"} {
+		run, err := ResolveWorkflow(root, key)
+		if err != nil || run.RunID != "wf_3a23189e-9d5" {
+			t.Errorf("ResolveWorkflow(%q) = %v, %v", key, run, err)
+		}
+	}
+	if _, err := ResolveWorkflow(root, "wf_3a"); err == nil || !strings.Contains(err.Error(), "wf_3a23189e-9d5 (analyze, 1 agents)") {
+		t.Errorf("ambiguous prefix must list candidates, got %v", err)
+	}
+	if _, err := ResolveWorkflow(root, "zzz"); !errors.Is(err, ErrWorkflowNotFound) {
+		t.Errorf("want ErrWorkflowNotFound, got %v", err)
+	}
+}
+
+func TestReadWorkflowManifestJSONReturnsTheWholeManifest(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addWorkflowManifest("wf_1111aaaa-aaa", `{"runId":"wf_1111aaaa-aaa","result":{"dispatched":3},"phases":[{"title":"Review"}]}`)
+	root := fs.discover()
+
+	m, err := ReadWorkflowManifestJSON(root.Workflows[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, _ := json.Marshal(m["result"])
+	if string(encoded) != `{"dispatched":3}` {
+		t.Errorf("result = %s", encoded)
+	}
+	if _, err := ReadWorkflowManifestJSON(&WorkflowRun{}); err == nil {
+		t.Error("a run without a manifest path must error, not return nil")
+	}
+}
+
+// TestDiscoveryAgreesWithWalkDirOnARealSession is the positive control against
+// the disk: point it at a real session and discovery must find exactly the
+// files an independent walk finds. It skips unless both variables are set.
+//
+//	TXOB_REAL_PROJECT_DIR=~/.claude/projects/<encoded-cwd> TXOB_REAL_SESSION_ID=<uuid> go test ./internal/session -run RealSession -v
+func TestDiscoveryAgreesWithWalkDirOnARealSession(t *testing.T) {
+	projectDir, sessionID := os.Getenv("TXOB_REAL_PROJECT_DIR"), os.Getenv("TXOB_REAL_SESSION_ID")
+	if projectDir == "" || sessionID == "" {
+		t.Skip("set TXOB_REAL_PROJECT_DIR and TXOB_REAL_SESSION_ID to run against a real session")
+	}
+	root, err := DiscoverSessionTranscripts(projectDir, sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, want := len(root.AllAgents()), countAgentFilesIndependently(t, filepath.Join(projectDir, sessionID))
+	t.Logf("discovered %d agents in %d runs + %d loose; walkdir counts %d", got, len(root.Workflows), len(root.Flatten())-1, want)
+	if got != want {
+		t.Fatalf("discovery = %d, independent walk = %d", got, want)
+	}
+}

--- a/internal/session/workflow_test.go
+++ b/internal/session/workflow_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -75,6 +76,10 @@ func TestDiscoveryReadsWorkflowRunDirectories(t *testing.T) {
 	fs.addWorkflowAgent("wf_aaaa1111-111", "aw1", assistantLine("2026-01-01T00:02:00.000Z", "wf body one"))
 	fs.addWorkflowAgent("wf_aaaa1111-111", "aw2", assistantLine("2026-01-01T00:03:00.000Z", "wf body two"))
 	fs.addWorkflowAgent("wf_bbbb2222-222", "aw3", assistantLine("2026-01-01T00:04:00.000Z", "wf body three"))
+	// The second run has a manifest with a start time, so discovery has no
+	// reason to open its agents; the lazy guard below is only meaningful
+	// because of that.
+	fs.addWorkflowManifest("wf_bbbb2222-222", `{"startTime":1767225840000,"status":"completed"}`)
 
 	root := fs.discover()
 
@@ -107,8 +112,12 @@ func TestDiscoveryReadsWorkflowRunDirectories(t *testing.T) {
 	if run.StartedAt != "2026-01-01T00:02:00.000Z" {
 		t.Errorf("run without manifest should start at its earliest agent, got %q", run.StartedAt)
 	}
-	if second := root.Workflows[1]; second.Agents[0].StartedAt != "" && !second.detailsLoaded {
-		t.Errorf("a run with agents must not read every agent's start eagerly")
+	if second := root.Workflows[1]; second.detailsLoaded || second.Agents[0].StartedAt != "" {
+		t.Errorf("a run whose manifest carries a start time must not read its agents' starts eagerly: loaded=%v startedAt=%q", second.detailsLoaded, second.Agents[0].StartedAt)
+	}
+	root.Workflows[1].LoadAgentDetails()
+	if root.Workflows[1].Agents[0].StartedAt != "2026-01-01T00:04:00.000Z" {
+		t.Errorf("LoadAgentDetails must fill the start, got %q", root.Workflows[1].Agents[0].StartedAt)
 	}
 	if run.Bytes <= 0 || run.Agents[0].Bytes <= 0 {
 		t.Errorf("sizes must be recorded: run=%d agent=%d", run.Bytes, run.Agents[0].Bytes)
@@ -123,9 +132,12 @@ func TestDiscoveryReadsWorkflowManifestAndJournal(t *testing.T) {
 	fs.addWorkflowJournal("wf_cccc3333-333", []string{"ac1", "ac2", "ac3"}, 2)
 	// Numbers quoted, as the real writer quotes them; agentCount deliberately
 	// wrong, as it is in 40 of 106 real runs.
-	fs.addWorkflowManifest("wf_cccc3333-333", `{"runId":"wf_cccc3333-333","timestamp":"2026-01-01T00:01:30.000Z","taskId":"wtask1234","workflowName":"analyze","summary":"one agent per thread","status":"completed","agentCount":"20","durationMs":"1487202","totalTokens":1741419,"totalToolCalls":"194"}`)
+	// "timestamp" is the run's COMPLETION time; startTime (epoch ms) is its
+	// start. Here the completion is placed BEFORE the other run's start so
+	// that ordering by the wrong field would be visible.
+	fs.addWorkflowManifest("wf_cccc3333-333", `{"runId":"wf_cccc3333-333","timestamp":"2026-01-01T00:00:10.000Z","startTime":"1767225690000","taskId":"wtask1234","workflowName":"analyze","summary":"one agent per thread","status":"completed","agentCount":"20","durationMs":"1487202","totalTokens":1741419,"totalToolCalls":"194"}`)
 	// A manifest with no agent directory is still a run.
-	fs.addWorkflowManifest("wf_dddd4444-444", `{"runId":"wf_dddd4444-444","timestamp":"2026-01-01T00:00:30.000Z","taskId":"wtask9999","workflowName":"empty","status":"failed"}`)
+	fs.addWorkflowManifest("wf_dddd4444-444", `{"runId":"wf_dddd4444-444","timestamp":"2026-01-01T00:00:30.000Z","startTime":1767225630000,"taskId":"wtask9999","workflowName":"empty","status":"failed"}`)
 
 	root := fs.discover()
 
@@ -133,14 +145,17 @@ func TestDiscoveryReadsWorkflowManifestAndJournal(t *testing.T) {
 		t.Fatalf("runs = %d, want 2", len(root.Workflows))
 	}
 	if root.Workflows[0].RunID != "wf_dddd4444-444" {
-		t.Errorf("runs must order by manifest timestamp; first = %s", root.Workflows[0].RunID)
+		t.Errorf("runs must order by start time (startTime), not by the completion timestamp; first = %s", root.Workflows[0].RunID)
 	}
 	run := root.Workflows[1]
 	if !run.ManifestFound || run.TaskID != "wtask1234" || run.Name != "analyze" || run.Status != "completed" || run.Summary != "one agent per thread" {
 		t.Errorf("manifest not applied: %+v", *run)
 	}
 	if run.StartedAt != "2026-01-01T00:01:30.000Z" {
-		t.Errorf("StartedAt must come from the manifest, got %q", run.StartedAt)
+		t.Errorf("StartedAt must come from the manifest's startTime (1767225690000 ms = 00:01:30Z), got %q", run.StartedAt)
+	}
+	if run.CompletedAt != "2026-01-01T00:00:10.000Z" {
+		t.Errorf("CompletedAt must be the manifest's timestamp, got %q", run.CompletedAt)
 	}
 	if run.DurationMs != 1487202 || run.TotalTokens != 1741419 || run.TotalToolCalls != 194 {
 		t.Errorf("quoted and unquoted numbers must both decode: %d %d %d", run.DurationMs, run.TotalTokens, run.TotalToolCalls)
@@ -319,5 +334,43 @@ func TestDiscoveryAgreesWithWalkDirAcrossAProjectsRoot(t *testing.T) {
 	t.Logf("sessions=%d agents=%d (walkdir %d) workflow runs=%d mismatches=%d", sessions, agents, walked, runs, mismatches)
 	if sessions == 0 || walked == 0 {
 		t.Fatalf("the control inspected nothing: sessions=%d walked=%d", sessions, walked)
+	}
+}
+
+func TestAmbiguityErrorsAreBounded(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	for i := 0; i < 30; i++ {
+		fs.addAgent(fmt.Sprintf("a%02d", i), &AgentMeta{Name: fmt.Sprintf("worker-%02d", i)}, assistantLine("2026-01-01T00:01:00.000Z", "x"))
+	}
+	_, err := ResolveAgent(fs.discover(), "a")
+	if err == nil {
+		t.Fatal("want ambiguity")
+	}
+	if !strings.Contains(err.Error(), "a19 (worker-19), ... and 10 more") || strings.Contains(err.Error(), "a20 (") {
+		t.Errorf("ambiguity must name at most %d candidates and count the rest, got %v", maxNamedCandidates, err)
+	}
+}
+
+func TestResolveAgentMatchesNamesCaseInsensitively(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("a1", &AgentMeta{Name: "review"}, assistantLine("2026-01-01T00:01:00.000Z", "x"))
+	fs.addAgent("a12", &AgentMeta{Description: "code review pass"}, assistantLine("2026-01-01T00:01:00.000Z", "x"))
+	root := fs.discover()
+	for _, key := range []string{"review", "Review", "REVIEW"} {
+		got, err := ResolveAgent(root, key)
+		if err != nil || got.AgentID != "a1" {
+			t.Errorf("ResolveAgent(%q) = %v, %v; an exact name must win regardless of case", key, got, err)
+		}
+	}
+}
+
+func TestFormatBytesNeverPrintsATousandAndTwentyFour(t *testing.T) {
+	for n, want := range map[int64]string{
+		0: "0 B", 1023: "1023 B", 1024: "1.0 KB", 1048575: "1.0 MB", 1023*1024 + 1000: "1.0 MB",
+		1048576: "1.0 MB", 1073741823: "1.0 GB", 5*1024*1024 + 200*1024: "5.2 MB",
+	} {
+		if got := FormatBytes(n); got != want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", n, got, want)
+		}
 	}
 }

--- a/internal/session/workflow_test.go
+++ b/internal/session/workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // addWorkflowAgent writes an agent transcript inside a workflow run directory,
@@ -372,5 +373,38 @@ func TestFormatBytesNeverPrintsATousandAndTwentyFour(t *testing.T) {
 		if got := FormatBytes(n); got != want {
 			t.Errorf("FormatBytes(%d) = %q, want %q", n, got, want)
 		}
+	}
+}
+
+func TestLatestTranscriptActivitySeesSubagentsInBothLayouts(t *testing.T) {
+	fs := newFakeSession(t, userLine("2026-01-01T00:00:00.000Z", "go"))
+	fs.addAgent("aloose", &AgentMeta{AgentType: "Explore"}, assistantLine("2026-01-01T00:01:00.000Z", "x"))
+	fs.addWorkflowAgent("wf_live0001-aaa", "awf", assistantLine("2026-01-01T00:02:00.000Z", "x"))
+
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mid := old.Add(time.Hour)
+	recent := old.Add(2 * time.Hour)
+	sessionDir := filepath.Join(fs.projectDir, fs.sessionID)
+	for path, at := range map[string]time.Time{
+		filepath.Join(fs.projectDir, fs.sessionID+".jsonl"):                                       old,
+		filepath.Join(sessionDir, "subagents", "agent-aloose.jsonl"):                              mid,
+		filepath.Join(sessionDir, "subagents", "workflows", "wf_live0001-aaa", "agent-awf.jsonl"): recent,
+	} {
+		if err := os.Chtimes(path, at, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, ok := LatestTranscriptActivity(fs.projectDir)
+	if !ok || !got.Equal(recent) {
+		t.Errorf("LatestTranscriptActivity = %s, %v; want the workflow agent's %s", got, ok, recent)
+	}
+	// Positive control: the main file alone would have said "idle for hours".
+	info, _ := os.Stat(filepath.Join(fs.projectDir, fs.sessionID+".jsonl"))
+	if !info.ModTime().Equal(old) {
+		t.Fatalf("control: main jsonl mtime = %s, want %s", info.ModTime(), old)
+	}
+	if _, ok := LatestTranscriptActivity(filepath.Join(fs.projectDir, "does-not-exist")); ok {
+		t.Errorf("a missing project directory must report no activity, not a zero time")
 	}
 }

--- a/internal/session/workflow_test.go
+++ b/internal/session/workflow_test.go
@@ -266,3 +266,58 @@ func TestDiscoveryAgreesWithWalkDirOnARealSession(t *testing.T) {
 		t.Fatalf("discovery = %d, independent walk = %d", got, want)
 	}
 }
+
+// TestDiscoveryAgreesWithWalkDirAcrossAProjectsRoot is the corpus-wide form of
+// the control above: every session under every project directory. It prints
+// the totals it saw, so a run that finds nothing cannot pass as a clean one.
+//
+//	TXOB_REAL_PROJECTS_ROOT=~/.claude/projects go test ./internal/session -run ProjectsRoot -v
+func TestDiscoveryAgreesWithWalkDirAcrossAProjectsRoot(t *testing.T) {
+	root := os.Getenv("TXOB_REAL_PROJECTS_ROOT")
+	if root == "" {
+		t.Skip("set TXOB_REAL_PROJECTS_ROOT to run against a real ~/.claude/projects")
+	}
+	projects, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions, agents, runs, walked, mismatches := 0, 0, 0, 0, 0
+	for _, project := range projects {
+		if !project.IsDir() {
+			continue
+		}
+		projectDir := filepath.Join(root, project.Name())
+		entries, err := os.ReadDir(projectDir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+				continue
+			}
+			sessionID := strings.TrimSuffix(e.Name(), ".jsonl")
+			tree, err := DiscoverSessionTranscripts(projectDir, sessionID)
+			if err != nil {
+				t.Errorf("%s/%s: %v", project.Name(), sessionID, err)
+				continue
+			}
+			sessions++
+			got := len(tree.AllAgents())
+			agents += got
+			runs += len(tree.Workflows)
+			want := 0
+			if _, err := os.Stat(filepath.Join(projectDir, sessionID)); err == nil {
+				want = countAgentFilesIndependently(t, filepath.Join(projectDir, sessionID))
+			}
+			walked += want
+			if got != want {
+				mismatches++
+				t.Errorf("%s/%s: discovery=%d walkdir=%d", project.Name(), sessionID, got, want)
+			}
+		}
+	}
+	t.Logf("sessions=%d agents=%d (walkdir %d) workflow runs=%d mismatches=%d", sessions, agents, walked, runs, mismatches)
+	if sessions == 0 || walked == 0 {
+		t.Fatalf("the control inspected nothing: sessions=%d walked=%d", sessions, walked)
+	}
+}

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -46,6 +46,9 @@ run_test() {
 # Asserts a command fails AND that its message names the reason. Checking the
 # exit code alone cannot tell "rejected the flag combination" from "crashed for
 # some other reason", and both exit non-zero.
+# Every helper passes the pattern after -e: a pattern that begins with "--"
+# is otherwise read by grep as an option, and every such test then fails
+# with "unrecognized option" against output that matched. It bit twice.
 run_test_error_contains() {
     local test_name="${1}"
     shift
@@ -65,7 +68,7 @@ run_test_error_contains() {
         return
     fi
 
-    if ! echo "${output}" | grep -qE "${expected_pattern}"; then
+    if ! echo "${output}" | grep -qE -e "${expected_pattern}"; then
         echo "FAIL (error did not match '${expected_pattern}')"
         echo "    Output: ${output}" | head -5
         failed=$((failed + 1))
@@ -98,7 +101,7 @@ run_test_output_contains() {
         return
     fi
 
-    if ! echo "${output}" | grep -qE "${expected_pattern}"; then
+    if ! echo "${output}" | grep -qE -e "${expected_pattern}"; then
         echo "FAIL (output missing pattern: ${expected_pattern})"
         echo "    Output: ${output}" | head -5
         failed=$((failed + 1))

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -43,6 +43,39 @@ run_test() {
     passed=$((passed + 1))
 }
 
+# Asserts a command fails AND that its message names the reason. Checking the
+# exit code alone cannot tell "rejected the flag combination" from "crashed for
+# some other reason", and both exit non-zero.
+run_test_error_contains() {
+    local test_name="${1}"
+    shift
+    local expected_pattern="${1}"
+    shift
+
+    total=$((total + 1))
+    printf "  %-50s " "${test_name}..."
+
+    local output
+    local actual_exit=0
+    output=$("$@" 2>&1) || actual_exit=$?
+
+    if [ "${actual_exit}" -eq 0 ]; then
+        echo "FAIL (expected a non-zero exit)"
+        failed=$((failed + 1))
+        return
+    fi
+
+    if ! echo "${output}" | grep -qE "${expected_pattern}"; then
+        echo "FAIL (error did not match '${expected_pattern}')"
+        echo "    Output: ${output}" | head -5
+        failed=$((failed + 1))
+        return
+    fi
+
+    echo "PASS"
+    passed=$((passed + 1))
+}
+
 run_test_output_contains() {
     local test_name="${1}"
     shift
@@ -1743,6 +1776,205 @@ else
 fi
 
 echo ""
+echo "--- Transcript observability flags (agenc-txob) ---"
+
+# A Claude session is a tree of transcripts: the main conversation plus one
+# JSONL per subagent it spawned, nested arbitrarily deep. `session print` and
+# `mission print` reach that tree through --agents / --agent / --expand-agents.
+#
+# Two things are covered below. First the CLI contract: flag validation runs
+# before any server call or file read, so a bad combination reports itself
+# rather than failing later as a lookup error. Then the rendering itself,
+# against a transcript tree synthesized on disk.
+
+run_test_error_contains "session print rejects --agents with --agent" \
+    "mutually exclusive" \
+    "${agenc_test}" session print deadbeef --agents --agent aa8d6202
+
+run_test_error_contains "session print rejects --agents with --expand-agents" \
+    "mutually exclusive" \
+    "${agenc_test}" session print deadbeef --agents --expand-agents
+
+run_test_error_contains "session print rejects an unknown --format" \
+    "invalid [-][-]format" \
+    "${agenc_test}" session print deadbeef --format=yaml
+
+run_test_error_contains "session print rejects a non-positive --tail" \
+    "must be positive" \
+    "${agenc_test}" session print deadbeef --tail 0
+
+run_test_error_contains "mission print rejects --agents with --agent" \
+    "mutually exclusive" \
+    "${agenc_test}" mission print deadbeef --agents --agent aa8d6202
+
+run_test_error_contains "mission print rejects an unknown --format" \
+    "invalid [-][-]format" \
+    "${agenc_test}" mission print deadbeef --format=yaml
+
+run_test_output_contains "session print help documents --agents" \
+    "[-][-]agents " \
+    "${agenc_test}" session print --help
+
+run_test_output_contains "session print help documents --agent" \
+    "[-][-]agent string" \
+    "${agenc_test}" session print --help
+
+run_test_output_contains "session print help documents --expand-agents" \
+    "[-][-]expand-agents" \
+    "${agenc_test}" session print --help
+
+run_test_output_contains "session print help documents --verbose" \
+    "[-][-]verbose" \
+    "${agenc_test}" session print --help
+
+run_test_output_contains "mission print help documents --session" \
+    "[-][-]session string" \
+    "${agenc_test}" mission print --help
+
+run_test_output_contains "mission print help documents --agents" \
+    "[-][-]agents " \
+    "${agenc_test}" mission print --help
+
+
+# --- Rendering a real transcript tree -------------------------------------
+#
+# Claude writes transcripts to $HOME/.claude/projects/<agent-dir-with-slashes-
+# and-dots-turned-to-hyphens>/. That path is HOME-relative, and agenc reads it
+# through os.UserHomeDir(), which honours $HOME — while AGENC_DIRPATH (which
+# owns the database and the server socket) is a separate variable the wrapper
+# sets. So a throwaway HOME redirects transcript lookup and nothing else, and
+# the developer's real ~/.claude is never touched.
+#
+# `mission print` without --session resolves its file straight off the
+# filesystem (session.FindActiveJSONLPath), so no database row is needed for the
+# session. `session print` is the wrong door here: it resolves the session ID
+# through the server, which requires a row.
+#
+# The server is already running by this point, started under the real HOME, so
+# the fake HOME below is never inherited by a server start.
+
+txob_short_id=$(create_mission_and_echo_short_id --blank --headless --no-focus)
+txob_full_id=""
+if [ -n "${txob_short_id}" ]; then
+    txob_full_id=$("${agenc_test}" mission inspect "${txob_short_id}" 2>/dev/null | awk '/^Full ID:/{print $3; exit}')
+fi
+
+if [ -z "${txob_full_id}" ]; then
+    total=$((total + 1))
+    printf "  %-50s " "transcript rendering fixture..."
+    echo "SKIP (could not create a mission to hang a transcript off)"
+    skipped=$((skipped + 1))
+else
+    # Resolve the same way the agenc-test wrapper does, so the encoded project
+    # directory matches what the binary computes.
+    txob_agenc_dirpath=$(cd "${repo_dirpath}/_test-env" && pwd)
+    txob_agent_dirpath="${txob_agenc_dirpath}/missions/${txob_full_id}/agent"
+    txob_project=$(printf '%s' "${txob_agent_dirpath}" | tr '/.' '--')
+    txob_session="11111111-2222-3333-4444-555555555555"
+    txob_home=$(mktemp -d)
+    txob_projdir="${txob_home}/.claude/projects/${txob_project}"
+    mkdir -p "${txob_projdir}/${txob_session}/subagents"
+
+    # A session that: was forked from another, spawned a subagent, was
+    # compacted, and had an instruction queued mid-turn. The fork record comes
+    # first so that a tailed render has to scan past the window to find it.
+    cat > "${txob_projdir}/${txob_session}.jsonl" <<'TXOB_MAIN'
+{"type":"user","uuid":"m1","timestamp":"2026-01-01T00:00:00.000Z","forkedFrom":{"sessionId":"aaaaaaaa-1111-2222-3333-444444444444","messageUuid":"m1"},"origin":{"kind":"human"},"message":{"role":"user","content":"MAIN HUMAN TURN"}}
+{"type":"assistant","uuid":"m2","timestamp":"2026-01-01T00:00:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_e2e","name":"Agent","input":{"description":"e2e scout","subagent_type":"Explore"}}]}}
+{"type":"user","uuid":"m3","timestamp":"2026-01-01T00:00:30.000Z","toolUseResult":{"status":"completed","agentId":"ae2e0001","agentType":"Explore","totalDurationMs":29000,"totalToolUseCount":4},"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_e2e","content":"ok"}]}}
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-01-01T00:00:40.000Z","content":"QUEUED MID TURN"}
+{"type":"system","subtype":"compact_boundary","uuid":"m4","timestamp":"2026-01-01T00:00:50.000Z","compactMetadata":{"trigger":"manual","preTokens":354559,"postTokens":26757}}
+{"type":"assistant","uuid":"m5","timestamp":"2026-01-01T00:01:00.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"E2E THINKING BLOCK"},{"type":"text","text":"MAIN ASSISTANT REPLY"}]}}
+TXOB_MAIN
+
+    cat > "${txob_projdir}/${txob_session}/subagents/agent-ae2e0001.jsonl" <<'TXOB_AGENT'
+{"type":"user","uuid":"s1","timestamp":"2026-01-01T00:00:02.000Z","message":{"role":"user","content":"SUBAGENT PROMPT"}}
+{"type":"assistant","uuid":"s2","timestamp":"2026-01-01T00:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"SUBAGENT ANSWER"}]}}
+TXOB_AGENT
+
+    printf '%s' '{"agentType":"Explore","description":"e2e scout","toolUseId":"toolu_e2e","spawnDepth":1,"model":"haiku"}' \
+        > "${txob_projdir}/${txob_session}/subagents/agent-ae2e0001.meta.json"
+
+    run_test_output_contains "mission print renders the main conversation" \
+        "MAIN HUMAN TURN" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print tags a human turn's origin" \
+        "USER human" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print names the spawned subagent" \
+        "ae2e0001" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print shows the compaction boundary" \
+        "COMPACTED.*354559" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print shows a mid-turn queued instruction" \
+        "QUEUED MID TURN" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print shows fork provenance past the tail" \
+        "FORK.*aaaaaaaa-1111-2222-3333-444444444444" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --tail 2
+
+    run_test_output_contains "mission print hides thinking by default" \
+        "MAIN ASSISTANT REPLY" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print --verbose shows thinking" \
+        "E2E THINKING BLOCK" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --verbose
+
+    run_test_output_contains "mission print --agents lists the subagent tree" \
+        "ae2e0001.*Explore.*haiku" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agents
+
+    run_test_output_contains "mission print --agent prints one subagent" \
+        "SUBAGENT ANSWER" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agent ae2e0001
+
+    run_test_output_contains "mission print --expand-agents inlines the subagent" \
+        "begin agent ae2e0001" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --expand-agents
+
+    run_test_output_contains "mission print --format=jsonl emits raw records" \
+        '"uuid":"m1"' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --format=jsonl
+
+    run_test_error_contains "mission print rejects an unknown agent ID" \
+        "no matching subagent transcript" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agent nosuchagent
+
+    # The default render must NOT inline the subagent — otherwise --expand-agents
+    # is meaningless and the "not shown" hint would be a lie.
+    total=$((total + 1))
+    printf "  %-50s " "mission print does not inline subagents by default..."
+    txob_default_out=$(env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" 2>/dev/null || true)
+    if echo "${txob_default_out}" | grep -q "SUBAGENT ANSWER"; then
+        echo "FAIL (subagent inlined without --expand-agents)"
+        failed=$((failed + 1))
+    elif ! echo "${txob_default_out}" | grep -q "MAIN ASSISTANT REPLY"; then
+        echo "FAIL (nothing rendered, so the check inspected nothing)"
+        failed=$((failed + 1))
+    else
+        echo "PASS"
+        passed=$((passed + 1))
+    fi
+
+    run_test_output_has_no_ansi "mission print --agents emits no ANSI" \
+        "ae2e0001" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agents
+
+    run_test_output_has_no_ansi "mission print emits no ANSI" \
+        "MAIN HUMAN TURN" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    rm -rf "${txob_home}"
+fi
+
+echo ""
 echo "--- No ANSI escapes in command output (agenc-hxr4) ---"
 
 # AgenC command output is consumed overwhelmingly by agents, not read by a
@@ -1924,7 +2156,13 @@ run_test "config cron rm removes the mid-spell fixture" \
 # formatters are pinned by unit tests instead (TestFormatPlainRepoName_HasNoAnsi,
 # TestPlainGitRepoName_HasNoAnsi). Listed as skips rather than passes so the
 # gap stays visible — see agenc-pman.
-for uncoverable in "mission peers" "mission search"; do
+# `mission print` and `mission print --agents` are covered for real in the
+# transcript section above, against a synthesized transcript tree under a
+# throwaway HOME. `session print` is not: it resolves its session ID through the
+# server, which needs a sessions row that only a live Claude run creates. Its
+# rendering path is the same shared code, and printAgentTree's plainness is
+# additionally pinned by TestPrintAgentTreeEmitsNoAnsi.
+for uncoverable in "mission peers" "mission search" "session print --agents"; do
     total=$((total + 1))
     printf "  %-50s " "${uncoverable} emits no ANSI..."
     echo "SKIP (cannot populate rows in the test environment)"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1992,11 +1992,11 @@ TXOB_WF
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
 
     run_test_output_contains "mission print anchors a workflow spawn to its run" \
-        'Workflow.*\[workflow wf_e2e00001-abc (analyze): 1 agents, completed, 1m05s\]' \
+        'Workflow.*\[workflow wf_e2e00001-abc \(analyze\): 1 agents, completed, 1m05s\]' \
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
 
     run_test_output_contains "mission print ends with a stdout footer naming the listing command" \
-        '\[SUBAGENTS\] 2 transcript(s) not shown: 1 spawned directly, 1 in 1 workflow run(s) - --agents to list them.*agenc mission print .* --agents' \
+        '\[SUBAGENTS\] 2 transcript\(s\) not shown: 1 spawned directly, 1 in 1 workflow run\(s\) - --agents to list them.*agenc mission print .* --agents' \
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
 
     run_test_output_contains "mission print --agents opens with a session header" \
@@ -2012,7 +2012,7 @@ TXOB_WF
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agents --json
 
     run_test_output_contains "mission print --workflow describes the run by prefix" \
-        'workflow wf_e2e00001-abc (analyze): completed, 1m05s, 1 agents, 7 tool calls' \
+        'workflow wf_e2e00001-abc \(analyze\): completed, 1m05s, 1 agents, 7 tool calls' \
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --workflow e2e00001
 
     run_test_output_contains "mission print --workflow lists the run's agents" \
@@ -2046,7 +2046,7 @@ TXOB_WF
     fi
 
     run_test_error_contains "mission print --json outside its views teaches --format=jsonl" \
-        "--format=jsonl" \
+        "use [-][-]format=jsonl" \
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --json
 
     run_test_error_contains "mission print suggests the nearest flag for a typo" \

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1895,6 +1895,26 @@ TXOB_AGENT
     printf '%s' '{"agentType":"Explore","description":"e2e scout","toolUseId":"toolu_e2e","spawnDepth":1,"model":"haiku"}' \
         > "${txob_projdir}/${txob_session}/subagents/agent-ae2e0001.meta.json"
 
+    # A workflow run: its agents live one directory down, its manifest beside
+    # the subagents directory, and its spawn is linked through the task ID the
+    # Workflow tool's result reported. This layout held 55% of the subagent
+    # transcripts on the machine this was written on and was invisible before.
+    txob_run="wf_e2e00001-abc"
+    mkdir -p "${txob_projdir}/${txob_session}/subagents/workflows/${txob_run}" "${txob_projdir}/${txob_session}/workflows"
+    cat >> "${txob_projdir}/${txob_session}.jsonl" <<'TXOB_WF'
+{"type":"assistant","uuid":"m6","timestamp":"2026-01-01T00:02:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_wf","name":"Workflow","input":{"scriptPath":"/x/analyze.js"}}]}}
+{"type":"user","uuid":"m7","timestamp":"2026-01-01T00:02:01.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_wf","content":"Workflow launched in background. Task ID: we2etask1\nSummary: e2e workflow"}]}}
+{"type":"user","uuid":"m8","timestamp":"2026-01-01T00:03:00.000Z","origin":{"kind":"human"},"message":{"role":"user","content":"LATE HUMAN TURN"}}
+TXOB_WF
+    printf '%s\n' '{"type":"user","uuid":"w1","timestamp":"2026-01-01T00:02:10.000Z","message":{"role":"user","content":"WORKFLOW AGENT PROMPT"}}' \
+        > "${txob_projdir}/${txob_session}/subagents/workflows/${txob_run}/agent-awf00001.jsonl"
+    printf '%s' '{"agentType":"workflow-subagent","spawnDepth":1}' \
+        > "${txob_projdir}/${txob_session}/subagents/workflows/${txob_run}/agent-awf00001.meta.json"
+    printf '%s\n' '{"type":"started","key":"k","agentId":"awf00001"}' \
+        > "${txob_projdir}/${txob_session}/subagents/workflows/${txob_run}/journal.jsonl"
+    printf '%s' '{"runId":"wf_e2e00001-abc","timestamp":"2026-01-01T00:02:00.500Z","taskId":"we2etask1","workflowName":"analyze","summary":"e2e workflow","status":"completed","durationMs":"65000","totalToolCalls":"7","phases":[{"title":"Review"}],"result":{"dispatched":1}}' \
+        > "${txob_projdir}/${txob_session}/workflows/${txob_run}.json"
+
     run_test_output_contains "mission print renders the main conversation" \
         "MAIN HUMAN TURN" \
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
@@ -1970,6 +1990,72 @@ TXOB_AGENT
     run_test_output_has_no_ansi "mission print emits no ANSI" \
         "MAIN HUMAN TURN" \
         env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print anchors a workflow spawn to its run" \
+        'Workflow.*\[workflow wf_e2e00001-abc (analyze): 1 agents, completed, 1m05s\]' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print ends with a stdout footer naming the listing command" \
+        '\[SUBAGENTS\] 2 transcript(s) not shown: 1 spawned directly, 1 in 1 workflow run(s) - --agents to list them.*agenc mission print .* --agents' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}"
+
+    run_test_output_contains "mission print --agents opens with a session header" \
+        'session .*: [0-9]+ messages, [0-9]+ tool calls, [0-9]+ errors, 1 compactions, ' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agents
+
+    run_test_output_contains "mission print --agents shows a workflow run as one row" \
+        'wf_e2e00001-abc +workflow +- +1 agents +7 ' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agents
+
+    run_test_output_contains "mission print --agents --json is a document" \
+        '"run_id": "wf_e2e00001-abc"' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agents --json
+
+    run_test_output_contains "mission print --workflow describes the run by prefix" \
+        'workflow wf_e2e00001-abc (analyze): completed, 1m05s, 1 agents, 7 tool calls' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --workflow e2e00001
+
+    run_test_output_contains "mission print --workflow lists the run's agents" \
+        'awf00001 +workflow-subagent' \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --workflow analyze
+
+    run_test_output_contains "mission print --agent reaches a workflow agent" \
+        "WORKFLOW AGENT PROMPT" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agent awf00001
+
+    run_test_output_contains "mission print --agent accepts a description fragment" \
+        "SUBAGENT PROMPT" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --agent "e2e scout"
+
+    run_test_output_contains "mission print --since keeps only the window" \
+        "LATE HUMAN TURN" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --since 2026-01-01T00:02:30Z
+
+    total=$((total + 1))
+    printf "  %-50s " "mission print --since drops records before it..."
+    txob_since_out=$(env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --since 2026-01-01T00:02:30Z 2>/dev/null || true)
+    if echo "${txob_since_out}" | grep -q "MAIN HUMAN TURN"; then
+        echo "FAIL (a record before --since was rendered)"
+        failed=$((failed + 1))
+    elif ! echo "${txob_since_out}" | grep -q "LATE HUMAN TURN"; then
+        echo "FAIL (nothing rendered, so the check inspected nothing)"
+        failed=$((failed + 1))
+    else
+        echo "PASS"
+        passed=$((passed + 1))
+    fi
+
+    run_test_error_contains "mission print --json outside its views teaches --format=jsonl" \
+        "--format=jsonl" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --json
+
+    run_test_error_contains "mission print suggests the nearest flag for a typo" \
+        "did you mean --agents" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --subagents
+
+    run_test_output_has_no_ansi "mission print --workflow emits no ANSI" \
+        "awf00001" \
+        env HOME="${txob_home}" "${agenc_test}" mission print "${txob_short_id}" --workflow analyze
 
     rm -rf "${txob_home}"
 fi


### PR DESCRIPTION
Implements the listing and printing halves of #23. The search half is deliberately still open; see "What this does not do".

While building it I found the layout in my own issue was wrong, and wrong in a way that mattered: a session's subagents are not all in `<session-id>/subagents/`.

## The measurement

Agents spawned by the **Workflow** tool are written one directory deeper, in `<session-id>/subagents/workflows/<run-id>/`, with the run's manifest beside it at `<session-id>/workflows/<run-id>.json`. `os.ReadDir` on `subagents/` does not descend, so that whole layer was invisible.

On this machine, counting the two layouts separately:

| layout | transcripts | reachable before |
|---|---|---|
| `subagents/agent-*.jsonl` | 7,158 | yes |
| `subagents/workflows/<run-id>/agent-*.jsonl` | **8,918** | **no** |

55% of all subagent transcripts. The worst single session holds 7,214 agent transcripts in 60 workflow runs; every command in this repo could see 38 of them.

The uncomfortable part: my first cut of this work *also* only read the flat directory, and I "verified" it with a corpus sweep that walked directories the same non-recursive way the code did. The sweep confirmed the bug. There is now a test that counts agent files with `filepath.WalkDir`, sharing no code with discovery, and requires discovery to agree. Env-gated so it can run against real data:

```
$ TXOB_REAL_PROJECTS_ROOT=~/.claude/projects go test ./internal/session -run ProjectsRoot -v
    sessions=1742 agents=16127 (walkdir 16127) workflow runs=108 mismatches=0
```

## The interface

#23 asked for a way to list subagents and a way to print one. The listing part needs care: a flat list is unusable when one session has 7,214 of them, and reading each transcript to build a row costs 731 MB and 16 seconds.

So a **workflow run is one row**, built from its manifest and a directory listing without opening a single agent transcript:

```
$ agenc session print bd6af806 --agents
session bd6af806-...: 1883 messages, 560 tool calls, 21 errors, 1 compactions, 9.9 MB, 2026-08-16 18:37 - 2026-09-03 17:17
subagents: 38 spawned directly (30.7 MB); 7176 in 60 workflow run(s) (685.7 MB)
AGENT                          TYPE             MODEL   MSGS        TOOLS  ERR  STARTED           SIZE      LABEL
(main)                         session          -       1883        560    21   2026-08-16 18:37  9.9 MB
at1-builder-0e147e1dfc2869fd   t1-builder       opus    167         55     2    2026-08-16 18:48  702.2 KB  t1-builder
wf_05f3e3e5-0b8                workflow         -       699 agents  1481   -    2026-08-21 19:59  50.0 MB   classify: completed, 47m17s - one agent per thread
```

102 lines, 23 KB, 2.3 s for that 7,214-agent session. The `SIZE` column is there so an agent can decide what it can afford to read *before* reading it.

From there:

- `--agent <id>`: agent ID, unique ID prefix, the agent's **name**, or a fragment of its description, so `--agent reviewer-tests` works.
- `--workflow <id>`: run ID, prefix with or without `wf_`, task ID, or workflow name. Prints the run's status, phases and structured result, then its agents.
- `--agents --json` / `--workflow <id> --json`: the same documents for programs. A table is not an API.
- `--expand-agents`: inlines directly spawned agents at their spawn sites.
- `--since` / `--until`: a time window instead of a record count, on both text and `--format=jsonl`. `--tail N` counts records whose size is unpredictable; a reader of a 96 MB transcript wants "what happened after 14:00".
- `session ls --mission <id>`: per session, started, messages, tools, errors, compactions, forked-from, subagent count, size.

**The transcript now teaches its own drill-down**, which I think matters more than any single flag. A Workflow spawn used to render as a bare `> Workflow()`, 62 times in that session, with no run ID and no way to open it. Now:

```
> Workflow()  [workflow wf_8fe56837-849 (openers): 2 agents, completed, 5m51s]
```

and every render of a main transcript ends with one line on stdout:

```
[SUBAGENTS] 7214 transcript(s) not shown: 38 spawned directly, 7176 in 60 workflow run(s) - --agents to list them, --agent <id> or --workflow <id> to open one - agenc session print bd6af806 --agents
```

On stdout, not stderr, and carrying the exact command: an agent that captured only stdout and never read `--help` still finds the next step. Misses and ambiguity answer the same way (`no matching workflow run ... (--agents lists the runs)`), and a misspelt flag gets `unknown flag: --subagents (did you mean --agents?)`.

Everything else in the default render is unchanged except that record classes which change how a conversation reads are no longer dropped: compaction boundaries and their summaries, fork provenance, queued mid-turn input, message origin (`USER human` vs `USER peer:name` vs `USER task-notification`), and errors. `--verbose` adds the bookkeeping classes.

## Bounded on purpose

The failure mode I was most worried about is a command that helpfully emits 700 MB into an agent's context.

- Every listing is bounded by the number of **runs**, never their agents.
- `--expand-agents` never inlines a workflow run, and stops inlining directly spawned agents past `--max-expand-mb` (default 16), leaving a note naming the agent, its size and the flag. That session renders to 1.3 MB instead of hundreds.
- `--format=jsonl --expand-agents` honours the same budget, reporting skipped agents on stderr since the raw stream cannot carry a note.
- Ambiguity errors name at most 20 candidates. `--agent a` on that session used to produce 138 KB of stderr.

## One behaviour change, flagged deliberately

`15733c4` is the only commit here that changes what the **server** does rather than adding a read path.

`missionIdleDuration` measured idleness from the main JSONL's mtime alone. The main agent writes nothing while it waits on a subagent or a workflow run, and the subagents' own logs are where the activity is during exactly that stretch, so a long run read as idle. The 30-minute timeout against a 47-minute workflow run on this machine means a mission blocked on it would have been stopped mid-run with 699 agents working under it. It now takes the newest mtime across every transcript of the mission's sessions (36 ms over 7,275 files, every two minutes).

Happy to pull that commit out into its own PR if you would rather evaluate it separately.

## What this does not do

The third bullet of #23, search indexing, is **not** here. `mission search` still indexes only the main JSONL, so subagent content stays unsearchable. It needs per-file offsets in the index rather than the single `last_indexed_offset` the schema has today, which is a migration and its own PR. Worth knowing that the current behaviour reads as "nothing happened" rather than "not indexed".

Also unaddressed, found while working: `<session-id>/tool-results/` holds oversized tool outputs the transcript references by path (197 files, 16 MB in that session), and 19 project directories on this machine belong to sessions launched from a mission's scratch cwd. Neither is reachable by any command.

## Verification

**Against real transcripts, not fixtures.** The corpus sweep above; the 7,214-agent session for every bound quoted here.

**Adversarial review.** A clean-context reviewer with no stake in the code reproduced **10 defects** on my first cut, each with a quoted command. All ten are fixed in `992af4b` with a test that failed first, and the same reviewer re-ran every original probe against the fix. The two worst were mine to be embarrassed about:

- I read the run manifest's `timestamp` as the run's **start**. It is the completion time; `startTime` is the start. Every run's `STARTED` was shifted by the run's duration, 47 minutes on one, and 22 of 60 runs sorted into the wrong position.
- `--format=jsonl --expand-agents` ignored the expansion budget entirely: 42.5 MB emitted against a 1 MB budget.

Also fixed from that review: a run whose spawn site sat inside a budget-skipped agent was reported as having "no spawn site in the printed range" (false); `--until <bare date>` landed an hour off on DST days; the budget note repeated once per spawn record; flag suggestions fired on a sibling command's real flag; `ResolveAgent` matched names case-sensitively in one branch and insensitively in another; `formatBytes(1048575)` printed `1024.0 KB`.

**Mutation testing.** Every guard added here was checked by deleting the code it protects and confirming a test goes red. The reviewer independently mutated 18 more, found the 2 that survived (a vacuous laziness assertion and an untested flag default), and both are real tests now.

**Checks.** `make check` passes (modules, gofmt, vet, golangci-lint, deadcode, `go test -race -cover`). `make e2e` on this branch: **227/237 passed, 5 failed, 5 skipped**. All 5 failures reproduce identically on pristine `upstream/main` (185/194, the same 5): 4 `claude-update` cases that shell out to GNU `timeout`, absent on macOS, and 1 tmux detach case. 42 of the passing tests are new here, covering the nested layout, the spawn anchor, the stdout footer, the overview and its JSON, `--workflow` by prefix and by name, `--agent` on a workflow agent and by description fragment, `--since` in both directions, the refusals, the flag suggestion and the no-ANSI rule.

**No ANSI.** The new views follow the no-ANSI-in-command-output convention. `mission print`, `mission print --agents` and `mission print --workflow` each get a real escape-byte check with a pattern proving the table actually rendered. `session print --agents` is on the skip list for the same reason as the existing `mission peers` and `mission search` skips: the harness has no way to populate a resolvable session ID.
